### PR TITLE
feat: implement contact form delivery and abuse protection (#12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,8 @@
+# Public
 NEXT_PUBLIC_SITE_URL=
+
+# Server-only contact delivery (Resend)
+# Never commit real values. See docs for provider setup.
+RESEND_API_KEY=
+CONTACT_TO_EMAIL=
+CONTACT_FROM_EMAIL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   quality:
-    name: Lint, typecheck, and build
+    name: Test, lint, typecheck, and build
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Test
+        run: npm test
 
       - name: Lint
         run: npm run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ If an issue conflicts with an accepted canonical document, stop and report the c
 - `npm run dev` — dev server
 - `gh` is available for issue/PR workflows; PRs use `Closes #<issue>` with one PR per issue.
 
-There is a minimal `npm test` runner using Node's built-in `node:test` via `tsx`, covering the contact-delivery feature (`src/features/contact/**/*.test.ts`). For other areas, verification remains manual/visual smoke checks plus lint/typecheck/build.
+There is a minimal `npm test` runner using Node's built-in `node:test` via `tsx`, covering the contact-delivery feature (`src/features/contact/*.test.ts`). For other areas, verification remains manual/visual smoke checks plus lint/typecheck/build.
 
 ### Build quirk
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ If an issue conflicts with an accepted canonical document, stop and report the c
 - `npm run dev` — dev server
 - `gh` is available for issue/PR workflows; PRs use `Closes #<issue>` with one PR per issue.
 
-There is **no automated test runner** configured — no test files, no Jest/Playwright config committed. Verification is manual/visual smoke checks plus lint/typecheck/build. Do not invent a `npm test`.
+There is a minimal `npm test` runner using Node's built-in `node:test` via `tsx`, covering the contact-delivery feature (`src/features/contact/**/*.test.ts`). For other areas, verification remains manual/visual smoke checks plus lint/typecheck/build.
 
 ### Build quirk
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.3.0",
         "tailwindcss": "^4",
+        "tsx": "^4.23.12",
         "typescript": "^5"
       },
       "engines": {
@@ -310,6 +311,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3299,6 +3742,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3867,6 +4352,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6501,6 +7001,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/features/contact/**/*.test.ts"
+    "test": "tsx --test src/features/contact/*.test.ts"
   },
   "dependencies": {
     "next": "16.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "next typegen && tsc --noEmit"
+    "typecheck": "next typegen && tsc --noEmit",
+    "test": "tsx --test src/features/contact/**/*.test.ts"
   },
   "dependencies": {
     "next": "16.3.0",
@@ -25,6 +26,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.3.0",
     "tailwindcss": "^4",
+    "tsx": "^4.23.12",
     "typescript": "^5"
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 
 import { Container } from "@/components/layout/container";
 import { PageShell } from "@/components/layout/page-shell";
+import { ContactSection } from "@/components/sections/contact/contact-section";
 import { HeroSection } from "@/components/sections/home/hero-section";
 import { ProjectsSection } from "@/components/sections/projects/projects-section";
 import { ResumeSection } from "@/components/sections/resume/resume-section";
 import { SkillsSection } from "@/components/sections/skills/skills-section";
+import { getContactContent } from "@/content/contact";
 import { getPortfolioProfile } from "@/content/profile";
 import { getFeaturedProjects } from "@/content/projects";
 import { getResumeContent } from "@/content/resume";
@@ -39,6 +41,7 @@ export default async function LocalePage({
   const skills = getSkillsContent(locale);
   const projects = getFeaturedProjects(locale);
   const resume = getResumeContent(locale);
+  const contact = getContactContent(locale);
 
   return (
     <PageShell>
@@ -46,8 +49,9 @@ export default async function LocalePage({
       <SkillsSection content={skills} />
       <ProjectsSection content={projects} />
       <ResumeSection content={resume} />
+      <ContactSection content={contact} />
 
-      {navigationSectionIds.slice(5).map((sectionId) => (
+      {navigationSectionIds.slice(6).map((sectionId) => (
         <section
           aria-labelledby={`${sectionId}-anchor-title`}
           className="navigation-anchor navigation-anchor--placeholder"

--- a/src/components/sections/contact/contact-form.tsx
+++ b/src/components/sections/contact/contact-form.tsx
@@ -5,9 +5,10 @@ import { useFormStatus } from "react-dom";
 
 import type { ContactContentView } from "@/content/contact";
 import { submitContactForm } from "@/features/contact/actions";
-import type {
-  ContactFieldErrors,
-  ContactFieldName,
+import {
+  validateContactSubmission,
+  type ContactFieldErrors,
+  type ContactFieldName,
 } from "@/features/contact/validation";
 
 const FIELD_ORDER: ContactFieldName[] = ["name", "email", "subject", "message"];
@@ -43,6 +44,7 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
     subject: "",
     message: "",
   });
+  const [clientErrors, setClientErrors] = useState<ContactFieldErrors>({});
   const [previousStatus, setPreviousStatus] = useState("idle");
 
   if (state.status !== previousStatus) {
@@ -52,11 +54,17 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
     }
   }
 
+  const hasClientErrors = Object.keys(clientErrors).length > 0;
+  const serverErrors =
+    state.status === "field-error" ? state.fieldErrors : {};
   const fieldErrors = (
-    state.status === "field-error" ? state.fieldErrors : {}
+    hasClientErrors ? clientErrors : serverErrors
   ) as ContactFieldErrors;
 
   const statusMessage = (() => {
+    if (hasClientErrors) {
+      return "";
+    }
     switch (state.status) {
       case "success":
         return content.status.success;
@@ -73,6 +81,24 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
 
   function handleChange(field: ContactFieldName, value: string) {
     setValues((current) => ({ ...current, [field]: value }));
+    setClientErrors((current) => {
+      if (current[field] === undefined) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    const errors = validateContactSubmission(values);
+    if (Object.keys(errors).length > 0) {
+      event.preventDefault();
+      setClientErrors(errors);
+    } else {
+      setClientErrors({});
+    }
   }
 
   return (
@@ -81,6 +107,7 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
       aria-label={content.aria.formLabel}
       className="contact-form"
       noValidate
+      onSubmit={handleSubmit}
     >
       <p className="contact-form__required-note">{content.aria.requiredNote}</p>
 

--- a/src/components/sections/contact/contact-form.tsx
+++ b/src/components/sections/contact/contact-form.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+import type { ContactContentView } from "@/content/contact";
+import { submitContactForm } from "@/features/contact/actions";
+import type {
+  ContactFieldErrors,
+  ContactFieldName,
+} from "@/features/contact/validation";
+
+const FIELD_ORDER: ContactFieldName[] = ["name", "email", "subject", "message"];
+
+interface ContactFormProps {
+  content: ContactContentView;
+}
+
+const initialState = { status: "idle" } as const;
+
+function SubmitButton({ content }: Readonly<{ content: ContactContentView }>) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      className="contact-form__submit"
+      disabled={pending}
+      type="submit"
+    >
+      {pending ? content.form.submitting : content.form.submit}
+    </button>
+  );
+}
+
+export function ContactForm({ content }: Readonly<ContactFormProps>) {
+  const [state, formAction] = useActionState(
+    submitContactForm,
+    initialState,
+  );
+  const [values, setValues] = useState({
+    name: "",
+    email: "",
+    subject: "",
+    message: "",
+  });
+  const [previousStatus, setPreviousStatus] = useState("idle");
+
+  if (state.status !== previousStatus) {
+    setPreviousStatus(state.status);
+    if (state.status === "success") {
+      setValues({ name: "", email: "", subject: "", message: "" });
+    }
+  }
+
+  const fieldErrors = (
+    state.status === "field-error" ? state.fieldErrors : {}
+  ) as ContactFieldErrors;
+
+  const statusMessage = (() => {
+    switch (state.status) {
+      case "success":
+        return content.status.success;
+      case "rejected":
+        return content.status.rejected;
+      case "rate-limited":
+        return content.status.rateLimited;
+      case "server-error":
+        return content.status.serverError;
+      default:
+        return "";
+    }
+  })();
+
+  function handleChange(field: ContactFieldName, value: string) {
+    setValues((current) => ({ ...current, [field]: value }));
+  }
+
+  return (
+    <form
+      action={formAction}
+      aria-label={content.aria.formLabel}
+      className="contact-form"
+      noValidate
+    >
+      <p className="contact-form__required-note">{content.aria.requiredNote}</p>
+
+      {FIELD_ORDER.map((field) => {
+        const label = content.form[field];
+        const placeholder = content.form[`${field}Placeholder`];
+        const errorCode = fieldErrors[field];
+        const describedBy = errorCode ? `${field}-error` : undefined;
+
+        const commonProps = {
+          "aria-describedby": describedBy,
+          "aria-invalid": errorCode ? true : undefined,
+          id: field,
+          name: field,
+          onChange: (
+            event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+          ) => handleChange(field, event.target.value),
+          required: true,
+          value: values[field],
+        };
+
+        if (field === "message") {
+          return (
+            <div className="contact-form__field" key={field}>
+              <label htmlFor={field}>
+                {label} <span aria-hidden="true">*</span>
+              </label>
+              <textarea
+                {...commonProps}
+                placeholder={placeholder}
+                rows={6}
+              />
+              {errorCode ? (
+                <p className="contact-form__error" id={`${field}-error`}>
+                  {content.errors[errorCode]}
+                </p>
+              ) : null}
+            </div>
+          );
+        }
+
+        return (
+          <div className="contact-form__field" key={field}>
+            <label htmlFor={field}>
+              {label} <span aria-hidden="true">*</span>
+            </label>
+            <input
+              {...commonProps}
+              autoComplete={
+                field === "email"
+                  ? "email"
+                  : field === "name"
+                    ? "name"
+                    : "off"
+              }
+              placeholder={placeholder}
+              type={field === "email" ? "email" : "text"}
+            />
+            {errorCode ? (
+              <p className="contact-form__error" id={`${field}-error`}>
+                {content.errors[errorCode]}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+
+      <div className="contact-form__honeypot" aria-hidden="true">
+        <label htmlFor="website">{content.aria.honeypot}</label>
+        <input
+          autoComplete="off"
+          id="website"
+          name="website"
+          tabIndex={-1}
+          type="text"
+        />
+      </div>
+
+      <div className="contact-form__actions">
+        <SubmitButton content={content} />
+      </div>
+
+      {statusMessage ? (
+        <p
+          aria-live="polite"
+          className={`contact-form__status contact-form__status--${state.status}`}
+          role="status"
+        >
+          {statusMessage}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/src/components/sections/contact/contact-form.tsx
+++ b/src/components/sections/contact/contact-form.tsx
@@ -5,6 +5,7 @@ import { useFormStatus } from "react-dom";
 
 import type { ContactContentView } from "@/content/contact";
 import { submitContactForm } from "@/features/contact/actions";
+import type { SubmitContactResult } from "@/features/contact/submit";
 import {
   validateContactSubmission,
   type ContactFieldErrors,
@@ -44,25 +45,25 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
     subject: "",
     message: "",
   });
-  const [clientErrors, setClientErrors] = useState<ContactFieldErrors>({});
-  const [previousStatus, setPreviousStatus] = useState("idle");
+  const [fieldErrors, setFieldErrors] = useState<ContactFieldErrors>({});
+  const [lastState, setLastState] = useState<SubmitContactResult>(initialState);
 
-  if (state.status !== previousStatus) {
-    setPreviousStatus(state.status);
+  if (state !== lastState) {
+    setLastState(state);
     if (state.status === "success") {
       setValues({ name: "", email: "", subject: "", message: "" });
+      setFieldErrors({});
+    } else if (state.status === "field-error") {
+      setFieldErrors(state.fieldErrors);
+    } else {
+      setFieldErrors({});
     }
   }
 
-  const hasClientErrors = Object.keys(clientErrors).length > 0;
-  const serverErrors =
-    state.status === "field-error" ? state.fieldErrors : {};
-  const fieldErrors = (
-    hasClientErrors ? clientErrors : serverErrors
-  ) as ContactFieldErrors;
+  const hasFieldErrors = Object.keys(fieldErrors).length > 0;
 
   const statusMessage = (() => {
-    if (hasClientErrors) {
+    if (hasFieldErrors) {
       return "";
     }
     switch (state.status) {
@@ -81,7 +82,7 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
 
   function handleChange(field: ContactFieldName, value: string) {
     setValues((current) => ({ ...current, [field]: value }));
-    setClientErrors((current) => {
+    setFieldErrors((current) => {
       if (current[field] === undefined) {
         return current;
       }
@@ -95,9 +96,9 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
     const errors = validateContactSubmission(values);
     if (Object.keys(errors).length > 0) {
       event.preventDefault();
-      setClientErrors(errors);
+      setFieldErrors(errors);
     } else {
-      setClientErrors({});
+      setFieldErrors({});
     }
   }
 

--- a/src/components/sections/contact/contact-section.tsx
+++ b/src/components/sections/contact/contact-section.tsx
@@ -1,0 +1,61 @@
+import { Container } from "@/components/layout/container";
+import { SectionHeading } from "@/components/ui/section-heading";
+import type { ContactContentView } from "@/content/contact";
+
+import { ContactForm } from "./contact-form";
+
+interface ContactSectionProps {
+  content: ContactContentView;
+}
+
+export function ContactSection({ content }: Readonly<ContactSectionProps>) {
+  return (
+    <section
+      aria-labelledby="contact-title"
+      className="contact-section navigation-anchor"
+      id="contact"
+    >
+      <Container>
+        <div className="contact-section__intro">
+          <SectionHeading
+            description={content.description}
+            eyebrow={content.eyebrow}
+            title={content.title}
+            titleId="contact-title"
+          />
+        </div>
+
+        <div className="contact-layout">
+          <aside className="contact-info" aria-label={content.detailsLabel}>
+            <div className="contact-info__card">
+              <h3 className="contact-info__heading">{content.detailsLabel}</h3>
+              <ul className="contact-info__list">
+                {content.details.map((detail) => (
+                  <li key={detail.id}>
+                    <a
+                      className="contact-info__link"
+                      href={detail.href}
+                      rel="noopener noreferrer"
+                      target={detail.href ? "_blank" : undefined}
+                    >
+                      <span className="contact-info__label">
+                        {detail.label}
+                      </span>
+                      <span className="contact-info__value">
+                        {detail.value}
+                      </span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </aside>
+
+          <div className="contact-panel">
+            <ContactForm content={content} />
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/content/contact.ts
+++ b/src/content/contact.ts
@@ -1,0 +1,183 @@
+import type { Locale } from "@/features/i18n/config";
+
+type LocalizedText = Readonly<Record<Locale, string>>;
+
+export type ContactFieldName = "name" | "email" | "subject" | "message";
+
+export interface ContactDetailView {
+  id: string;
+  label: string;
+  value: string;
+  href?: string;
+}
+
+export interface ContactContentView {
+  eyebrow: string;
+  title: string;
+  description: string;
+  detailsLabel: string;
+  details: ReadonlyArray<ContactDetailView>;
+  form: {
+    name: string;
+    namePlaceholder: string;
+    email: string;
+    emailPlaceholder: string;
+    subject: string;
+    subjectPlaceholder: string;
+    message: string;
+    messagePlaceholder: string;
+    submit: string;
+    submitting: string;
+  };
+  errors: Record<string, string>;
+  status: {
+    success: string;
+    rejected: string;
+    serverError: string;
+    rateLimited: string;
+  };
+  aria: {
+    formLabel: string;
+    requiredNote: string;
+    statusLive: string;
+    honeypot: string;
+  };
+}
+
+export const contactDetails = {
+  github: {
+    id: "github",
+    label: { en: "GitHub", vi: "GitHub" },
+    value: { en: "Akbi47", vi: "Akbi47" },
+    href: "https://github.com/Akbi47",
+  },
+} as const;
+
+const contactCopy = {
+  eyebrow: {
+    en: "Get in touch",
+    vi: "Liên hệ",
+  },
+  title: {
+    en: "Contact",
+    vi: "Liên hệ",
+  },
+  description: {
+    en: "Questions, ideas, or collaboration — the form sends a message straight to my inbox.",
+    vi: "Thắc mắc, ý tưởng hay hợp tác — biểu mẫu gửi tin nhắn thẳng đến hộp thư của mình.",
+  },
+  detailsLabel: {
+    en: "Find me on",
+    vi: "Kết nối với mình",
+  },
+  form: {
+    name: { en: "Name", vi: "Họ tên" },
+    namePlaceholder: { en: "Your name", vi: "Tên của bạn" },
+    email: { en: "Email", vi: "Email" },
+    emailPlaceholder: { en: "you@example.com", vi: "you@example.com" },
+    subject: { en: "Subject", vi: "Tiêu đề" },
+    subjectPlaceholder: { en: "What is this about?", vi: "Về vấn đề gì?" },
+    message: { en: "Message", vi: "Nội dung" },
+    messagePlaceholder: {
+      en: "Write your message here…",
+      vi: "Viết nội dung tại đây…",
+    },
+    submit: { en: "Send Message", vi: "Gửi tin nhắn" },
+    submitting: { en: "Sending…", vi: "Đang gửi…" },
+  },
+  errors: {
+    required: { en: "This field is required.", vi: "Trường này là bắt buộc." },
+    "too-short": {
+      en: "This value is too short.",
+      vi: "Giá trị này quá ngắn.",
+    },
+    "too-long": {
+      en: "This value is too long.",
+      vi: "Giá trị này quá dài.",
+    },
+    "invalid-email": {
+      en: "Please enter a valid email address.",
+      vi: "Vui lòng nhập địa chỉ email hợp lệ.",
+    },
+  },
+  status: {
+    success: {
+      en: "Your message was sent. Thank you!",
+      vi: "Tin nhắn của bạn đã được gửi. Cảm ơn bạn!",
+    },
+    rejected: {
+      en: "Your message could not be sent. Please try again.",
+      vi: "Không thể gửi tin nhắn. Vui lòng thử lại.",
+    },
+    serverError: {
+      en: "Something went wrong while sending your message. Please try again later.",
+      vi: "Đã xảy ra lỗi khi gửi tin nhắn. Vui lòng thử lại sau.",
+    },
+    rateLimited: {
+      en: "Too many messages from this device. Please wait a while and try again.",
+      vi: "Quá nhiều tin nhắn từ thiết bị này. Vui lòng chờ một lúc rồi thử lại.",
+    },
+  },
+  aria: {
+    formLabel: { en: "Contact form", vi: "Biểu mẫu liên hệ" },
+    requiredNote: {
+      en: "Fields marked with an asterisk are required.",
+      vi: "Các trường có dấu hoa thị là bắt buộc.",
+    },
+    statusLive: {
+      en: "Form submission status",
+      vi: "Trạng thái gửi biểu mẫu",
+    },
+    honeypot: {
+      en: "Leave this field empty",
+      vi: "Để trống trường này",
+    },
+  },
+} as const;
+
+export function getContactContent(locale: Locale): ContactContentView {
+  const localized = (text: LocalizedText) => text[locale];
+
+  return {
+    eyebrow: localized(contactCopy.eyebrow),
+    title: localized(contactCopy.title),
+    description: localized(contactCopy.description),
+    detailsLabel: localized(contactCopy.detailsLabel),
+    details: Object.values(contactDetails).map((detail) => ({
+      id: detail.id,
+      label: localized(detail.label),
+      value: localized(detail.value),
+      href: detail.href,
+    })),
+    form: {
+      name: localized(contactCopy.form.name),
+      namePlaceholder: localized(contactCopy.form.namePlaceholder),
+      email: localized(contactCopy.form.email),
+      emailPlaceholder: localized(contactCopy.form.emailPlaceholder),
+      subject: localized(contactCopy.form.subject),
+      subjectPlaceholder: localized(contactCopy.form.subjectPlaceholder),
+      message: localized(contactCopy.form.message),
+      messagePlaceholder: localized(contactCopy.form.messagePlaceholder),
+      submit: localized(contactCopy.form.submit),
+      submitting: localized(contactCopy.form.submitting),
+    },
+    errors: Object.fromEntries(
+      Object.entries(contactCopy.errors).map(([key, value]) => [
+        key,
+        localized(value),
+      ]),
+    ),
+    status: {
+      success: localized(contactCopy.status.success),
+      rejected: localized(contactCopy.status.rejected),
+      serverError: localized(contactCopy.status.serverError),
+      rateLimited: localized(contactCopy.status.rateLimited),
+    },
+    aria: {
+      formLabel: localized(contactCopy.aria.formLabel),
+      requiredNote: localized(contactCopy.aria.requiredNote),
+      statusLive: localized(contactCopy.aria.statusLive),
+      honeypot: localized(contactCopy.aria.honeypot),
+    },
+  };
+}

--- a/src/features/contact/actions.ts
+++ b/src/features/contact/actions.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { headers } from "next/headers";
+
+import { extractClientIdentifier } from "./client-identifier";
+import { createResendDeliveryProvider } from "./delivery";
+import { createInMemoryRateLimiter } from "./rate-limit";
+import {
+  submitContact,
+  type SubmitContactResult,
+} from "./submit";
+
+const CONTACT_RATE_LIMIT = {
+  burstLimit: 2,
+  burstWindowMs: 60_000,
+  hourlyLimit: 5,
+  hourlyWindowMs: 3_600_000,
+} as const;
+
+/**
+ * Process-local rate limiter.
+ *
+ * Limitation: this reduces abuse per running instance only. It is not a
+ * distributed or durable limiter — on serverless/multi-instance
+ * deployments each instance keeps its own state, so effective limits are
+ * approximate and reset when an instance restarts. A durable limiter
+ * (for example Upstash Redis) must be introduced as a separate,
+ * explicitly approved change if public launch requires it.
+ */
+const rateLimiter = createInMemoryRateLimiter({
+  ...CONTACT_RATE_LIMIT,
+  now: () => Date.now(),
+});
+
+function buildProvider() {
+  return createResendDeliveryProvider({
+    apiKey: process.env.RESEND_API_KEY ?? "",
+  });
+}
+
+export async function submitContactForm(
+  _previousState: SubmitContactResult,
+  formData: FormData,
+): Promise<SubmitContactResult> {
+  const headerStore = await headers();
+
+  // Assumption (Vercel-specific): on Vercel the platform sets
+  // `x-forwarded-for` to the client address. No other header is trusted.
+  const forwardedFor = headerStore.get("x-forwarded-for") ?? undefined;
+  const clientId = extractClientIdentifier(forwardedFor);
+
+  return submitContact(
+    {
+      name: String(formData.get("name") ?? ""),
+      email: String(formData.get("email") ?? ""),
+      subject: String(formData.get("subject") ?? ""),
+      message: String(formData.get("message") ?? ""),
+      honeypot: String(formData.get("website") ?? ""),
+    },
+    {
+      provider: buildProvider(),
+      limiter: rateLimiter,
+      clientId,
+      fromEmail: process.env.CONTACT_FROM_EMAIL ?? "",
+      toEmail: process.env.CONTACT_TO_EMAIL ?? "",
+    },
+  );
+}

--- a/src/features/contact/client-identifier.test.ts
+++ b/src/features/contact/client-identifier.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { extractClientIdentifier } from "./client-identifier";
+
+test("client-identifier: returns null when header is absent", () => {
+  assert.equal(extractClientIdentifier(undefined), null);
+});
+
+test("client-identifier: returns null for empty or whitespace-only values", () => {
+  assert.equal(extractClientIdentifier(""), null);
+  assert.equal(extractClientIdentifier("   "), null);
+});
+
+test("client-identifier: uses the first entry of a comma list", () => {
+  assert.equal(
+    extractClientIdentifier("203.0.113.7, 198.51.100.2"),
+    "203.0.113.7",
+  );
+  assert.equal(
+    extractClientIdentifier("2001:db8::1, 203.0.113.7"),
+    "2001:db8::1",
+  );
+});
+
+test("client-identifier: strips an IPv4 port", () => {
+  assert.equal(extractClientIdentifier("203.0.113.7:53120"), "203.0.113.7");
+});
+
+test("client-identifier: strips brackets and port from an IPv6 literal", () => {
+  assert.equal(
+    extractClientIdentifier("[2001:db8::1]:53120"),
+    "2001:db8::1",
+  );
+});
+
+test("client-identifier: trims surrounding whitespace", () => {
+  assert.equal(extractClientIdentifier("  203.0.113.7  "), "203.0.113.7");
+});
+
+test("client-identifier: fails conservatively on a garbage value", () => {
+  assert.equal(extractClientIdentifier("not-an-ip-address"), null);
+  assert.equal(extractClientIdentifier("spambot.example.com"), null);
+});

--- a/src/features/contact/client-identifier.ts
+++ b/src/features/contact/client-identifier.ts
@@ -1,0 +1,47 @@
+const IPV4_PATTERN = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+const IPV6_PATTERN = /^[0-9a-fA-F:]+$/;
+
+function stripPort(value: string): string {
+  if (value.startsWith("[")) {
+    const close = value.indexOf("]");
+    if (close > 0) {
+      return value.slice(1, close);
+    }
+  }
+
+  if (value.includes(".")) {
+    return value.split(":")[0];
+  }
+
+  return value;
+}
+
+/**
+ * Extracts a conservative client identifier from the platform-provided
+ * forwarded client-IP header.
+ *
+ * Assumption (Vercel-specific): on Vercel, `x-forwarded-for` is set by
+ * the platform to the client's address. This code intentionally does not
+ * trust arbitrary user-controlled header values beyond the platform's
+ * behavior, and fails closed (returns null) for anything it cannot
+ * confidently interpret.
+ */
+export function extractClientIdentifier(
+  forwardedFor: string | undefined,
+): string | null {
+  if (!forwardedFor) {
+    return null;
+  }
+
+  const first = forwardedFor.split(",")[0].trim();
+  if (first.length === 0) {
+    return null;
+  }
+
+  const candidate = stripPort(first);
+  if (IPV4_PATTERN.test(candidate) || IPV6_PATTERN.test(candidate)) {
+    return candidate;
+  }
+
+  return null;
+}

--- a/src/features/contact/delivery.test.ts
+++ b/src/features/contact/delivery.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createResendDeliveryProvider,
+  type ContactMessage,
+} from "./delivery";
+
+const validMessage: ContactMessage = {
+  from: "sender@verified-domain.com",
+  to: "owner@example.com",
+  replyTo: "visitor@example.com",
+  subject: "Project inquiry",
+  text: "Hello, I would like to discuss a project with you.",
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("delivery: success response maps to accepted", async () => {
+  let calledUrl = "";
+  let calledInit: RequestInit | undefined;
+
+  const provider = createResendDeliveryProvider({
+    apiKey: "re_secret_key",
+    fetchFn: async (url, init) => {
+      calledUrl = String(url);
+      calledInit = init;
+      return jsonResponse(200, { id: "resend-message-123" });
+    },
+  });
+
+  const result = await provider.send(validMessage);
+
+  assert.equal(result.status, "accepted");
+  assert.equal(calledUrl, "https://api.resend.com/emails");
+  assert.equal(calledInit?.method, "POST");
+  const headers = new Headers(calledInit?.headers);
+  assert.equal(headers.get("authorization"), "Bearer re_secret_key");
+  assert.equal(headers.get("content-type"), "application/json");
+
+  const body = JSON.parse(String(calledInit?.body));
+  assert.deepEqual(body, {
+    from: "sender@verified-domain.com",
+    to: "owner@example.com",
+    reply_to: "visitor@example.com",
+    subject: "Project inquiry",
+    text: "Hello, I would like to discuss a project with you.",
+  });
+});
+
+test("delivery: provider 4xx maps to rejected, never accepted", async () => {
+  const provider = createResendDeliveryProvider({
+    apiKey: "re_secret_key",
+    fetchFn: async () => jsonResponse(400, { message: "bad request" }),
+  });
+
+  const result = await provider.send(validMessage);
+
+  assert.equal(result.status, "rejected");
+});
+
+test("delivery: provider 5xx maps to rejected, never accepted", async () => {
+  const provider = createResendDeliveryProvider({
+    apiKey: "re_secret_key",
+    fetchFn: async () => jsonResponse(503, { message: "unavailable" }),
+  });
+
+  const result = await provider.send(validMessage);
+
+  assert.equal(result.status, "rejected");
+});
+
+test("delivery: network failure maps to error, never accepted", async () => {
+  const provider = createResendDeliveryProvider({
+    apiKey: "re_secret_key",
+    fetchFn: async () => {
+      throw new Error("connection reset");
+    },
+  });
+
+  const result = await provider.send(validMessage);
+
+  assert.equal(result.status, "error");
+});
+
+test("delivery: fetch abort (timeout) maps to error, never accepted", async () => {
+  const provider = createResendDeliveryProvider({
+    apiKey: "re_secret_key",
+    fetchFn: async (_url, init) => {
+      assert.ok(init?.signal, "expected an AbortSignal");
+      init?.signal?.throwIfAborted();
+      throw new Error("aborted");
+    },
+  });
+
+  const result = await provider.send(validMessage);
+
+  assert.equal(result.status, "error");
+});
+
+test("delivery: missing api key is rejected before fetch", async () => {
+  const provider = createResendDeliveryProvider({
+    apiKey: "",
+    fetchFn: async () => {
+      throw new Error("should not be called");
+    },
+  });
+
+  const result = await provider.send(validMessage);
+
+  assert.equal(result.status, "error");
+});

--- a/src/features/contact/delivery.ts
+++ b/src/features/contact/delivery.ts
@@ -1,0 +1,89 @@
+export interface ContactMessage {
+  from: string;
+  to: string;
+  replyTo: string;
+  subject: string;
+  text: string;
+}
+
+export type DeliveryResult =
+  | { status: "accepted"; messageId?: string }
+  | { status: "rejected" }
+  | { status: "error" };
+
+export interface ContactDeliveryProvider {
+  send(message: ContactMessage): Promise<DeliveryResult>;
+}
+
+interface ResendProviderOptions {
+  apiKey: string;
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Resend HTTP API delivery adapter using native fetch.
+ *
+ * Only a successful provider response (HTTP 2xx) is treated as accepted.
+ * Every provider error is mapped to an internal typed failure and the
+ * provider's raw response is never exposed to the caller.
+ */
+export function createResendDeliveryProvider(
+  options: ResendProviderOptions,
+): ContactDeliveryProvider {
+  const apiKey = options.apiKey.trim();
+  const fetchFn = options.fetchFn ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    async send(message: ContactMessage): Promise<DeliveryResult> {
+      if (apiKey.length === 0) {
+        return { status: "error" };
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+      try {
+        const response = await fetchFn(RESEND_ENDPOINT, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${apiKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            from: message.from,
+            to: message.to,
+            reply_to: message.replyTo,
+            subject: message.subject,
+            text: message.text,
+          }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return { status: "rejected" };
+        }
+
+        let messageId: string | undefined;
+        try {
+          const data = (await response.json()) as { id?: unknown };
+          if (typeof data.id === "string") {
+            messageId = data.id;
+          }
+        } catch {
+          // Response body is not JSON; a 2xx still counts as accepted.
+        }
+
+        return { status: "accepted", messageId };
+      } catch {
+        return { status: "error" };
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+  };
+}

--- a/src/features/contact/honeypot.test.ts
+++ b/src/features/contact/honeypot.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isHoneypotFilled } from "./honeypot";
+
+test("honeypot: empty value is not filled", () => {
+  assert.equal(isHoneypotFilled(""), false);
+  assert.equal(isHoneypotFilled("   "), false);
+  assert.equal(isHoneypotFilled(undefined), false);
+});
+
+test("honeypot: non-empty value is filled", () => {
+  assert.equal(isHoneypotFilled("spambot"), true);
+  assert.equal(isHoneypotFilled("  x  "), true);
+});

--- a/src/features/contact/honeypot.ts
+++ b/src/features/contact/honeypot.ts
@@ -1,0 +1,3 @@
+export function isHoneypotFilled(value: string | undefined | null): boolean {
+  return value !== undefined && value !== null && value.trim().length > 0;
+}

--- a/src/features/contact/rate-limit.test.ts
+++ b/src/features/contact/rate-limit.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createInMemoryRateLimiter,
+  type RateLimiter,
+} from "./rate-limit";
+
+interface MutableClock {
+  time: number;
+}
+
+function makeLimiter(clock: MutableClock): RateLimiter {
+  return createInMemoryRateLimiter({
+    burstLimit: 2,
+    burstWindowMs: 60_000,
+    hourlyLimit: 5,
+    hourlyWindowMs: 3_600_000,
+    now: () => clock.time,
+  });
+}
+
+function makeHourlyLimiter(clock: MutableClock): RateLimiter {
+  return createInMemoryRateLimiter({
+    burstLimit: 10,
+    burstWindowMs: 60_000,
+    hourlyLimit: 5,
+    hourlyWindowMs: 3_600_000,
+    now: () => clock.time,
+  });
+}
+
+test("rate-limit: allows requests under the burst limit", () => {
+  const clock: MutableClock = { time: 0 };
+  const limiter = makeLimiter(clock);
+
+  assert.equal(limiter.tryConsume("ip-1"), true);
+  assert.equal(limiter.tryConsume("ip-1"), true);
+});
+
+test("rate-limit: rejects when the burst window is exhausted", () => {
+  const clock: MutableClock = { time: 0 };
+  const limiter = makeLimiter(clock);
+
+  assert.equal(limiter.tryConsume("ip-1"), true);
+  assert.equal(limiter.tryConsume("ip-1"), true);
+  assert.equal(limiter.tryConsume("ip-1"), false);
+});
+
+test("rate-limit: different keys are independent", () => {
+  const clock: MutableClock = { time: 0 };
+  const limiter = makeLimiter(clock);
+
+  assert.equal(limiter.tryConsume("ip-1"), true);
+  assert.equal(limiter.tryConsume("ip-1"), true);
+  assert.equal(limiter.tryConsume("ip-2"), true);
+});
+
+test("rate-limit: burst budget refills after the burst window elapses", () => {
+  const clock: MutableClock = { time: 0 };
+  const limiter = makeLimiter(clock);
+
+  assert.equal(limiter.tryConsume("ip-1"), true);
+  assert.equal(limiter.tryConsume("ip-1"), true);
+  assert.equal(limiter.tryConsume("ip-1"), false);
+
+  clock.time += 61_000;
+  assert.equal(limiter.tryConsume("ip-1"), true);
+});
+
+test("rate-limit: rejects once the hourly cap is reached", () => {
+  const clock: MutableClock = { time: 0 };
+  const limiter = makeHourlyLimiter(clock);
+
+  for (let i = 0; i < 5; i++) {
+    assert.equal(limiter.tryConsume("ip-1"), true, `attempt ${i}`);
+  }
+  assert.equal(limiter.tryConsume("ip-1"), false);
+});
+
+test("rate-limit: hourly cap resets after the hourly window elapses", () => {
+  const clock: MutableClock = { time: 0 };
+  const limiter = makeHourlyLimiter(clock);
+
+  for (let i = 0; i < 5; i++) {
+    assert.equal(limiter.tryConsume("ip-1"), true, `attempt ${i}`);
+  }
+  assert.equal(limiter.tryConsume("ip-1"), false);
+
+  clock.time += 3_600_001;
+  assert.equal(limiter.tryConsume("ip-1"), true);
+});
+
+test("rate-limit: reset clears all state", () => {
+  const clock: MutableClock = { time: 0 };
+  const limiter = makeLimiter(clock);
+
+  for (let i = 0; i < 5; i++) {
+    limiter.tryConsume("ip-1");
+  }
+  assert.equal(limiter.tryConsume("ip-1"), false);
+
+  limiter.reset();
+  assert.equal(limiter.tryConsume("ip-1"), true);
+});

--- a/src/features/contact/rate-limit.ts
+++ b/src/features/contact/rate-limit.ts
@@ -1,0 +1,81 @@
+export interface RateLimiterConfig {
+  burstLimit: number;
+  burstWindowMs: number;
+  hourlyLimit: number;
+  hourlyWindowMs: number;
+  now: () => number;
+}
+
+export interface RateLimiter {
+  tryConsume(key: string): boolean;
+  reset(): void;
+}
+
+interface Bucket {
+  burstTimestamps: number[];
+  hourlyTimestamps: number[];
+}
+
+/**
+ * Process-local in-memory rate limiter.
+ *
+ * Limitation: this reduces abuse per running instance only. It is not a
+ * distributed or durable limiter — on serverless/multi-instance
+ * deployments each instance keeps its own state, so effective limits are
+ * approximate and reset when an instance restarts.
+ */
+export function createInMemoryRateLimiter(
+  config: RateLimiterConfig,
+): RateLimiter {
+  const buckets = new Map<string, Bucket>();
+
+  function getBucket(key: string): Bucket {
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { burstTimestamps: [], hourlyTimestamps: [] };
+      buckets.set(key, bucket);
+    }
+    return bucket;
+  }
+
+  function trimWithin(
+    timestamps: number[],
+    windowMs: number,
+    now: number,
+  ): number[] {
+    return timestamps.filter((timestamp) => now - timestamp < windowMs);
+  }
+
+  return {
+    tryConsume(key: string): boolean {
+      const now = config.now();
+      const bucket = getBucket(key);
+
+      bucket.burstTimestamps = trimWithin(
+        bucket.burstTimestamps,
+        config.burstWindowMs,
+        now,
+      );
+      bucket.hourlyTimestamps = trimWithin(
+        bucket.hourlyTimestamps,
+        config.hourlyWindowMs,
+        now,
+      );
+
+      if (bucket.burstTimestamps.length >= config.burstLimit) {
+        return false;
+      }
+      if (bucket.hourlyTimestamps.length >= config.hourlyLimit) {
+        return false;
+      }
+
+      bucket.burstTimestamps.push(now);
+      bucket.hourlyTimestamps.push(now);
+      return true;
+    },
+
+    reset(): void {
+      buckets.clear();
+    },
+  };
+}

--- a/src/features/contact/submit.test.ts
+++ b/src/features/contact/submit.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  submitContact,
+  type SubmitContactDeps,
+  type SubmitContactInput,
+} from "./submit";
+
+import type { ContactDeliveryProvider } from "./delivery";
+import type { RateLimiter } from "./rate-limit";
+
+const validInput: SubmitContactInput = {
+  name: "Khoa Quach",
+  email: "visitor@example.com",
+  subject: "Project inquiry",
+  message: "Hello, I would like to discuss a project with you.",
+  honeypot: "",
+};
+
+function makeDeps(overrides: Partial<SubmitContactDeps> = {}): SubmitContactDeps {
+  return {
+    provider: {
+      send: async () => ({ status: "accepted" }),
+    },
+    limiter: {
+      tryConsume: () => true,
+      reset: () => {},
+    },
+    clientId: "203.0.113.7",
+    fromEmail: "sender@verified-domain.com",
+    toEmail: "owner@example.com",
+    ...overrides,
+  };
+}
+
+test("submit: valid payload with provider acceptance maps to success", async () => {
+  let sent: unknown;
+  const provider: ContactDeliveryProvider = {
+    send: async (message) => {
+      sent = message;
+      return { status: "accepted" };
+    },
+  };
+
+  const result = await submitContact(validInput, makeDeps({ provider }));
+
+  assert.equal(result.status, "success");
+  assert.deepEqual(sent, {
+    from: "sender@verified-domain.com",
+    to: "owner@example.com",
+    replyTo: "visitor@example.com",
+    subject: "Project inquiry",
+    text: 'From: Khoa Quach <visitor@example.com>\n\nHello, I would like to discuss a project with you.',
+  });
+});
+
+test("submit: invalid payload returns field-error and never calls provider", async () => {
+  let providerCalled = false;
+  const provider: ContactDeliveryProvider = {
+    send: async () => {
+      providerCalled = true;
+      return { status: "accepted" };
+    },
+  };
+
+  const result = await submitContact(
+    { ...validInput, email: "not-an-email" },
+    makeDeps({ provider }),
+  );
+
+  assert.equal(result.status, "field-error");
+  assert.ok("email" in result.fieldErrors);
+  assert.equal(providerCalled, false);
+});
+
+test("submit: honeypot filled returns rejected and never calls provider", async () => {
+  let providerCalled = false;
+  const provider: ContactDeliveryProvider = {
+    send: async () => {
+      providerCalled = true;
+      return { status: "accepted" };
+    },
+  };
+
+  const result = await submitContact(
+    { ...validInput, honeypot: "spambot" },
+    makeDeps({ provider }),
+  );
+
+  assert.equal(result.status, "rejected");
+  assert.equal(providerCalled, false);
+});
+
+test("submit: missing client identifier fails conservatively as rejected", async () => {
+  let providerCalled = false;
+  const provider: ContactDeliveryProvider = {
+    send: async () => {
+      providerCalled = true;
+      return { status: "accepted" };
+    },
+  };
+
+  const result = await submitContact(
+    validInput,
+    makeDeps({ provider, clientId: null }),
+  );
+
+  assert.equal(result.status, "rejected");
+  assert.equal(providerCalled, false);
+});
+
+test("submit: rate limited returns rate-limited and never calls provider", async () => {
+  let providerCalled = false;
+  const provider: ContactDeliveryProvider = {
+    send: async () => {
+      providerCalled = true;
+      return { status: "accepted" };
+    },
+  };
+  const limiter: RateLimiter = {
+    tryConsume: () => false,
+    reset: () => {},
+  };
+
+  const result = await submitContact(
+    validInput,
+    makeDeps({ provider, limiter }),
+  );
+
+  assert.equal(result.status, "rate-limited");
+  assert.equal(providerCalled, false);
+});
+
+test("submit: provider rejected maps to server-error", async () => {
+  const provider: ContactDeliveryProvider = {
+    send: async () => ({ status: "rejected" }),
+  };
+
+  const result = await submitContact(validInput, makeDeps({ provider }));
+
+  assert.equal(result.status, "server-error");
+});
+
+test("submit: provider error maps to server-error", async () => {
+  const provider: ContactDeliveryProvider = {
+    send: async () => ({ status: "error" }),
+  };
+
+  const result = await submitContact(validInput, makeDeps({ provider }));
+
+  assert.equal(result.status, "server-error");
+});
+
+test("submit: missing from email is server-error and never calls provider", async () => {
+  let providerCalled = false;
+  const provider: ContactDeliveryProvider = {
+    send: async () => {
+      providerCalled = true;
+      return { status: "accepted" };
+    },
+  };
+
+  const result = await submitContact(
+    validInput,
+    makeDeps({ provider, fromEmail: "" }),
+  );
+
+  assert.equal(result.status, "server-error");
+  assert.equal(providerCalled, false);
+});
+
+test("submit: missing to email is server-error and never calls provider", async () => {
+  let providerCalled = false;
+  const provider: ContactDeliveryProvider = {
+    send: async () => {
+      providerCalled = true;
+      return { status: "accepted" };
+    },
+  };
+
+  const result = await submitContact(
+    validInput,
+    makeDeps({ provider, toEmail: "" }),
+  );
+
+  assert.equal(result.status, "server-error");
+  assert.equal(providerCalled, false);
+});
+
+test("submit: provider failure can never map to success", async () => {
+  for (const delivery of [
+    { status: "rejected" },
+    { status: "error" },
+  ] as const) {
+    const provider: ContactDeliveryProvider = {
+      send: async () => delivery,
+    };
+
+    const result = await submitContact(validInput, makeDeps({ provider }));
+
+    assert.notEqual(result.status, "success", `for ${delivery.status}`);
+    assert.equal(result.status, "server-error");
+  }
+});

--- a/src/features/contact/submit.ts
+++ b/src/features/contact/submit.ts
@@ -1,0 +1,80 @@
+import type { ContactDeliveryProvider } from "./delivery";
+import { isHoneypotFilled } from "./honeypot";
+import type { RateLimiter } from "./rate-limit";
+import {
+  validateContactSubmission,
+  type ContactFieldErrors,
+} from "./validation";
+
+export interface SubmitContactInput {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+  honeypot: string;
+}
+
+export interface SubmitContactDeps {
+  provider: ContactDeliveryProvider;
+  limiter: RateLimiter;
+  clientId: string | null;
+  fromEmail: string;
+  toEmail: string;
+}
+
+export type SubmitContactResult =
+  | { status: "idle" }
+  | { status: "field-error"; fieldErrors: ContactFieldErrors }
+  | { status: "rejected" }
+  | { status: "rate-limited" }
+  | { status: "server-error" }
+  | { status: "success" };
+
+export async function submitContact(
+  input: SubmitContactInput,
+  deps: SubmitContactDeps,
+): Promise<SubmitContactResult> {
+  if (isHoneypotFilled(input.honeypot)) {
+    return { status: "rejected" };
+  }
+
+  if (deps.clientId === null) {
+    return { status: "rejected" };
+  }
+
+  const fieldErrors = validateContactSubmission(input);
+  if (Object.keys(fieldErrors).length > 0) {
+    return { status: "field-error", fieldErrors };
+  }
+
+  const fromEmail = deps.fromEmail.trim();
+  const toEmail = deps.toEmail.trim();
+
+  if (fromEmail.length === 0 || toEmail.length === 0) {
+    return { status: "server-error" };
+  }
+
+  if (!deps.limiter.tryConsume(deps.clientId)) {
+    return { status: "rate-limited" };
+  }
+
+  const delivery = await deps.provider.send({
+    from: fromEmail,
+    to: toEmail,
+    replyTo: input.email.trim(),
+    subject: input.subject.trim(),
+    text: [
+      `From: ${input.name.trim()} <${input.email.trim()}>`,
+      ``,
+      input.message.trim(),
+    ].join("\n"),
+  });
+
+  switch (delivery.status) {
+    case "accepted":
+      return { status: "success" };
+    case "rejected":
+    case "error":
+      return { status: "server-error" };
+  }
+}

--- a/src/features/contact/validation.test.ts
+++ b/src/features/contact/validation.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  validateContactSubmission,
+  type ContactFieldName,
+} from "./validation";
+
+interface Expectation {
+  label: string;
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+  want: ContactFieldName[];
+}
+
+const table: Expectation[] = [
+  {
+    label: "accepts a valid trimmed payload",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: [],
+  },
+  {
+    label: "trims surrounding whitespace before validating",
+    name: "  Khoa Quach  ",
+    email: "  visitor@example.com  ",
+    subject: "  Project inquiry  ",
+    message: "  Hello, I would like to discuss a project with you.  ",
+    want: [],
+  },
+  {
+    label: "rejects missing name",
+    name: "",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["name"],
+  },
+  {
+    label: "rejects missing email",
+    name: "Khoa Quach",
+    email: "",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["email"],
+  },
+  {
+    label: "rejects missing subject",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["subject"],
+  },
+  {
+    label: "rejects missing message",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "",
+    want: ["message"],
+  },
+  {
+    label: "rejects blank whitespace-only fields",
+    name: "   ",
+    email: "   ",
+    subject: "   ",
+    message: "   ",
+    want: ["name", "email", "subject", "message"],
+  },
+  {
+    label: "rejects malformed email",
+    name: "Khoa Quach",
+    email: "not-an-email",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["email"],
+  },
+  {
+    label: "rejects email without domain",
+    name: "Khoa Quach",
+    email: "visitor@",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["email"],
+  },
+  {
+    label: "rejects email missing local part",
+    name: "Khoa Quach",
+    email: "@example.com",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["email"],
+  },
+  {
+    label: "rejects name below minimum length",
+    name: "A",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["name"],
+  },
+  {
+    label: "accepts name at minimum length",
+    name: "Aa",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: [],
+  },
+  {
+    label: "rejects name above maximum length",
+    name: "x".repeat(81),
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["name"],
+  },
+  {
+    label: "accepts name at maximum length",
+    name: "x".repeat(80),
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: [],
+  },
+  {
+    label: "rejects subject below minimum length",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "A",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["subject"],
+  },
+  {
+    label: "rejects subject above maximum length",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "x".repeat(121),
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["subject"],
+  },
+  {
+    label: "rejects message below minimum length",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "Too short",
+    want: ["message"],
+  },
+  {
+    label: "accepts message at minimum length",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "1234567890",
+    want: [],
+  },
+  {
+    label: "rejects message above maximum length",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "x".repeat(4001),
+    want: ["message"],
+  },
+  {
+    label: "accepts message at maximum length",
+    name: "Khoa Quach",
+    email: "visitor@example.com",
+    subject: "Project inquiry",
+    message: "x".repeat(4000),
+    want: [],
+  },
+  {
+    label: "rejects email above maximum length",
+    name: "Khoa Quach",
+    email: `${"a".repeat(243)}@example.com`,
+    subject: "Project inquiry",
+    message: "Hello, I would like to discuss a project with you.",
+    want: ["email"],
+  },
+];
+
+for (const entry of table) {
+  test(`validation: ${entry.label}`, () => {
+    const errors = validateContactSubmission({
+      name: entry.name,
+      email: entry.email,
+      subject: entry.subject,
+      message: entry.message,
+    });
+
+    const errorFields = Object.keys(errors) as ContactFieldName[];
+    assert.deepEqual(errorFields.sort(), [...entry.want].sort());
+  });
+}

--- a/src/features/contact/validation.ts
+++ b/src/features/contact/validation.ts
@@ -1,0 +1,95 @@
+export type ContactFieldName = "name" | "email" | "subject" | "message";
+
+export type ContactFieldErrorCode =
+  | "required"
+  | "too-short"
+  | "too-long"
+  | "invalid-email";
+
+export type ContactFieldErrors = Partial<
+  Record<ContactFieldName, ContactFieldErrorCode>
+>;
+
+export interface ContactSubmissionInput {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
+export const CONTACT_LIMITS = {
+  name: { min: 2, max: 80 },
+  email: { min: 1, max: 254 },
+  subject: { min: 2, max: 120 },
+  message: { min: 10, max: 4000 },
+} as const;
+
+function checkLength(
+  value: string,
+  field: ContactFieldName,
+  errors: ContactFieldErrors,
+): string {
+  const trimmed = value.trim();
+  const { min, max } = CONTACT_LIMITS[field];
+
+  if (trimmed.length === 0) {
+    errors[field] = "required";
+  } else if (trimmed.length < min) {
+    errors[field] = "too-short";
+  } else if (trimmed.length > max) {
+    errors[field] = "too-long";
+  }
+
+  return trimmed;
+}
+
+function isValidEmail(email: string): boolean {
+  if (email.length > CONTACT_LIMITS.email.max) {
+    return false;
+  }
+
+  const atIndex = email.indexOf("@");
+  const lastAtIndex = email.lastIndexOf("@");
+
+  if (atIndex <= 0 || lastAtIndex !== atIndex) {
+    return false;
+  }
+
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1);
+
+  if (local.length === 0 || domain.length === 0) {
+    return false;
+  }
+
+  if (!domain.includes(".")) {
+    return false;
+  }
+
+  const invalidChars = /[^\w.!#$%&'*+/=?^`{|}~-]/;
+  if (invalidChars.test(local)) {
+    return false;
+  }
+
+  const domainPart = /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  return domainPart.test(domain);
+}
+
+export function validateContactSubmission(
+  input: ContactSubmissionInput,
+): ContactFieldErrors {
+  const errors: ContactFieldErrors = {};
+
+  checkLength(input.name, "name", errors);
+  checkLength(input.subject, "subject", errors);
+  checkLength(input.message, "message", errors);
+
+  const email = input.email.trim();
+  if (email.length === 0) {
+    errors.email = "required";
+  } else if (!isValidEmail(email)) {
+    errors.email = "invalid-email";
+  }
+
+  return errors;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1677,14 +1677,246 @@ video {
   }
 }
 
+.contact-section {
+  padding-block: var(--section-space);
+  border-block-end: 1px solid var(--color-border);
+  background:
+    radial-gradient(
+      circle at 10% 88%,
+      var(--color-accent-soft),
+      transparent 26rem
+    ),
+    var(--color-page);
+}
+
+.contact-section__intro {
+  display: grid;
+  gap: var(--space-8);
+}
+
+.contact-layout {
+  display: grid;
+  gap: var(--space-6);
+  margin-block-start: var(--space-10);
+}
+
+.contact-info__card {
+  display: grid;
+  gap: var(--space-5);
+  padding: var(--space-6);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-md);
+}
+
+.contact-info__heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.contact-info__list {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  gap: var(--space-3);
+  list-style: none;
+}
+
+.contact-info__link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  color: var(--color-text);
+  text-decoration: none;
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.contact-info__link:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-accent-soft);
+}
+
+.contact-info__label {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.contact-info__value {
+  font-weight: var(--font-weight-semibold);
+}
+
+.contact-panel {
+  padding: var(--space-6);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-md);
+}
+
+.contact-form {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.contact-form__required-note {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.contact-form__field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.contact-form__field label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.contact-form__field input,
+.contact-form__field textarea {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.contact-form__field input:hover,
+.contact-form__field textarea:hover {
+  border-color: var(--color-border-strong);
+}
+
+.contact-form__field input:focus-visible,
+.contact-form__field textarea:focus-visible {
+  border-color: var(--color-focus);
+}
+
+.contact-form__field input[aria-invalid="true"],
+.contact-form__field textarea[aria-invalid="true"] {
+  border-color: var(--color-error);
+}
+
+.contact-form__field textarea {
+  min-height: 9rem;
+  resize: vertical;
+}
+
+.contact-form__error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
+.contact-form__honeypot {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.contact-form__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.contact-form__submit {
+  display: inline-flex;
+  min-height: 3.25rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-6);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.contact-form__submit:hover:not(:disabled) {
+  border-color: var(--color-accent-hover);
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+}
+
+.contact-form__submit:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.contact-form__status {
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.contact-form__status--success {
+  background: color-mix(in oklch, var(--color-success) 14%, transparent);
+  color: var(--color-success);
+}
+
+.contact-form__status--rejected,
+.contact-form__status--server-error {
+  background: color-mix(in oklch, var(--color-error) 12%, transparent);
+  color: var(--color-error);
+}
+
+.contact-form__status--rate-limited {
+  background: color-mix(in oklch, var(--color-error) 12%, transparent);
+  color: var(--color-error);
+}
+
+@media (min-width: 64rem) {
+  .contact-layout {
+    grid-template-columns: minmax(16rem, 22rem) minmax(0, 1fr);
+    align-items: start;
+    gap: var(--space-8);
+  }
+
+  .contact-info__card {
+    position: sticky;
+    top: calc(var(--header-scroll-offset) + var(--space-3));
+  }
+
+  .contact-panel {
+    padding: var(--space-8);
+  }
+}
+
 .navigation-anchor--placeholder {
   display: grid;
   min-height: max(28rem, 65vh);
   align-items: center;
   border-block-start: 1px solid var(--color-border);
-}
-
-.navigation-anchor--placeholder:nth-of-type(odd) {
+}.navigation-anchor--placeholder:nth-of-type(odd) {
   background: var(--color-surface-subtle);
 }
 


### PR DESCRIPTION
## Summary

Implements the real Contact section and secure server-side message delivery for Issue #12.

**Provider:** Resend via native `fetch` (no SDK dependency). Server Action + React `useActionState`/`useFormStatus`. Hand-written pure TypeScript validation (server-authoritative). Honeypot + process-local server-side rate limiting.

### Changes

- `src/components/sections/contact/contact-section.tsx` — replaces the `#contact` placeholder; keeps exact `id="contact"` + `navigation-anchor` behavior. Desktop 2-column (info left, form right), mobile single column.
- `src/content/contact.ts` — localized EN/VI content model. Left column uses **only the verified GitHub profile** (`https://github.com/Akbi47`); email/phone/LinkedIn/location omitted pending owner approval.
- `src/features/contact/contact-form.tsx` — accessible form (real labels, `aria-describedby` field errors, `aria-invalid`, `aria-live` status, keyboard-friendly, honeypot field hidden off-screen). Controlled inputs: values preserved on failure, cleared intentionally on success. States: idle / field-error / rejected / rate-limited / server-error / success. Submitting state disables the button and shows localized pending text.
- `src/features/contact/actions.ts` — `"use server"` action. Reads `x-forwarded-for` (Vercel assumption, isolated in one function), builds the real Resend provider, delegates to the core.
- `src/features/contact/validation.ts` — pure typed validation (name 2–80, email ≤254 + syntax, subject 2–120, message 10–4000, whitespace-trimmed), shared client/server rules.
- `src/features/contact/honeypot.ts` — honeypot detection.
- `src/features/contact/rate-limit.ts` — `RateLimiter` interface + in-memory implementation (injectable clock), burst + hourly caps.
- `src/features/contact/client-identifier.ts` — single client-IP extraction function (first `x-forwarded-for` entry, port-stripped, fails closed on garbage).
- `src/features/contact/delivery.ts` — `ContactDeliveryProvider` interface + Resend adapter (native fetch, AbortSignal timeout, only 2xx → accepted, provider errors mapped to internal typed failures, raw responses never exposed).
- `src/features/contact/submit.ts` — orchestration core: honeypot → client-id → validation → config check → rate-limit → provider. Provider acceptance is the **only** path to `success`.
- Tests via Node `node:test` + `tsx` (`npm test`) — 53 tests.
- `.env.example` — added `RESEND_API_KEY`, `CONTACT_TO_EMAIL`, `CONTACT_FROM_EMAIL` (names only). `.github/workflows/ci.yml` — added `npm test`. `AGENTS.md` — updated test-runner note (now real).

## Acceptance criteria

- [x] Form labels/errors accessible (real labels, aria-describedby, aria-invalid, aria-live status)
- [x] Invalid submissions rejected server-side (server validation authoritative; client only mirrors)
- [x] Honeypot and rate limit enforced server-side
- [x] Successful delivery verified in a production-like environment (real Resend key, verified `feaon.com` sender, inbox receipt confirmed)
- [x] No mail/provider secrets exposed client-side or committed (env names only; provider server-only)
- [x] Failure states never falsely report success (only provider 2xx → success)
- [x] lint, typecheck, focused tests (53), and build pass

## Verification

- `npm test` → **53/53 pass** (validation incl. trimming/boundaries; honeypot rejection + honeypot never invokes provider; rate-limit allowed/rejected/refill/reset; client-identifier extraction; delivery success/4xx/5xx/network-abort/missing-key; submit orchestration incl. "provider failure can never map to success").
- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run build` ✅ (Turbopack) · `git diff --check` ✅
- Browser (Playwright, EN+VI, desktop+mobile, light+dark): **23/23 checks passed** — section anchor + 2-col/mobile layout, fields + hidden honeypot, server field errors + aria association, malformed email localized error, honeypot → generic rejection (never success), missing config → server-error (fails closed), values preserved on failure, success state renders + clears form, rate-limited state renders + preserves values, keyboard-only completion, pending state disables button + localized text, no horizontal overflow (both viewports), dark theme, vi localization, zero console/runtime errors.
- Screenshots captured to `/tmp/qvak-contact/*.png` (desktop light/dark, mobile, vi) during verification.

## Env setup (owner)

```bash
RESEND_API_KEY=re_...            # Resend API key (server-only)
CONTACT_TO_EMAIL=owner@...        # destination inbox (server-only)
CONTACT_FROM_EMAIL=contact@...    # must be on a verified Resend sending domain (server-only)
```

`from` = `CONTACT_FROM_EMAIL`, `to` = `CONTACT_TO_EMAIL`, `reply_to` = validated visitor email, plain-text body. Without these, the action returns `server-error` (fails closed — never fake success).

## Rate-limit limitations (documented)

Process-local in-memory rate limiting (burst 2/min, 5/hour per normalized client IP) **reduces abuse per running instance only**; it is not a distributed/durable limiter. On serverless/multi-instance deployments each instance keeps its own state, so effective limits are approximate and reset on restart. A durable limiter (e.g., Upstash Redis) would add new paid infrastructure and is intentionally **not** introduced here — tracked as a separate decision if required before public launch. `x-forwarded-for` handling is Vercel-specific and isolated; unrecognizable values fail closed.

## Provider verification (DONE — real Resend delivery confirmed)

Real end-to-end delivery was verified in a production-like environment with real credentials:

- **Direct Resend API send accepted** — HTTP 200, message id `17caca38-cddb-4634-b8fa-634d7f5af69d` (sender `QVAK Portfolio <portfolio@feaon.com>` on a Resend-verified domain, recipient inbox confirmed).
- **Actual Contact form submission** — server action called Resend (`submitContactForm` 1771ms), returned `success`, form cleared itself. Browser check confirmed status `contact-form__status--success` with zero console errors.
- **Inbox receipt confirmed by owner** for both messages.

No secrets were committed: `.env.example` contains names only; real values live in git-ignored `.env.local`. The owner pasted the key into `.env.example` during verification; it was moved to `.env.local` and `.env.example` restored to a template — **the owner should regenerate the Resend API key** as a precaution since it was briefly present in a tracked file.

## Known limitations / follow-ups

- Real end-to-end delivery verification is **complete** (see Provider verification section). Owner should regenerate the Resend API key as a precaution since it was briefly pasted into the tracked `.env.example` during verification.
- Email/phone/LinkedIn/location intentionally omitted from the left column until owner approves public values.
- No HTML email; plain-text body only (user-controlled content never rendered as HTML).
- No message bodies/visitor emails/logs are logged; provider responses are mapped to generic user messages.

## Scope

No Footer, newsletter, CMS, SEO, redirects, cutover, or Resume changes.


