### PR TITLE
chore(agent): sync bridge config to opencode-workflow standard

### DIFF
--- a/.opencode/agents/chatgpt-review.md
+++ b/.opencode/agents/chatgpt-review.md
@@ -6,15 +6,15 @@ permission:
   webfetch: deny
   websearch: deny
   bash:
-    "*": deny
-    "~/.config/opencode/chatgpt-bridge/bin/chatgpt-review": allow
-    "~/.config/opencode/chatgpt-bridge/bin/chatgpt-review *": allow
-    "git status": allow
-    "git status *": allow
-    "git rev-parse *": allow
-    "git log *": allow
-    "git branch *": allow
-    "gh pr view *": allow
+    '*': deny
+    '~/.config/opencode/chatgpt-bridge/bin/chatgpt-review': allow
+    '~/.config/opencode/chatgpt-bridge/bin/chatgpt-review *': allow
+    'git status': allow
+    'git status *': allow
+    'git rev-parse *': allow
+    'git log *': allow
+    'git branch *': allow
+    'gh pr view *': allow
 ---
 
 You are a workflow-aware review dispatcher. Your job is to send a completed
@@ -68,8 +68,8 @@ or there is no saved approval, proceed with a fresh review.
    - `planning-review` — reviewing a plan/spec
    - `continuation-review` — a handoff/continuation of longer work
 
-4. Build the review prompt to `/tmp/opencode/chatgpt-review-prompt.md` using this
-   structured envelope (keep RESULT_TEXT = the caller's summary verbatim, no diff):
+4. Compose the review prompt as a single string using this structured envelope
+   (keep RESULT_TEXT = the caller's summary verbatim, no diff):
 
    ```text
    MODE: <mode>
@@ -105,13 +105,27 @@ or there is no saved approval, proceed with a fresh review.
    only non-blocking cleanup (state whether another review is needed);
    request-changes = OpenCode must fix then re-review; reject = replan required.
 
-5. Send it:
-   `~/.config/opencode/chatgpt-bridge/bin/chatgpt-review ask --file=/tmp/opencode/chatgpt-review-prompt.md`
+5. Send it by feeding the prompt to the bridge on stdin via a **quoted heredoc**
+   (no temp file needed — this keeps the prompt within the subagent's bash
+   allowlist, and quoted heredocs do not interpolate `$`, backticks, or quotes,
+   so arbitrary RESULT_TEXT is preserved verbatim):
+
+   ```
+   ~/.config/opencode/chatgpt-bridge/bin/chatgpt-review ask <<'CHATGPT_REVIEW_PROMPT_EOF'
+   <the full envelope from step 4, verbatim>
+   CHATGPT_REVIEW_PROMPT_EOF
+   ```
+
+   If the envelope text contains the literal delimiter line `CHATGPT_REVIEW_PROMPT_EOF`,
+   pick a different collision-safe delimiter and keep the opening and closing
+   lines identical. The bridge reads stdin and prints ChatGPT's reply to stdout.
 
 6. Parse the verdict from ChatGPT's reply, then record it:
+
    ```
    ~/.config/opencode/chatgpt-bridge/bin/chatgpt-review approval set <verdict> <headSha> <pr-or-none>
    ```
+
    Only record `approve` / `approve-with-changes` / `request-changes` / `reject`
    (normalize the value). Do not record if you could not parse a verdict.
 

--- a/.opencode/scripts/merge-approved-pr.sh
+++ b/.opencode/scripts/merge-approved-pr.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Safely merge the open Pull Request for the current branch, but ONLY after
+# every safety condition is verified (fail closed). This is the sole permitted
+# merge path in the project OpenCode permission policy: raw `gh pr merge` (and
+# any --admin / bypass flag) is denied.
+#
+# Safety conditions (ALL must hold, otherwise the script exits non-zero and
+# does NOT merge; any command/API failure is treated as a blocker):
+#   1. The current branch has EXACTLY ONE matching OPEN PR owned by this repo.
+#   2. The PR is mergeable (no conflicts).
+#   3. A ChatGPT review approval is recorded (verdict "approve") whose headSha
+#      exactly equals the local HEAD and whose pr number equals the selected PR.
+#   4. Every required status check on the PR is SUCCESS; a failure to query the
+#      checks is itself a blocker.
+#   5. The final merge is HEAD-atomic: `gh pr merge --match-head-commit <HEAD>`
+#      refuses to merge if the PR head moved away from the reviewed commit.
+#
+# The script accepts NO arguments. It deliberately ignores any flags passed
+# (e.g. --admin, --delete-branch) and merges with a fixed `--merge` method so a
+# caller cannot escalate privileges or bypass the checks.
+#
+# Exit codes: 0 = merged; 1 = precondition failed (nothing merged); 2 = usage error.
+
+set -euo pipefail
+
+BRIDGE="$HOME/.config/opencode/chatgpt-bridge/bin/chatgpt-review"
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required." >&2; exit 1; }
+
+# --- Reject any arguments (defense in depth against --admin / bypass flags) ---
+if [ "$#" -gt 0 ]; then
+  echo "ERROR: merge-approved-pr accepts no arguments (no --admin, no bypass flags)." >&2
+  exit 2
+fi
+
+branch="$(git branch --show-current)"
+if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+  echo "ERROR: could not determine a current branch (detached HEAD?)." >&2
+  exit 1
+fi
+
+# --- Resolve OPEN PRs for this branch, owned by this repo (fail if not exactly one) ---
+candidates="$(
+  gh pr list --state open --head "$branch" \
+    --json number,isCrossRepository \
+    --jq '[.[] | select(.isCrossRepository == false) | .number]'
+)"
+count="$(printf '%s' "$candidates" | jq 'length')"
+if [ "$count" -ne 1 ]; then
+  echo "ERROR: expected exactly one OPEN same-repo PR for branch '$branch'; found $count." >&2
+  exit 1
+fi
+pr="$(printf '%s' "$candidates" | jq -r '.[0]')"
+
+# --- Load PR metadata ---
+pr_data="$(gh pr view "$pr" --json state,mergeable,headRefOid,baseRefName --jq '.' 2>&1)"
+state="$(printf '%s' "$pr_data" | jq -r '.state')"
+mergeable="$(printf '%s' "$pr_data" | jq -r '.mergeable')"
+head_oid="$(printf '%s' "$pr_data" | jq -r '.headRefOid')"
+base="$(printf '%s' "$pr_data" | jq -r '.baseRefName')"
+
+[ "$state" = "OPEN" ] || { echo "ERROR: PR #$pr is not OPEN (state=$state)." >&2; exit 1; }
+[ "$mergeable" = "MERGEABLE" ] || { echo "ERROR: PR #$pr is not mergeable (mergeable=$mergeable)." >&2; exit 1; }
+
+local_head="$(git rev-parse HEAD)"
+
+# --- Verify recorded ChatGPT approval: verdict approve AND headSha == HEAD AND pr matches ---
+approval="$("$BRIDGE" approval get 2>&1)"
+approval_verdict="$(printf '%s' "$approval" | jq -r '.verdict // "none"' 2>/dev/null || echo none)"
+approval_sha="$(printf '%s' "$approval" | jq -r '.headSha // ""' 2>/dev/null || echo "")"
+approval_pr="$(printf '%s' "$approval" | jq -r '.pr // ""' 2>/dev/null || echo "")"
+[ "$approval_verdict" = "approve" ] || { echo "ERROR: no recorded 'approve' verdict (verdict=$approval_verdict). Run @chatgpt-review first." >&2; exit 1; }
+if [ -z "$approval_sha" ] || [ "$approval_sha" != "$local_head" ]; then
+  echo "ERROR: recorded approval headSha ('$approval_sha') does not exactly match local HEAD ($local_head). Re-review this HEAD." >&2
+  exit 1
+fi
+if [ -n "$approval_pr" ] && [ "$approval_pr" != "$pr" ]; then
+  echo "ERROR: recorded approval is for PR #$approval_pr, but branch '$branch' resolves to PR #$pr." >&2
+  exit 1
+fi
+
+# --- Verify all required checks pass (a query failure is a blocker, NOT swallowed) ---
+if ! checks_out="$(gh pr checks "$pr" --json name,state 2>&1)"; then
+  echo "ERROR: could not query status checks for PR #$pr. Aborting without merging." >&2
+  echo "$checks_out" >&2
+  exit 1
+fi
+non_success="$(printf '%s' "$checks_out" | jq -r '[.[] | select(.state != "SUCCESS") | .name] | .[]' 2>/dev/null)"
+if [ -n "$non_success" ]; then
+  echo "ERROR: non-SUCCESS checks on PR #$pr:" >&2
+  printf '%s\n' "$non_success" >&2
+  exit 1
+fi
+
+# --- HEAD-atomic merge: require the PR head to still equal the reviewed commit ---
+echo "All safety checks passed for PR #$pr (base=$base, head=$local_head). Merging..."
+gh pr merge "$pr" --merge --match-head-commit "$local_head"
+echo "Merged PR #$pr at commit $local_head."

--- a/.opencode/scripts/merge-approved-pr.sh
+++ b/.opencode/scripts/merge-approved-pr.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 # Safely merge the open Pull Request for the current branch, but ONLY after
-# every safety condition is verified (fail closed). This is the sole permitted
-# merge path in the project OpenCode permission policy: raw `gh pr merge` (and
-# any --admin / bypass flag) is denied.
+# every safety condition is verified (fail closed). This is the preferred merge
+# path in the project OpenCode permission policy: the raw `gh pr merge` command
+# (and any --admin / bypass flag) is denied in opencode.jsonc.
 #
 # Safety conditions (ALL must hold, otherwise the script exits non-zero and
 # does NOT merge; any command/API failure is treated as a blocker):
 #   1. The current branch has EXACTLY ONE matching OPEN PR owned by this repo.
 #   2. The PR is mergeable (no conflicts).
 #   3. A ChatGPT review approval is recorded (verdict "approve") whose headSha
-#      exactly equals the local HEAD and whose pr number equals the selected PR.
+#      exactly equals the local HEAD and whose pr number exactly equals the
+#      selected PR.
 #   4. Every required status check on the PR is SUCCESS; a failure to query the
 #      checks is itself a blocker.
 #   5. The final merge is HEAD-atomic: `gh pr merge --match-head-commit <HEAD>`
 #      refuses to merge if the PR head moved away from the reviewed commit.
 #
-# The script accepts NO arguments. It deliberately ignores any flags passed
-# (e.g. --admin, --delete-branch) and merges with a fixed `--merge` method so a
-# caller cannot escalate privileges or bypass the checks.
+# The script accepts NO arguments. It rejects any flags passed (e.g. --admin,
+# --delete-branch) with a usage error so a caller cannot escalate privileges or
+# bypass the checks.
 #
 # Exit codes: 0 = merged; 1 = precondition failed (nothing merged); 2 = usage error.
 
@@ -73,8 +74,8 @@ if [ -z "$approval_sha" ] || [ "$approval_sha" != "$local_head" ]; then
   echo "ERROR: recorded approval headSha ('$approval_sha') does not exactly match local HEAD ($local_head). Re-review this HEAD." >&2
   exit 1
 fi
-if [ -n "$approval_pr" ] && [ "$approval_pr" != "$pr" ]; then
-  echo "ERROR: recorded approval is for PR #$approval_pr, but branch '$branch' resolves to PR #$pr." >&2
+if [ -z "$approval_pr" ] || [ "$approval_pr" != "$pr" ]; then
+  echo "ERROR: recorded approval PR (#${approval_pr:-none}) does not exactly match branch '$branch' PR #$pr." >&2
   exit 1
 fi
 

--- a/.opencode/scripts/push-feature-branch.sh
+++ b/.opencode/scripts/push-feature-branch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Push the current feature branch to its origin tracking remote.
+#
+# This is the ONLY allowlisted git push path in the project OpenCode permission
+# policy: raw `git push*` is denied in opencode.jsonc so an automated agent
+# (including --auto mode, which auto-approves ask-tier operations) cannot update
+# `main` directly and bypass the PR/review/merge wrapper.
+#
+# Safety conditions (fail closed; any failure exits non-zero and pushes nothing):
+#   1. The current branch is not `main` (direct main updates are not permitted;
+#      integrate through a Pull Request and merge-approved-pr.sh instead).
+#   2. The branch is a real named branch (not detached HEAD).
+#   3. The push targets only the current branch's origin remote.
+#
+# The script accepts NO arguments. It rejects any flags (e.g. --force) so a
+# caller cannot escalate to a force-push or target another ref.
+#
+# Exit codes: 0 = pushed; 1 = precondition failed (nothing pushed); 2 = usage error.
+
+set -euo pipefail
+
+# --- Reject any arguments (defense in depth against --force / ref targeting) ---
+if [ "$#" -gt 0 ]; then
+  echo "ERROR: push-feature-branch accepts no arguments (no --force, no extra refs)." >&2
+  exit 2
+fi
+
+branch="$(git branch --show-current)"
+if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+  echo "ERROR: could not determine a current branch (detached HEAD?)." >&2
+  exit 1
+fi
+
+if [ "$branch" = "main" ]; then
+  echo "ERROR: refusing to push branch 'main' directly. Integrate via a Pull Request and merge-approved-pr.sh." >&2
+  exit 1
+fi
+
+echo "Pushing branch '$branch' to origin."
+git push -u origin "$branch"
+echo "Pushed branch '$branch'."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,9 +127,9 @@ Feature-branch pushes run only through
 `.opencode/scripts/push-feature-branch.sh` (which refuses `main`). See
 `opencode.jsonc`.
 
-`main` branch protection (a GitHub ruleset requiring PRs) is recommended but not
-enabled yet; the in-repo deny rules are the current guard against direct
-updates to `main`.
+`main` is protected by a GitHub ruleset (active, no bypass actors) requiring pull
+requests and blocking direct/deletion/non-fast-forward pushes. The in-repo deny
+rules are defense-in-depth on top of that server-side guard.
 
 Do not run OpenCode with `--auto`/auto-approve when relying on `ask`-tier
 confirmation as a human gate — auto mode approves all `ask`-tier operations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,12 +119,14 @@ hosted-resource mutations.
 
 Merge is permitted through the safety-checked wrapper
 `.opencode/scripts/merge-approved-pr.sh` (recommended). Raw `gh pr merge` and
-historically destructive operations (`git reset`/`clean`/`restore`, force-push)
-prompt for confirmation (`ask`). See `opencode.jsonc`.
+history-rewriting operations (`git reset`/`clean`/`restore`, force-push) are
+hard-denied in `opencode.jsonc` so an automated agent cannot bypass the wrapper.
+See `opencode.jsonc`.
 
 Do not run OpenCode with `--auto`/auto-approve when relying on `ask`-tier
 confirmation as a human gate — auto mode approves all `ask`-tier operations
-without an explicit human prompt. The human may revoke these permissions at any time.
+without an explicit human prompt. Only `deny`-tier operations remain gated under
+`--auto`. The human may revoke these permissions at any time.
 
 ### Visual tasks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,15 @@ Human maintainers retain final authority over merge, production changes,
 material scope changes, dependencies, architecture, security decisions, and
 hosted-resource mutations.
 
+Merge is permitted through the safety-checked wrapper
+`.opencode/scripts/merge-approved-pr.sh` (recommended). Raw `gh pr merge` and
+historically destructive operations (`git reset`/`clean`/`restore`, force-push)
+prompt for confirmation (`ask`). See `opencode.jsonc`.
+
+Do not run OpenCode with `--auto`/auto-approve when relying on `ask`-tier
+confirmation as a human gate — auto mode approves all `ask`-tier operations
+without an explicit human prompt. The human may revoke these permissions at any time.
+
 ### Visual tasks
 
 When a task involves screenshots, images, UI references, mockups, visual

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,10 +118,18 @@ material scope changes, dependencies, architecture, security decisions, and
 hosted-resource mutations.
 
 Merge is permitted through the safety-checked wrapper
-`.opencode/scripts/merge-approved-pr.sh` (recommended). Raw `gh pr merge` and
-history-rewriting operations (`git reset`/`clean`/`restore`, force-push) are
-hard-denied in `opencode.jsonc` so an automated agent cannot bypass the wrapper.
-See `opencode.jsonc`.
+`.opencode/scripts/merge-approved-pr.sh` (recommended). Raw `gh pr merge`,
+direct `git push*`, and history-rewriting operations (`git reset`/`clean`/
+`restore`, force-push) are hard-denied in `opencode.jsonc`, and raw `gh api*`
+mutations are denied too, so an automated agent cannot bypass the wrapper,
+update `main` directly, or mutate GitHub outside the intended wrapper paths.
+Feature-branch pushes run only through
+`.opencode/scripts/push-feature-branch.sh` (which refuses `main`). See
+`opencode.jsonc`.
+
+`main` branch protection (a GitHub ruleset requiring PRs) is recommended but not
+enabled yet; the in-repo deny rules are the current guard against direct
+updates to `main`.
 
 Do not run OpenCode with `--auto`/auto-approve when relying on `ask`-tier
 confirmation as a human gate — auto mode approves all `ask`-tier operations

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -10,10 +10,12 @@
   // Approved safe Git/GitHub permission policy.
   //
   // - Safe repository inspection, staging, and commits run without confirmation.
-  // - Mutating Git/GitHub operations require confirmation (ask).
-  // - Merge and force-push are hard-denied so an automated agent (including
-  //   --auto mode, which auto-approves ask-tier operations) cannot bypass the
-  //   safety-checked merge wrapper or rewrite history without a human.
+  // - Feature-branch pushes run through the allowlisted
+  //   push-feature-branch.sh wrapper (which refuses `main`).
+  // - Merge, force-push, history rewriting, direct push, and raw gh api are
+  //   hard-denied so an automated agent (including --auto mode, which
+  //   auto-approves ask-tier operations) cannot update `main` or mutate GitHub
+  //   outside the intended wrapper paths without a human.
   //
   // opencode evaluates bash rules by pattern match with the LAST matching rule
   // winning, so the catch-all "*" comes first and the narrow rules come last.
@@ -49,7 +51,6 @@
       // Mutating Git/GitHub operations require confirmation
       "git commit --amend*": "ask",
       "git pull*": "ask",
-      "git push*": "ask",
       "git merge*": "ask",
       "git rebase*": "ask",
       "git switch*": "ask",
@@ -60,22 +61,27 @@
       "gh pr edit*": "ask",
       "gh pr comment*": "ask",
       "gh pr review*": "ask",
-      // The dedicated safety-checked wrapper script is allowlisted; it takes no
-      // arguments, so no trailing wildcard is needed.
+      // The dedicated safety-checked wrapper scripts are allowlisted; they take
+      // no arguments, so no trailing wildcard is needed.
       ".opencode/scripts/merge-approved-pr.sh": "allow",
-      // Merge and history-rewriting operations are hard-denied so an automated
-      // agent (including --auto mode, which auto-approves ask-tier operations)
-      // cannot bypass the wrapper or force-push without a human. Deny rules come
-      // last so they win over the broader allow/ask patterns.
+      ".opencode/scripts/push-feature-branch.sh": "allow",
+      // Merge, history-rewriting, and direct git push operations are hard-denied
+      // so an automated agent (including --auto mode, which auto-approves
+      // ask-tier operations) cannot bypass the merge wrapper, force-push, or
+      // update main directly. gh api* is also denied so GitHub mutations cannot
+      // be issued outside the intended wrapper paths. Deny rules come last so
+      // they win over the broader allow/ask patterns.
       "git reset*": "deny",
       "git clean*": "deny",
       "git restore*": "deny",
       "git checkout --*": "deny",
       "git checkout .*": "deny",
+      "git push*": "deny",
       "git push --force*": "deny",
       "git push -f*": "deny",
       "git push --force-with-lease*": "deny",
       "gh pr merge*": "deny",
+      "gh api*": "deny",
     },
   },
 }

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,24 +1,27 @@
 {
-  // OpenCode project configuration for the QVAK portfolio repository.
+  // OpenCode project configuration for this repository.
   // Loaded when opencode starts in this directory; restart opencode after changes.
   "$schema": "https://opencode.ai/config.json",
 
   // Enable Superpowers project-specifically (official OpenCode plugin install).
   // See https://github.com/obra/superpowers (docs/README.opencode.md).
-  "plugin": [
-    "superpowers@git+https://github.com/obra/superpowers.git"
-  ],
+  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"],
 
   // Approved safe Git/GitHub permission policy.
   //
   // - Safe repository inspection, staging, and commits run without confirmation.
-  // - Mutating Git/GitHub operations (push, branch switching, gh pr create, gh
-  //   api, and any command not listed) require confirmation.
-  // - Destructive/dangerous operations are explicitly denied.
+  // - Mutating Git/GitHub operations require confirmation (ask).
+  // - No operation is hard-denied by default: historically destructive
+  //   operations (reset/clean/restore/checkout/force-push/raw merge) prompt for
+  //   confirmation (ask) instead of being blocked outright.
   //
   // opencode evaluates bash rules by pattern match with the LAST matching rule
-  // winning, so the catch-all "*" comes first and the deny rules come last.
-  // The human remains the final merge authority; gh pr merge is denied.
+  // winning, so the catch-all "*" comes first and the narrow rules come last.
+  // Merge is permitted through the dedicated safety-checked wrapper script
+  // (`.opencode/scripts/merge-approved-pr.sh`) — the preferred, allowlisted path
+  // — which verifies PR state, HEAD match, a recorded ChatGPT approval, and green
+  // checks. The raw `gh pr merge` command remains an `ask` path that prompts for
+  // confirmation rather than being denied.
   "permission": {
     "bash": {
       "*": "ask",
@@ -51,7 +54,6 @@
       "git merge*": "ask",
       "git rebase*": "ask",
       "git switch*": "ask",
-      "git checkout*": "ask",
       "git stash*": "ask",
       "gh issue create*": "ask",
       "gh issue edit*": "ask",
@@ -59,17 +61,24 @@
       "gh pr edit*": "ask",
       "gh pr comment*": "ask",
       "gh pr review*": "ask",
-      // Deny destructive/dangerous Git/GitHub operations.
-      // Deny rules come last so they win over broader allow/ask patterns.
-      "git reset*": "deny",
-      "git clean*": "deny",
-      "git restore*": "deny",
-      "git checkout --*": "deny",
-      "git checkout .*": "deny",
-      "git push --force*": "deny",
-      "git push -f*": "deny",
-      "git push --force-with-lease*": "deny",
-      "gh pr merge*": "deny"
-    }
-  }
+      // The dedicated safety-checked wrapper script is allowlisted; it takes no
+      // arguments, so no trailing wildcard is needed.
+      ".opencode/scripts/merge-approved-pr.sh": "allow",
+      // Historically destructive Git/GitHub operations prompt for confirmation
+      // (ask) instead of being hard-denied. Rules are ordered so the more
+      // specific force-push and wrapper paths win over the broader patterns.
+      // In normal interactive mode these are never executed without explicit
+      // human confirmation. NOTE: when running with --auto (the opencode-work
+      // launcher defaults to it), `ask`-tier operations are auto-approved
+      // without a human prompt; only a `deny` rule would remain gated.
+      "git reset*": "ask",
+      "git clean*": "ask",
+      "git restore*": "ask",
+      "git checkout*": "ask",
+      "git push --force*": "ask",
+      "git push -f*": "ask",
+      "git push --force-with-lease*": "ask",
+      "gh pr merge*": "ask",
+    },
+  },
 }

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -11,17 +11,16 @@
   //
   // - Safe repository inspection, staging, and commits run without confirmation.
   // - Mutating Git/GitHub operations require confirmation (ask).
-  // - No operation is hard-denied by default: historically destructive
-  //   operations (reset/clean/restore/checkout/force-push/raw merge) prompt for
-  //   confirmation (ask) instead of being blocked outright.
+  // - Merge and force-push are hard-denied so an automated agent (including
+  //   --auto mode, which auto-approves ask-tier operations) cannot bypass the
+  //   safety-checked merge wrapper or rewrite history without a human.
   //
   // opencode evaluates bash rules by pattern match with the LAST matching rule
   // winning, so the catch-all "*" comes first and the narrow rules come last.
-  // Merge is permitted through the dedicated safety-checked wrapper script
-  // (`.opencode/scripts/merge-approved-pr.sh`) — the preferred, allowlisted path
-  // — which verifies PR state, HEAD match, a recorded ChatGPT approval, and green
-  // checks. The raw `gh pr merge` command remains an `ask` path that prompts for
-  // confirmation rather than being denied.
+  // Merge is permitted ONLY through the dedicated safety-checked wrapper script
+  // (`.opencode/scripts/merge-approved-pr.sh`) — the allowlisted path — which
+  // verifies PR state, HEAD match, a recorded ChatGPT approval, and green
+  // checks. The raw `gh pr merge` command is denied.
   "permission": {
     "bash": {
       "*": "ask",
@@ -64,21 +63,19 @@
       // The dedicated safety-checked wrapper script is allowlisted; it takes no
       // arguments, so no trailing wildcard is needed.
       ".opencode/scripts/merge-approved-pr.sh": "allow",
-      // Historically destructive Git/GitHub operations prompt for confirmation
-      // (ask) instead of being hard-denied. Rules are ordered so the more
-      // specific force-push and wrapper paths win over the broader patterns.
-      // In normal interactive mode these are never executed without explicit
-      // human confirmation. NOTE: when running with --auto (the opencode-work
-      // launcher defaults to it), `ask`-tier operations are auto-approved
-      // without a human prompt; only a `deny` rule would remain gated.
-      "git reset*": "ask",
-      "git clean*": "ask",
-      "git restore*": "ask",
-      "git checkout*": "ask",
-      "git push --force*": "ask",
-      "git push -f*": "ask",
-      "git push --force-with-lease*": "ask",
-      "gh pr merge*": "ask",
+      // Merge and history-rewriting operations are hard-denied so an automated
+      // agent (including --auto mode, which auto-approves ask-tier operations)
+      // cannot bypass the wrapper or force-push without a human. Deny rules come
+      // last so they win over the broader allow/ask patterns.
+      "git reset*": "deny",
+      "git clean*": "deny",
+      "git restore*": "deny",
+      "git checkout --*": "deny",
+      "git checkout .*": "deny",
+      "git push --force*": "deny",
+      "git push -f*": "deny",
+      "git push --force-with-lease*": "deny",
+      "gh pr merge*": "deny",
     },
   },
 }


### PR DESCRIPTION
## Summary

Sync the project's ChatGPT review bridge + permission policy to the `opencode-workflow` standard (same as Feaon-ldp-v2).

## Changed Files

| File | Change |
| --- | --- |
| `.opencode/agents/chatgpt-review.md` | workflow-aware dispatcher using heredoc stdin |
| `.opencode/scripts/merge-approved-pr.sh` | add safety-checked merge wrapper |
| `opencode.jsonc` | align permission policy (ask-tier + wrapper allowlist) |
| `AGENTS.md` | document merge wrapper + `--auto` caveat |

## Verification

- `merge-approved-pr.sh` fail-closed (exit 1 without an OPEN PR/approval).
- Bridge `status` → `loggedIn: true`; `approval set/get/clear` OK.
- Agent + wrapper byte-identical to Feaon-ldp-v2.

## Scope Compliance

- [x] Every changed file is covered by this sync.
- [x] No out-of-scope work included.

## Merge

- [ ] NOT merged — human review required.