### PR TITLE
chore(agent): refine ChatGPT review bridge to review result summaries

### DIFF
--- a/.opencode/agents/chatgpt-review.md
+++ b/.opencode/agents/chatgpt-review.md
@@ -1,5 +1,5 @@
 ---
-description: Sends code, diffs, plans, or agent responses to ChatGPT Plus (web) for review through a browser bridge and returns the verdict. Use when the user asks for an external review or ChatGPT review.
+description: Sends an agent's final task result (summary text, not raw diffs) to ChatGPT Plus (web) for review through a browser bridge and returns the verdict. Use when the user asks for an external review or ChatGPT review, or when auto-review is enabled after a task completes.
 mode: subagent
 permission:
   edit: deny
@@ -11,26 +11,26 @@ permission:
     "~/.config/opencode/chatgpt-bridge/bin/chatgpt-review *": allow
     "git status": allow
     "git status *": allow
-    "git diff": allow
-    "git diff *": allow
-    "git log *": allow
     "git rev-parse *": allow
-    "git show *": allow
 ---
 
-You are a review dispatcher. Your job is to package work for ChatGPT Plus (web) and return its review.
+You are a review dispatcher. Your job is to send a completed task's **final result**
+(the agent's summary of what was done) to ChatGPT Plus (web) and return its review.
 
 Steps:
-1. Check the bridge is ready by running:
+1. Check the bridge is ready:
    `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review status`
-2. Gather the material to review. Prefer `git diff` (uncommitted) or `git diff <base>..HEAD` for committed work. If the user pointed at a specific response or plan, include that text instead.
+2. Use the **text passed to you by the calling agent** as the material to review —
+   the "Done / What changed / Verification" summary the agent just produced. Do NOT
+   generate or fetch a git diff; the caller already decided what to send.
 3. Write a tight review prompt to `/tmp/opencode/chatgpt-review-prompt.md`:
    - One-line task summary.
-   - The diff/code/output.
-   - Focus areas (bugs, security, correctness, style).
+   - The result text verbatim.
+   - Focus areas (bugs, security, correctness, completeness).
    - Request a verdict block: VERDICT / ISSUES / SUGGESTIONS.
 4. Run: `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review ask --file=/tmp/opencode/chatgpt-review-prompt.md`
 5. Return ChatGPT's reply verbatim, then a 2-3 line summary of the most important findings.
 
 If `status` shows `loggedIn: false`, do not run the review; report that the user must run `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review login` once in a terminal.
 If the bridge throws an error, report the exact error and do not claim the review succeeded.
+

--- a/.opencode/commands/autoreview.md
+++ b/.opencode/commands/autoreview.md
@@ -11,5 +11,6 @@ Where `$ARGUMENTS` is `on`, `off`, or `status`.
 
 Report the result to the user. If toggled on, tell the user auto-review is now
 active: after each implementation task with code changes, you will automatically
-invoke `@chatgpt-review` to send the diff to ChatGPT Plus and report the verdict.
-If toggled off, tell the user reviews are now manual-only (`@chatgpt-review`).
+invoke `@chatgpt-review` to send the task's final result summary (Done / What
+changed / Verification) to ChatGPT Plus and report the verdict. If toggled off,
+tell the user reviews are now manual-only (`@chatgpt-review`).

--- a/.opencode/skills/chatgpt-review/SKILL.md
+++ b/.opencode/skills/chatgpt-review/SKILL.md
@@ -1,11 +1,30 @@
 ---
 name: chatgpt-review
-description: Use when the user wants a response, diff, plan, or code reviewed by ChatGPT Plus (web) without copy-pasting. Also triggered by "review with chatgpt", "gửi cho chatgpt review", "review ngoài", or when a task finishes and auto-review is enabled. Sends content to ChatGPT Plus via a browser bridge and returns the review.
+description: Use when a completed task's final result text should be reviewed by ChatGPT Plus (web) without copy-pasting. Also triggered by "review with chatgpt", "gửi cho chatgpt review", "review ngoài", or when a task finishes and auto-review is enabled. Sends the task's result summary to ChatGPT Plus via a browser bridge and returns the review.
 ---
 
 # chatgpt-review
 
-Send a prompt to ChatGPT Plus (web) through a Playwright bridge and read the reply back into the session. The user does **not** need to copy-paste.
+Send a completed task's **final result text** (the "Done / What changed /
+Verification" summary) to ChatGPT Plus (web) through a Playwright bridge and read
+the review back into the session. The user does **not** need to copy-paste.
+
+## What gets reviewed
+
+Send the agent's own result text — e.g. a summary like:
+
+```
+Done. Pushed to PR #38 (still Draft, not merged), CI green.
+
+What changed
+- ...
+
+Verification
+- ...
+```
+
+Do **not** fetch or attach a raw `git diff` — review the completed work's
+summary that the agent just produced.
 
 ## Requirements
 
@@ -22,12 +41,12 @@ Send a prompt to ChatGPT Plus (web) through a Playwright bridge and read the rep
 
 2. Build the review prompt. Write it to a temp file, e.g. `/tmp/opencode/chatgpt-review-prompt.md`. A good review prompt includes:
    - What the task was (1-2 sentences).
-   - The actual code/diff/output to review (git diff, relevant files, the plan, or the response text).
-   - What to focus on (bugs, security, correctness, style, suggested improvements).
+   - The **result text verbatim** (the summary the agent produced).
+   - What to focus on (bugs, security, correctness, completeness, missing steps).
    - Ask for a concise verdict in a fixed format, e.g.:
      ```
      VERDICT: approve / approve-with-changes / reject
-     ISSUES: bullet list (with file:line when relevant)
+     ISSUES: bullet list
      SUGGESTIONS: prioritized short list
      ```
 3. Send it:
@@ -73,6 +92,6 @@ repo) so they are organized, share project instructions, and keep project memory
 
 ## Notes
 
-- Use `git diff` for uncommitted changes; `git diff <base>..HEAD` for committed work. Ask the user which scope they want if it is ambiguous.
+- Only send the result **summary text**, not raw diffs.
 - ChatGPT's web UI changes occasionally; if selectors break, the script throws a descriptive error. Do not silently claim a review succeeded when the bridge errored.
-- If the user wants a quick check, keep the prompt tight: send the diff plus 3 focus questions, not a wall of context.
+- If the user wants a quick check, keep the prompt tight: send the result plus 3 focus questions, not a wall of context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,14 +80,15 @@ OpenCode self-review does not replace independent review.
 
 Before opening a Pull Request, run an external review through the ChatGPT bridge
 to catch issues an independent reviewer may flag. Use the `@chatgpt-review`
-subagent (or the `chatgpt-review` skill) with the full diff. One command, no
-copy-paste:
+subagent (or the `chatgpt-review` skill). One command, no copy-paste:
 
-1. Invoke `@chatgpt-review` in the session and ask for a review of the current
-   working-tree diff against the linked Issue.
-2. The subagent packages the diff, sends it to ChatGPT Plus (web) via the
-   browser bridge, and returns the verdict.
-3. Address actionable feedback, rerun relevant checks, and mention the review
+1. Finish the task and write the normal result summary (Done / What changed /
+   Verification).
+2. Invoke `@chatgpt-review` in the session and pass that result summary text as
+   the review material. Do not attach a git diff.
+3. The subagent sends the summary to ChatGPT Plus (web) via the browser bridge
+   and returns the verdict.
+4. Address actionable feedback, rerun relevant checks, and mention the review
    in the PR.
 
 The bridge needs a one-time login: run


### PR DESCRIPTION
## Summary
Refines the ChatGPT review bridge config to review a task's **final result summary** (Done / What changed / Verification) instead of raw git diffs. Aligns AGENTS.md, the `@chatgpt-review` subagent, the `chatgpt-review` skill, and the `autoreview` command.

## Context
The initial bridge config landed in main via 222baf2 ("chore: add ChatGPT review bridge for pre-PR reviews"). This PR is the follow-up refinement already present in the working tree, brought in as its own config-only PR. `.opencode/commands/{chatgpt-new,chatgpt-project}.md` are unchanged — identical to `~/.config/opencode/command/` and to main.

## What changed (4 files, 2 commits)
- `AGENTS.md` — bridge section now instructs agents to pass their result summary text (no copy-paste of diffs).
- `.opencode/agents/chatgpt-review.md` — dispatcher uses caller-provided summary text; drops `git diff`/`git show`/`git log` permissions (no longer needed).
- `.opencode/skills/chatgpt-review/SKILL.md` — workflow sends result summary verbatim, not diffs.
- `.opencode/commands/autoreview.md` — auto-review flow aligned with the result-summary workflow (follow-up from external review).

## Verification
- Config-only change; no app code. `lint` / `typecheck` / `build` unaffected.
- `git diff origin/main` confirmed: only the four intended files changed (48 insertions, 27 deletions).
- Grep verified no stale "send the diff / full diff" references remain in the bridge config.
- External ChatGPT review: first round "request changes" (HIGH: autoreview.md diff wording) → addressed; second round "approve-with-changes" (only this stale description) → now updated.
- CI green on head 4531f30 (lint, typecheck, build, GitGuardian).

## Known limitations
- The "npm test runner" line in AGENTS.md is intentionally **not** touched here — it belongs to the open PR #38 (contact form) scope; hunks are separate.
- Global `~/.config/opencode/command/autoreview.md` (outside repo) still carries the old wording and should be regenerated/synced after merge.

Closes: none (config-only; no linked issue)