### PR TITLE
chore(agent): make ChatGPT review bridge workflow-aware

### DIFF
--- a/.opencode/agents/chatgpt-review.md
+++ b/.opencode/agents/chatgpt-review.md
@@ -1,5 +1,5 @@
 ---
-description: Sends an agent's final task result (summary text, not raw diffs) to ChatGPT Plus (web) for review through a browser bridge and returns the verdict. Use when the user asks for an external review or ChatGPT review, or when auto-review is enabled after a task completes.
+description: Workflow-aware independent reviewer. Sends an agent's completed task result (summary text, not raw diffs) to ChatGPT Plus (web) through a browser bridge, wrapped in structured workflow context, and returns a machine-actionable verdict that advances the workflow. Use when the user asks for an external/ChatGPT review, or when auto-review runs after a task completes.
 mode: subagent
 permission:
   edit: deny
@@ -12,25 +12,115 @@ permission:
     "git status": allow
     "git status *": allow
     "git rev-parse *": allow
+    "git log *": allow
+    "git branch *": allow
+    "gh pr view *": allow
 ---
 
-You are a review dispatcher. Your job is to send a completed task's **final result**
-(the agent's summary of what was done) to ChatGPT Plus (web) and return its review.
+You are a workflow-aware review dispatcher. Your job is to send a completed
+task's result to ChatGPT Plus (web) wrapped in enough workflow context for
+ChatGPT to act as an independent reviewer that advances the workflow, then return
+a machine-actionable verdict.
 
-Steps:
+## Pre-check: avoid redundant reviews
+
+Before sending, get the saved approval state for the current repo+branch:
+
+```
+~/.config/opencode/chatgpt-bridge/bin/chatgpt-review approval get
+```
+
+Then get the current HEAD SHA:
+
+```
+git rev-parse HEAD
+```
+
+If `approval get` returns `{ "verdict": "approve", "headSha": <sha> }` and the
+current HEAD SHA equals that stored `headSha` and nothing else materially changed,
+do NOT send another review. Report:
+
+```
+ChatGPT already approved HEAD <sha>. Status: awaiting human merge.
+```
+
+If the approval verdict is `request-changes`/`reject`, or the HEAD SHA differs,
+or there is no saved approval, proceed with a fresh review.
+
+## Steps (when a review is warranted)
+
 1. Check the bridge is ready:
    `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review status`
-2. Use the **text passed to you by the calling agent** as the material to review —
-   the "Done / What changed / Verification" summary the agent just produced. Do NOT
-   generate or fetch a git diff; the caller already decided what to send.
-3. Write a tight review prompt to `/tmp/opencode/chatgpt-review-prompt.md`:
-   - One-line task summary.
-   - The result text verbatim.
-   - Focus areas (bugs, security, correctness, completeness).
-   - Request a verdict block: VERDICT / ISSUES / SUGGESTIONS.
-4. Run: `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review ask --file=/tmp/opencode/chatgpt-review-prompt.md`
-5. Return ChatGPT's reply verbatim, then a 2-3 line summary of the most important findings.
+   (if `loggedIn` is `false`, report that the user must run login once; do not review.)
 
-If `status` shows `loggedIn: false`, do not run the review; report that the user must run `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review login` once in a terminal.
-If the bridge throws an error, report the exact error and do not claim the review succeeded.
+2. Collect lightweight GitHub context (only what is cheap and available):
+   - `git rev-parse --abbrev-ref HEAD` (branch)
+   - `git rev-parse HEAD` (head SHA)
+   - `git status --short` (working-tree state, one glance)
+   - If a PR number is known/mentioned, `gh pr view <n> --json number,state,headRefName,baseRefName,statusCheckRollup` (best-effort; ignore failures).
 
+3. Determine `MODE` from context (pick the closest, do not invent new ones):
+   - `implementation-review` — a coding task just completed
+   - `bugfix-review` — a bug fix
+   - `followup-review` — re-review after previously requested changes
+   - `pre-pr-review` — reviewing work about to become a PR
+   - `pr-review` — reviewing an existing PR
+   - `planning-review` — reviewing a plan/spec
+   - `continuation-review` — a handoff/continuation of longer work
+
+4. Build the review prompt to `/tmp/opencode/chatgpt-review-prompt.md` using this
+   structured envelope (keep RESULT_TEXT = the caller's summary verbatim, no diff):
+
+   ```text
+   MODE: <mode>
+   GOAL: <overall task/issue goal, 1-2 sentences>
+   CURRENT_STAGE: <IMPLEMENTING | IMPLEMENTATION_COMPLETE | CHATGPT_REVIEW | OPENCODE_FIXES | APPROVED>
+   TASK_SUMMARY: <one line>
+   RESULT_TEXT: <the implementing agent's final Done / What changed / Verification text verbatim>
+   REQUESTED_DECISION: <what ChatGPT should determine>
+   NEXT_ACTION_IF_APPROVED: <what happens next>
+   NEXT_ACTION_IF_CHANGES_REQUESTED: <what OpenCode does next>
+   REPO: <repo name>
+   BRANCH: <branch>
+   HEAD_SHA: <sha>
+   PR: <pr number or none>
+   BASE: <base branch if known>
+   AUTHORITY:
+   - ChatGPT: independent review; inspect GitHub/repo state when available; approve/request-changes; recommend next workflow action.
+   - OpenCode: implementation, fixes, tests, commits, pushes, issue/PR updates.
+   - Human maintainer: merge/deploy authority only.
+
+   Please inspect GitHub state where useful (PR state, HEAD SHA, CI status, diff)
+   to verify the summary's claims. Do not require the raw diff to be pasted here.
+
+   Respond in this exact machine-actionable format:
+
+   VERDICT: approve | approve-with-changes | request-changes | reject
+   NEXT_ACTION: <single explicit next workflow action>
+   ISSUES: <numbered actionable issues, or "none">
+   SUGGESTIONS: <optional>
+   ```
+
+   Verdict semantics: approve = no blocking work remains; approve-with-changes =
+   only non-blocking cleanup (state whether another review is needed);
+   request-changes = OpenCode must fix then re-review; reject = replan required.
+
+5. Send it:
+   `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review ask --file=/tmp/opencode/chatgpt-review-prompt.md`
+
+6. Parse the verdict from ChatGPT's reply, then record it:
+   ```
+   ~/.config/opencode/chatgpt-bridge/bin/chatgpt-review approval set <verdict> <headSha> <pr-or-none>
+   ```
+   Only record `approve` / `approve-with-changes` / `request-changes` / `reject`
+   (normalize the value). Do not record if you could not parse a verdict.
+
+7. Return ChatGPT's reply verbatim, then a 2-3 line summary: verdict, next action,
+   and whether the workflow should advance or loop.
+
+## Rules
+
+- Never treat "approve" as permission to merge — report it as "awaiting human merge".
+- If the bridge throws an error, surface the exact error; do not claim a review succeeded.
+- Do not self-declare approval; ChatGPT decides.
+- Keep the envelope small — no full conversation dumps, no raw diffs.

--- a/.opencode/commands/autoreview.md
+++ b/.opencode/commands/autoreview.md
@@ -10,7 +10,8 @@ Run the auto-review toggle:
 Where `$ARGUMENTS` is `on`, `off`, or `status`.
 
 Report the result to the user. If toggled on, tell the user auto-review is now
-active: after each implementation task with code changes, you will automatically
-invoke `@chatgpt-review` to send the task's final result summary (Done / What
-changed / Verification) to ChatGPT Plus and report the verdict. If toggled off,
-tell the user reviews are now manual-only (`@chatgpt-review`).
+active: after each implementation task with code changes, you will write your
+normal result summary and invoke `@chatgpt-review`, which wraps it in workflow
+context and returns a machine-actionable verdict. On `approve` the workflow
+advances and stops (no redundant re-review); on `request-changes` you fix and
+re-review. If toggled off, tell the user reviews are manual-only (`@chatgpt-review`).

--- a/.opencode/skills/chatgpt-review/SKILL.md
+++ b/.opencode/skills/chatgpt-review/SKILL.md
@@ -1,97 +1,118 @@
 ---
 name: chatgpt-review
-description: Use when a completed task's final result text should be reviewed by ChatGPT Plus (web) without copy-pasting. Also triggered by "review with chatgpt", "gửi cho chatgpt review", "review ngoài", or when a task finishes and auto-review is enabled. Sends the task's result summary to ChatGPT Plus via a browser bridge and returns the review.
+description: Use when a completed task's final result text should be independently reviewed by ChatGPT Plus (web) without copy-pasting. The bridge wraps the result in structured workflow context (mode, goal, stage, requested decision, next-action semantics, authority) and returns a machine-actionable verdict that advances the workflow. Also triggered by "review with chatgpt", "gửi cho chatgpt review", "review ngoài", or auto-review after a task completes.
 ---
 
 # chatgpt-review
 
-Send a completed task's **final result text** (the "Done / What changed /
-Verification" summary) to ChatGPT Plus (web) through a Playwright bridge and read
-the review back into the session. The user does **not** need to copy-paste.
+Send a completed task's **final result summary** to ChatGPT Plus (web) through a
+Playwright bridge, wrapped in a small structured workflow envelope, and read back
+a machine-actionable verdict. The user does **not** copy-paste anything.
 
 ## What gets reviewed
 
-Send the agent's own result text — e.g. a summary like:
+The implementing agent's own result text — e.g. "Done / What changed / Verification".
+**Never** send raw git diffs through the bridge. ChatGPT is instructed to inspect
+GitHub state itself when it needs deeper verification.
 
+## Handoff envelope
+
+The review prompt sent to ChatGPT is a small structured envelope, not a conversation dump:
+
+```text
+MODE: implementation-review | bugfix-review | followup-review | pre-pr-review | pr-review | planning-review | continuation-review
+GOAL: <overall goal>
+CURRENT_STAGE: IMPLEMENTING | IMPLEMENTATION_COMPLETE | CHATGPT_REVIEW | OPENCODE_FIXES | APPROVED
+TASK_SUMMARY: <one line>
+RESULT_TEXT: <verbatim summary>
+REQUESTED_DECISION: <what ChatGPT decides>
+NEXT_ACTION_IF_APPROVED: ...
+NEXT_ACTION_IF_CHANGES_REQUESTED: ...
+REPO / BRANCH / HEAD_SHA / PR / BASE
+AUTHORITY: ChatGPT=review; OpenCode=implement; Human=merge/deploy
 ```
-Done. Pushed to PR #38 (still Draft, not merged), CI green.
 
-What changed
-- ...
+## Review-response contract (ChatGPT must return)
 
-Verification
-- ...
+```text
+VERDICT: approve | approve-with-changes | request-changes | reject
+NEXT_ACTION: <single explicit next action>
+ISSUES: <numbered issues, or "none">
+SUGGESTIONS: <optional>
 ```
 
-Do **not** fetch or attach a raw `git diff` — review the completed work's
-summary that the agent just produced.
+Semantics:
+- **approve** — no blocking work remains.
+- **approve-with-changes** — only non-blocking cleanup; state whether re-review is needed.
+- **request-changes** — OpenCode must fix, then re-review.
+- **reject** — replan before continuing.
+
+## State machine
+
+```text
+IMPLEMENTING → IMPLEMENTATION_COMPLETE → CHATGPT_REVIEW
+   → REQUEST_CHANGES → OPENCODE_FIXES → RE-REVIEW (loop)
+   → APPROVED → HUMAN_ACTION_REQUIRED (awaiting human merge)
+```
+
+## Eliminating redundant review loops
+
+Approval state is stored per repo+branch in `chats.json` (via
+`chatgpt-review approval set|get|clear`). Before reviewing, check:
+
+- If `approval.get` returns `approve` and current HEAD SHA equals the stored
+  `headSha` and nothing materially changed → **do not re-review**; report
+  "awaiting human merge".
+- If HEAD SHA changed, base rebased, CI failed, or fixes were applied → re-review.
+
+"approve" does **not** mean OpenCode may merge. It means "ready for human merge".
 
 ## Requirements
 
-- First-time setup must be done once: run `chatgpt-review login` in a terminal (opens a visible browser to sign in to ChatGPT). Verify with `chatgpt-review status` (must show `"loggedIn": true`).
-- The bridge script is at `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review`.
+- One-time setup: `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review login`
+  (opens a browser to sign in), verify with `status` → `"loggedIn": true`.
+- Bridge lives at `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review`.
 
-## Workflow
+## Concurrency
 
-1. Check the bridge is ready:
-   ```
-   ~/.config/opencode/chatgpt-bridge/bin/chatgpt-review status
-   ```
-   If `loggedIn` is `false`, tell the user to run `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review login` in a terminal first.
+The bridge uses a **single Chrome profile** and serializes every run through a
+lock file (`~/.config/opencode/chatgpt-bridge/.lock`). If two repos trigger a
+review simultaneously, one waits for the other; it does not crash. If a run is
+stuck, a stale lock (dead PID) is auto-cleared.
 
-2. Build the review prompt. Write it to a temp file, e.g. `/tmp/opencode/chatgpt-review-prompt.md`. A good review prompt includes:
-   - What the task was (1-2 sentences).
-   - The **result text verbatim** (the summary the agent produced).
-   - What to focus on (bugs, security, correctness, completeness, missing steps).
-   - Ask for a concise verdict in a fixed format, e.g.:
-     ```
-     VERDICT: approve / approve-with-changes / reject
-     ISSUES: bullet list
-     SUGGESTIONS: prioritized short list
-     ```
-3. Send it:
-   ```
-   ~/.config/opencode/chatgpt-bridge/bin/chatgpt-review ask --file=/tmp/opencode/chatgpt-review-prompt.md
-   ```
-   The script prints ChatGPT's reply to stdout.
+## Subcommands
 
-4. Read the reply. If it failed (e.g. not signed in, UI changed), tell the user what to fix.
+```text
+chatgpt-review login|ask|status|chats|reset|project <...>
+chatgpt-review approval get|set <verdict> <sha> [pr]|clear
+```
+
+- `ask` — send a prompt (reads stdin or `--file=`); reuse per repo+branch.
+- `approval` — read/write the workflow approval state used to avoid loops.
+- `project` — manage ChatGPT Projects (list/create/attach/detach/resolve).
 
 ## Conversation reuse (per repo + branch)
 
-The bridge keeps **one ChatGPT thread per repo+branch** (`chats.json`) so reviews
-for the same branch build on prior context instead of spawning new chats.
+One ChatGPT thread per repo+branch (`chats.json`); a new thread is started when
+stale (`max_chars` / `max_turns` / `max_age_hours` in `bridge-config.json`) or a
+saved id fails to open. Force a fresh thread with `ask --new` or `/chatgpt-new`.
+Inspect with `chats`; drop mapping with `reset`.
 
-- On `ask`, the bridge reuses the saved conversation unless it is stale, or it
-  opens a fresh one and records the new chat id.
-- Fallback: if a saved conversation id fails to open, it starts a new one
-  automatically (no user action needed).
-- New conversation triggers (see `~/.config/opencode/chatgpt-bridge/bridge-config.json`):
-  - `max_chars` (default 400000) — accumulated prompt+reply characters
-  - `max_turns` (default 40) — number of exchanges
-  - `max_age_hours` (default 48) — since last use
-- Force a fresh thread: `.../chatgpt-review ask --new` or `/chatgpt-new` command.
-- Inspect state: `.../chatgpt-review chats` and `.../chatgpt-review reset`.
+## ChatGPT Projects
 
-## ChatGPT Projects support
+Optionally organize reviews into one ChatGPT Project per repo:
+- Enable per repo via `project_mode` or globally `"mode": "project"`, or per-call `ask --project`.
+- The bridge reuses/creates the project and keeps the thread inside it.
+- Manage with `project list|create|attach|detach|resolve` or `/chatgpt-project`.
 
-Instead of loose chats, reviews can live inside a **ChatGPT Project** (one per
-repo) so they are organized, share project instructions, and keep project memory.
+## Failure handling
 
-- Enabled per repo via `project_mode: { "<repoName>": true }` in `bridge-config.json`,
-  or globally with `"mode": "project"`, or per-call with `ask --project`.
-- On `ask`, the bridge auto-uses the repo's project; if none exists it **creates
-  one named after the repo** (or uses `--project=<name>` to target an existing one).
-- Chat reuse still applies inside the project (same repo+branch thread, same
-  chars/turns/age thresholds).
-- Manage projects: `.../chatgpt-review project list|create|attach|detach|resolve`,
-  or the `/chatgpt-project` command.
-- `ask --no-project` forces plain chat for that call.
-- Fallback: if a saved project or chat fails to open, the bridge falls back to a
-  plain conversation automatically.
+- `loggedIn: false` → report, do not review.
+- Bridge error → surface the exact error; never claim a false success or approval.
+- Cloudflare may block headless; `ask` runs headful by default (needs a display; use `xvfb-run` on headless servers).
 
 ## Notes
 
-- Only send the result **summary text**, not raw diffs.
-- ChatGPT's web UI changes occasionally; if selectors break, the script throws a descriptive error. Do not silently claim a review succeeded when the bridge errored.
-- If the user wants a quick check, keep the prompt tight: send the result plus 3 focus questions, not a wall of context.
+- Only send result summary text, never raw diffs.
+- Keep the envelope tight (small, structured), not a wall of context.
+- ChatGPT UI changes occasionally; if selectors break, the bridge throws a descriptive error.


### PR DESCRIPTION
Follow-up to #39: refine the ChatGPT review bridge to a workflow-aware envelope.

## What changed
- Wrap review submissions in a structured envelope (MODE / GOAL / CURRENT_STAGE / REQUESTED_DECISION / next-action semantics / AUTHORITY).
- Return a machine-actionable verdict (VERDICT / NEXT_ACTION / ISSUES / SUGGESTIONS).
- Add redundant-review suppression via stored approval state per repo+branch.
- Update `.opencode/agents/chatgpt-review.md`, `.opencode/commands/autoreview.md`, `.opencode/skills/chatgpt-review/SKILL.md`.

## Verification
- lint / typecheck not applicable (docs-only OpenCode config change).
- Verified working tree contains only the 3 intended files.
- ChatGPT review (via bridge) returned: approve.

## Known limitations
- None.

## Docs affected
- `.opencode/agents/chatgpt-review.md`, `.opencode/commands/autoreview.md`, `.opencode/skills/chatgpt-review/SKILL.md`