### PR TITLE
feat: add accessible resume image lightbox (#11)

### DIFF
--- a/src/components/sections/resume/resume-media-view.tsx
+++ b/src/components/sections/resume/resume-media-view.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+import type { ResumeMediaView as ResumeMediaViewData } from "@/content/resume";
+import { Lightbox } from "@/features/lightbox/lightbox";
+
+interface ResumeMediaViewProps {
+  media: ReadonlyArray<ResumeMediaViewData>;
+  viewImageLabel: string;
+  closeLabel: string;
+  lightboxLabel: string;
+}
+
+export function ResumeMediaView({
+  media,
+  viewImageLabel,
+  closeLabel,
+  lightboxLabel,
+}: Readonly<ResumeMediaViewProps>) {
+  const [activeMedia, setActiveMedia] = useState<ResumeMediaViewData | null>(
+    null,
+  );
+
+  const close = () => setActiveMedia(null);
+
+  return (
+    <div className="resume-media">
+      {media.map((item) => (
+        <figure className="resume-media__item" key={item.id}>
+          <div className="resume-media__thumbnail">
+            <Image
+              alt={item.alt}
+              className="resume-media__thumbnail-image"
+              fill
+              sizes="(min-width: 64rem) 18vw, 92vw"
+              src={item.thumbnailSrc}
+              style={{ objectFit: "cover" }}
+            />
+          </div>
+          {item.caption ? (
+            <figcaption className="resume-media__caption">
+              {item.caption}
+            </figcaption>
+          ) : null}
+          <button
+            aria-haspopup="dialog"
+            className="resume-media__view"
+            onClick={() => setActiveMedia(item)}
+            type="button"
+          >
+            {viewImageLabel}
+          </button>
+        </figure>
+      ))}
+
+      <Lightbox
+        closeLabel={closeLabel}
+        label={lightboxLabel}
+        onClose={close}
+        open={activeMedia !== null}
+      >
+        {activeMedia ? (
+          <figure className="lightbox-content">
+            <div
+              className="lightbox-content__frame"
+              data-aspect={
+                activeMedia.width && activeMedia.height ? "true" : "false"
+              }
+              style={
+                activeMedia.width && activeMedia.height
+                  ? { aspectRatio: `${activeMedia.width} / ${activeMedia.height}` }
+                  : undefined
+              }
+            >
+              <Image
+                alt={activeMedia.alt}
+                className="lightbox-content__image"
+                fill
+                sizes="(min-width: 64rem) 80vw, 100vw"
+                src={activeMedia.fullSrc}
+                style={{ objectFit: "contain" }}
+              />
+            </div>
+            {activeMedia.caption ? (
+              <figcaption className="lightbox-content__caption">
+                {activeMedia.caption}
+              </figcaption>
+            ) : null}
+          </figure>
+        ) : null}
+      </Lightbox>
+    </div>
+  );
+}

--- a/src/components/sections/resume/resume-section.tsx
+++ b/src/components/sections/resume/resume-section.tsx
@@ -11,6 +11,8 @@ import { Container } from "@/components/layout/container";
 import { SectionHeading } from "@/components/ui/section-heading";
 import type { ResumeContentView } from "@/content/resume";
 
+import { ResumeMediaView } from "./resume-media-view";
+
 interface ResumeSectionProps {
   content: ResumeContentView;
 }
@@ -233,6 +235,15 @@ export function ResumeSection({ content }: Readonly<ResumeSectionProps>) {
                       <li key={tag}>{tag}</li>
                     ))}
                   </ul>
+                ) : null}
+
+                {entry.media && entry.media.length > 0 ? (
+                  <ResumeMediaView
+                    closeLabel={content.closeLightbox}
+                    lightboxLabel={content.lightboxLabel}
+                    media={entry.media}
+                    viewImageLabel={content.viewImage}
+                  />
                 ) : null}
               </article>
 

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -28,6 +28,16 @@ export interface ResumeEntry {
   order: number;
 }
 
+export interface ResumeMediaView {
+  id: string;
+  thumbnailSrc: string;
+  fullSrc: string;
+  alt: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+}
+
 export interface ResumeEntryView {
   id: string;
   index: string;
@@ -38,7 +48,7 @@ export interface ResumeEntryView {
   summary?: string;
   highlights?: ReadonlyArray<string>;
   tags?: ReadonlyArray<string>;
-  media?: ReadonlyArray<ResumeMedia>;
+  media?: ReadonlyArray<ResumeMediaView>;
 }
 
 export interface ResumeCategoryView {
@@ -55,6 +65,9 @@ export interface ResumeContentView {
   previousEntry: string;
   nextEntry: string;
   entryCounter: string;
+  viewImage: string;
+  closeLightbox: string;
+  lightboxLabel: string;
   categories: ReadonlyArray<ResumeCategoryView>;
 }
 
@@ -344,6 +357,18 @@ const resumeCopy = {
     en: "Entry",
     vi: "Mục",
   },
+  viewImage: {
+    en: "View image",
+    vi: "Xem hình",
+  },
+  closeLightbox: {
+    en: "Close",
+    vi: "Đóng",
+  },
+  lightboxLabel: {
+    en: "Full-size image viewer",
+    vi: "Trình xem hình kích thước đầy đủ",
+  },
   categoryNames: {
     "career-journey": {
       en: "Career Journey",
@@ -371,6 +396,9 @@ export function getResumeContent(locale: Locale): ResumeContentView {
     previousEntry: resumeCopy.previousEntry[locale],
     nextEntry: resumeCopy.nextEntry[locale],
     entryCounter: resumeCopy.entryCounter[locale],
+    viewImage: resumeCopy.viewImage[locale],
+    closeLightbox: resumeCopy.closeLightbox[locale],
+    lightboxLabel: resumeCopy.lightboxLabel[locale],
     categories: categories.map((categoryId) => {
       const entries = (resumeEntries as ReadonlyArray<ResumeEntry>)
         .filter((entry) => entry.category === categoryId)
@@ -389,7 +417,15 @@ export function getResumeContent(locale: Locale): ResumeContentView {
           summary: entry.summary ? localized(entry.summary) : undefined,
           highlights: entry.highlights?.map(localized),
           tags: entry.tags?.map(localized),
-          media: entry.media,
+          media: entry.media?.map((media) => ({
+            id: media.id,
+            thumbnailSrc: media.thumbnailSrc,
+            fullSrc: media.fullSrc,
+            alt: localized(media.alt),
+            caption: media.caption ? localized(media.caption) : undefined,
+            width: media.width,
+            height: media.height,
+          })),
         })),
       };
     }),

--- a/src/features/lightbox/lightbox.tsx
+++ b/src/features/lightbox/lightbox.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useEffect, useRef, type MouseEvent, type ReactNode } from "react";
+
+interface LightboxProps {
+  open: boolean;
+  onClose: () => void;
+  label: string;
+  closeLabel: string;
+  children: ReactNode;
+}
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter(
+    (element) =>
+      element.offsetParent !== null || element === document.activeElement,
+  );
+}
+
+export function Lightbox({
+  open,
+  onClose,
+  label,
+  closeLabel,
+  children,
+}: Readonly<LightboxProps>) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    closeButtonRef.current?.focus({ preventScroll: true });
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+
+      const focusable = getFocusable(dialog);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || active === dialog) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || active === dialog) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousBodyOverflow;
+
+      if (
+        previouslyFocused instanceof HTMLElement &&
+        previouslyFocused.isConnected
+      ) {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+    };
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  function handleBackdropClick(event: MouseEvent<HTMLDivElement>) {
+    if (event.target === event.currentTarget) {
+      onCloseRef.current();
+    }
+  }
+
+  return createPortal(
+    <div className="lightbox-backdrop" onClick={handleBackdropClick}>
+      <div
+        aria-label={label}
+        aria-modal="true"
+        className="lightbox-dialog"
+        ref={dialogRef}
+        role="dialog"
+      >
+        <div className="lightbox-dialog__header">
+          <button
+            aria-label={closeLabel}
+            className="lightbox-dialog__close"
+            onClick={() => onCloseRef.current()}
+            ref={closeButtonRef}
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="none"
+              height="20"
+              viewBox="0 0 24 24"
+              width="20"
+            >
+              <path
+                d="M6 6l12 12M18 6L6 18"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="lightbox-dialog__body">{children}</div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1490,6 +1490,193 @@ video {
   background: var(--color-accent);
 }
 
+.resume-media {
+  display: grid;
+  gap: var(--space-4);
+  margin-block-start: var(--space-4);
+}
+
+.resume-media__item {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.resume-media__thumbnail {
+  position: relative;
+  width: min(100%, 20rem);
+  max-height: 12rem;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  aspect-ratio: 16 / 9;
+}
+
+.resume-media__thumbnail-image {
+  width: 100%;
+  height: 100%;
+}
+
+.resume-media__caption {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.resume-media__view {
+  display: inline-flex;
+  width: fit-content;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.resume-media__view:hover {
+  border-color: var(--color-accent-hover);
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+}
+
+.lightbox-backdrop {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  padding: var(--space-4);
+  place-items: center;
+  background: color-mix(in oklch, var(--color-page) 72%, transparent);
+  backdrop-filter: blur(0.25rem);
+}
+
+.lightbox-dialog {
+  display: flex;
+  width: min(100%, 72rem);
+  max-height: calc(100dvh - (var(--space-4) * 2));
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--color-surface-elevated);
+  box-shadow: var(--shadow-lg);
+}
+
+.lightbox-dialog__header {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--space-3) var(--space-4);
+  border-block-end: 1px solid var(--color-border);
+}
+
+.lightbox-dialog__close {
+  display: inline-grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition:
+    color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    border-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.lightbox-dialog__close:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-surface-subtle);
+}
+
+.lightbox-dialog__body {
+  display: grid;
+  min-height: 0;
+  flex: 1;
+  padding: var(--space-4);
+  place-items: center;
+  overflow: auto;
+}
+
+.lightbox-content {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.lightbox-content__frame {
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: min(72vh, 64rem);
+  max-height: 72vh;
+  place-items: center;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+}
+
+.lightbox-content__frame[data-aspect="true"] {
+  height: auto;
+}
+
+.lightbox-content__frame .lightbox-content__image {
+  width: 100%;
+  height: 100%;
+}
+
+.lightbox-content__caption {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
+@media (min-width: 64rem) {
+  .resume-media {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lightbox-backdrop {
+    padding: var(--space-8);
+  }
+
+  .lightbox-dialog {
+    width: min(100%, 88rem);
+  }
+
+  .lightbox-dialog__body {
+    padding: var(--space-6);
+  }
+
+  .lightbox-content__frame {
+    height: min(76vh, 68rem);
+    max-height: 76vh;
+  }
+
+  .lightbox-content__frame[data-aspect="true"] {
+    height: auto;
+  }
+}
+
 .navigation-anchor--placeholder {
   display: grid;
   min-height: max(28rem, 65vh);


### PR DESCRIPTION
## Summary

Adds a reusable, dependency-free accessible lightbox for Resume media plus a `ResumeMediaView` component that renders fixed-bounds thumbnails with an explicit **View Image** action and opens the original/full-size asset in a modal.

**Important scoping decision (per approved refinement #1):** zero legacy Resume assets are published. No files are copied from `docs/migration/legacy-assets/` into `public/`, and all production Resume `media` arrays remain **empty**. The feature is fully implemented and wired, but does **not** visibly render in the production Resume until approved/redacted derivatives exist.

### Implementation

- `src/features/lightbox/lightbox.tsx` — reusable client lightbox:
  - `createPortal` to `document.body`
  - render-only-when-open (children mount only while open → `fullSrc` is never requested before opening)
  - prominent X close button with localized label
  - Escape closes
  - accessible backdrop click-to-close (target === currentTarget)
  - Tab / Shift+Tab focus trap (close button guarantees ≥1 focusable)
  - exact-trigger focus restoration, guarded: only restores if the captured element is still an `HTMLElement` and still `isConnected` (fails safely otherwise)
  - body scroll lock that preserves and restores the body's previous inline `overflow` value (does not blindly reset to `""`); cleanup also runs if the component unmounts while open
  - `role="dialog"`, `aria-modal="true"`, localized `aria-label` dialog name (image keeps its own meaningful `alt`; caption rendered separately)
  - responsive `object-fit: contain` bounds without viewport overflow
- `src/content/resume.ts` — adds localized `ResumeMediaView` (thumbnail/fullSrc independently addressable) and localized `viewImage` / `closeLightbox` / `lightboxLabel` copy; production `media` arrays stay empty
- `src/components/sections/resume/resume-media-view.tsx` — fixed thumbnail bounds, View Image action, lightbox wiring
- `src/components/sections/resume/resume-section.tsx` — renders `ResumeMediaView` when an entry has media
- `src/styles/globals.css` — thumbnail + lightbox styling (light/dark, responsive)
- Removed `src/features/lightbox/.gitkeep` (directory is now tracked)

## Acceptance criteria

- [x] Modal behaves correctly by keyboard and pointer
- [x] Focus trap/restoration works (verified exact-trigger restoration; safe-skip when disconnected)
- [x] Escape and close button work
- [x] Full image is bounded responsively without viewport overflow (desktop 1166×684 frame, mobile 309×193 at 16:10, `object-fit: contain`, aspect preserved)
- [x] Thumbnail and full-size source are distinct-capable in the data model (`thumbnailSrc` / `fullSrc`)
- [x] Component is reusable rather than coupled to one Resume entry
- [x] `lint`, `typecheck`, build pass (Turbopack; verified passing)

## Verification

Automated checks (Playwright, temporary /tmp fixture — not committed, not part of production data):

```
29/29 checks passed
```

- **Network assertion:** `fullSrc` NOT requested before opening; requested only after the lightbox opens
- Escape / X / backdrop click all close; focus restores to the triggering View Image button each time
- Body `overflow` locked to `hidden` while open, restored to its prior inline value on close
- Focus moves to close button on open; Tab and Shift+Tab stay trapped inside the dialog
- Desktop + mobile dialog stays fully within the viewport; no horizontal page overflow
- Full image renders with `object-fit: contain`, aspect preserved, contained within frame
- Both themes (light/dark) and both locales (en/vi) for View Image / dialog labels
- Keyboard and pointer paths both exercised

Screenshots were captured from a temporary fixture and used for internal verification; they are intentionally **not** committed so no image can be mistaken for production Resume content.

### Commands

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run build` ✅ (Turbopack passed; `-- --webpack` also verified in CI path)

## Known limitations

- Resume media is not visible in the production Resume yet by design — all `media` arrays are empty pending approved/redacted asset derivatives.
- Vision subagent visual review was unavailable this session (returned empty repeatedly); pixel-level programmatic checks (object-fit, aspect, bounds, containment) were used in its place.

## Risks / follow-ups

- None beyond the intentional empty-media state above. No Contact/Footer/CMS/redirect/CV work included.
