### PR TITLE
feat: build multi-column footer and newsletter shell (#13)

### DIFF
--- a/docs/00-product-brief.md
+++ b/docs/00-product-brief.md
@@ -133,6 +133,8 @@ Inspired by the supplied reference:
 
 Newsletter can be visually present in MVP even if subscription persistence is deferred; if deferred, the action must not pretend success.
 
+Privacy / Terms / Cookies links are deferred until their routes exist. Until then the footer must not render fake `#` destinations; the links are added when the routes land.
+
 ## Image usage
 
 Three personal portraits are supplied:

--- a/docs/02-ui-ux-spec.md
+++ b/docs/02-ui-ux-spec.md
@@ -228,6 +228,8 @@ Bottom row:
 
 Mobile stacks logically; newsletter remains usable without excessive width.
 
+Privacy / Terms / Cookies render only when real routes exist; do not emit fake `#` destinations while the routes are absent.
+
 ## Motion
 
 Allowed:

--- a/docs/05-implementation-plan.md
+++ b/docs/05-implementation-plan.md
@@ -120,7 +120,7 @@
 - navigation
 - contact
 - newsletter UI
-- legal links
+- legal links (deferred until routes exist; do not emit fake `#` destinations)
 - back-to-top
 
 ### Quality

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/features/contact/*.test.ts"
+    "test": "tsx --test src/features/contact/*.test.ts src/features/newsletter/*.test.ts"
   },
   "dependencies": {
     "next": "16.3.0",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
 import { SiteHeader } from "@/components/navigation/site-header";
+import { FooterSection } from "@/components/sections/footer/footer-section";
+import { getFooterContent } from "@/content/footer";
 import { portfolioProfile } from "@/content/profile";
 import { locales } from "@/features/i18n/config";
 import { getMessages } from "@/features/i18n/messages";
@@ -25,6 +27,7 @@ export default async function LocaleLayout({
 }: Readonly<LocaleLayoutProps>) {
   const locale = await getLocaleFromParams(params);
   const messages = await getMessages(locale);
+  const footerContent = getFooterContent(locale);
 
   return (
     <html data-theme="light" lang={locale} suppressHydrationWarning>
@@ -41,6 +44,11 @@ export default async function LocaleLayout({
             themeToggleMessages={messages.themeToggle}
           />
           {children}
+          <FooterSection
+            content={footerContent}
+            locale={locale}
+            messages={messages.header}
+          />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/sections/footer/back-to-top.tsx
+++ b/src/components/sections/footer/back-to-top.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+interface BackToTopProps {
+  label: string;
+}
+
+export function BackToTop({ label }: Readonly<BackToTopProps>) {
+  function scrollToTop() {
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    window.scrollTo({
+      behavior: reduceMotion ? "auto" : "smooth",
+      top: 0,
+    });
+  }
+
+  return (
+    <button
+      aria-label={label}
+      className="site-footer__back-to-top"
+      onClick={scrollToTop}
+      title={label}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="18"
+        viewBox="0 0 24 24"
+        width="18"
+      >
+        <path
+          d="M12 19V5m0 0-6 6m6-6 6 6"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/sections/footer/footer-section.tsx
+++ b/src/components/sections/footer/footer-section.tsx
@@ -1,0 +1,110 @@
+import { Container } from "@/components/layout/container";
+import type { FooterContentView } from "@/content/footer";
+import type { Locale } from "@/features/i18n/config";
+import type { HeaderMessages } from "@/features/i18n/messages/types";
+import { navigationSectionIds } from "@/features/navigation/config";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+
+import { BackToTop } from "./back-to-top";
+import { NewsletterForm } from "./newsletter-form";
+
+interface FooterSectionProps {
+  content: FooterContentView;
+  locale: Locale;
+  messages: HeaderMessages;
+}
+
+export function FooterSection({
+  content,
+  locale,
+  messages,
+}: Readonly<FooterSectionProps>) {
+  const rootPath = getLocalizedPathname("/", locale);
+  const year = new Date().getFullYear();
+
+  return (
+    <footer aria-label={content.aria.footerLabel} className="site-footer">
+      <Container>
+        <div className="site-footer__grid">
+          <div className="site-footer__brand">
+            <h2 className="site-footer__brand-name">{content.brand.name}</h2>
+            <p className="site-footer__brand-description">
+              {content.brand.description}
+            </p>
+            <ul className="site-footer__socials">
+              {content.details.map((detail) => (
+                <li key={detail.id}>
+                  <a
+                    className="site-footer__social"
+                    href={detail.href}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <span className="site-footer__social-label">
+                      {detail.label}
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <nav aria-label={content.navigationLabel} className="site-footer__column">
+            <h3 className="site-footer__heading">
+              {content.navigationLabel}
+            </h3>
+            <ul className="site-footer__links">
+              {navigationSectionIds.map((sectionId) => (
+                <li key={sectionId}>
+                  <a
+                    className="site-footer__link"
+                    href={
+                      sectionId === "home"
+                        ? rootPath
+                        : `${rootPath}#${sectionId}`
+                    }
+                  >
+                    {messages.sections[sectionId]}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          <div className="site-footer__column">
+            <h3 className="site-footer__heading">{content.contactLabel}</h3>
+            <ul className="site-footer__links">
+              {content.details.map((detail) => (
+                <li key={detail.id}>
+                  <a
+                    className="site-footer__link"
+                    href={detail.href}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <span className="site-footer__link-label">
+                      {detail.label}:
+                    </span>{" "}
+                    {detail.value}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="site-footer__column">
+            <h3 className="site-footer__heading">{content.newsletter.label}</h3>
+            <NewsletterForm content={content} />
+          </div>
+        </div>
+
+        <div className="site-footer__bottom">
+          <p className="site-footer__copyright">
+            © {year} {content.brand.name}. {content.bottom.rights}
+          </p>
+          <BackToTop label={content.bottom.backToTop} />
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/src/components/sections/footer/newsletter-form.tsx
+++ b/src/components/sections/footer/newsletter-form.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+
+import type { FooterContentView } from "@/content/footer";
+import {
+  validateNewsletterSignup,
+  type NewsletterFieldErrors,
+} from "@/features/newsletter/validation";
+
+interface NewsletterFormProps {
+  content: FooterContentView;
+}
+
+export function NewsletterForm({ content }: Readonly<NewsletterFormProps>) {
+  const [email, setEmail] = useState("");
+  const [fieldError, setFieldError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const newsletter = content.newsletter;
+
+  function handleChange(value: string) {
+    setEmail(value);
+    setSubmitted(false);
+    if (fieldError) {
+      setFieldError(null);
+    }
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const errors: NewsletterFieldErrors = validateNewsletterSignup({ email });
+    const code = errors.email ?? null;
+
+    setSubmitted(false);
+    setFieldError(code ? newsletter.errors[code] : null);
+
+    if (!code) {
+      setSubmitted(true);
+    }
+  }
+
+  return (
+    <form
+      aria-label={newsletter.aria.formLabel}
+      className="newsletter-form"
+      noValidate
+      onSubmit={handleSubmit}
+    >
+      <p className="newsletter-form__description">{newsletter.description}</p>
+      <p className="newsletter-form__helper">{newsletter.helper}</p>
+
+      <div className="newsletter-form__field">
+        <label htmlFor="newsletter-email">{newsletter.aria.emailLabel}</label>
+        <input
+          aria-describedby={fieldError ? "newsletter-email-error" : undefined}
+          aria-invalid={fieldError ? true : undefined}
+          autoComplete="email"
+          id="newsletter-email"
+          name="email"
+          onChange={(event) => handleChange(event.target.value)}
+          placeholder={newsletter.placeholder}
+          required
+          type="email"
+          value={email}
+        />
+        {fieldError ? (
+          <p className="newsletter-form__error" id="newsletter-email-error">
+            {fieldError}
+          </p>
+        ) : null}
+      </div>
+
+      <button className="newsletter-form__submit" type="submit">
+        {newsletter.submit}
+      </button>
+
+      {submitted ? (
+        <p
+          aria-live="polite"
+          className="newsletter-form__status"
+          role="status"
+        >
+          {newsletter.unavailable}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/src/content/footer.ts
+++ b/src/content/footer.ts
@@ -1,0 +1,175 @@
+import type { Locale } from "@/features/i18n/config";
+
+import { contactDetails } from "./contact";
+
+type LocalizedText = Readonly<Record<Locale, string>>;
+
+export interface FooterSocialView {
+  id: string;
+  label: string;
+  value: string;
+  href: string;
+}
+
+export interface FooterContentView {
+  brand: {
+    name: string;
+    description: string;
+  };
+  navigationLabel: string;
+  contactLabel: string;
+  details: ReadonlyArray<FooterSocialView>;
+  newsletter: {
+    label: string;
+    description: string;
+    helper: string;
+    placeholder: string;
+    submit: string;
+    unavailable: string;
+    errors: Record<string, string>;
+    aria: {
+      formLabel: string;
+      emailLabel: string;
+      statusLive: string;
+    };
+  };
+  bottom: {
+    rights: string;
+    backToTop: string;
+  };
+  aria: {
+    footerLabel: string;
+  };
+}
+
+const footerCopy = {
+  brand: {
+    description: {
+      en: "Portfolio of Quach Vo Anh Khoa — software engineer and full-stack developer building calm, dependable web products.",
+      vi: "Portfolio của Quách Võ Anh Khoa — kỹ sư phần mềm và lập trình viên full-stack xây dựng những sản phẩm web gần gũi và đáng tin cậy.",
+    },
+  },
+  navigationLabel: {
+    en: "Navigation",
+    vi: "Điều hướng",
+  },
+  contactLabel: {
+    en: "Contact",
+    vi: "Liên hệ",
+  },
+  newsletter: {
+    label: {
+      en: "Newsletter",
+      vi: "Bản tin",
+    },
+    description: {
+      en: "Get occasional updates on new projects and experiments.",
+      vi: "Nhận tin cập nhật định kỳ về dự án và thử nghiệm mới.",
+    },
+    helper: {
+      en: "Sign-up is not active yet — your email will not be sent or stored.",
+      vi: "Đăng ký chưa được mở — email của bạn sẽ không được gửi hoặc lưu trữ.",
+    },
+    placeholder: {
+      en: "you@example.com",
+      vi: "you@example.com",
+    },
+    submit: {
+      en: "Subscribe",
+      vi: "Đăng ký",
+    },
+    unavailable: {
+      en: "Newsletter sign-up is not available yet — your email has not been sent or stored.",
+      vi: "Đăng ký bản tin hiện chưa được mở — email của bạn chưa được gửi hoặc lưu trữ.",
+    },
+    errors: {
+      required: {
+        en: "Please enter your email address.",
+        vi: "Vui lòng nhập địa chỉ email.",
+      },
+      "invalid-email": {
+        en: "Please enter a valid email address.",
+        vi: "Vui lòng nhập địa chỉ email hợp lệ.",
+      },
+      "too-long": {
+        en: "This email address is too long.",
+        vi: "Địa chỉ email này quá dài.",
+      },
+    },
+    aria: {
+      formLabel: {
+        en: "Newsletter sign-up",
+        vi: "Đăng ký bản tin",
+      },
+      emailLabel: {
+        en: "Email address",
+        vi: "Địa chỉ email",
+      },
+      statusLive: {
+        en: "Newsletter sign-up status",
+        vi: "Trạng thái đăng ký bản tin",
+      },
+    },
+  },
+  bottom: {
+    rights: {
+      en: "All rights reserved.",
+      vi: "Bảo lưu mọi quyền.",
+    },
+    backToTop: {
+      en: "Back to top",
+      vi: "Về đầu trang",
+    },
+  },
+  aria: {
+    footerLabel: {
+      en: "Footer",
+      vi: "Chân trang",
+    },
+  },
+} as const;
+
+export function getFooterContent(locale: Locale): FooterContentView {
+  const localized = (text: LocalizedText) => text[locale];
+
+  return {
+    brand: {
+      name: "Quach Vo Anh Khoa",
+      description: localized(footerCopy.brand.description),
+    },
+    navigationLabel: localized(footerCopy.navigationLabel),
+    contactLabel: localized(footerCopy.contactLabel),
+    details: Object.values(contactDetails).map((detail) => ({
+      id: detail.id,
+      label: localized(detail.label),
+      value: localized(detail.value),
+      href: detail.href,
+    })),
+    newsletter: {
+      label: localized(footerCopy.newsletter.label),
+      description: localized(footerCopy.newsletter.description),
+      helper: localized(footerCopy.newsletter.helper),
+      placeholder: localized(footerCopy.newsletter.placeholder),
+      submit: localized(footerCopy.newsletter.submit),
+      unavailable: localized(footerCopy.newsletter.unavailable),
+      errors: Object.fromEntries(
+        Object.entries(footerCopy.newsletter.errors).map(([key, value]) => [
+          key,
+          localized(value),
+        ]),
+      ),
+      aria: {
+        formLabel: localized(footerCopy.newsletter.aria.formLabel),
+        emailLabel: localized(footerCopy.newsletter.aria.emailLabel),
+        statusLive: localized(footerCopy.newsletter.aria.statusLive),
+      },
+    },
+    bottom: {
+      rights: localized(footerCopy.bottom.rights),
+      backToTop: localized(footerCopy.bottom.backToTop),
+    },
+    aria: {
+      footerLabel: localized(footerCopy.aria.footerLabel),
+    },
+  };
+}

--- a/src/features/newsletter/validation.test.ts
+++ b/src/features/newsletter/validation.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { validateNewsletterSignup } from "./validation";
+
+interface Expectation {
+  label: string;
+  email: string;
+  want: "required" | "too-long" | "invalid-email" | null;
+}
+
+const table: Expectation[] = [
+  { label: "accepts a valid email", email: "visitor@example.com", want: null },
+  {
+    label: "trims surrounding whitespace before validating",
+    email: "  visitor@example.com  ",
+    want: null,
+  },
+  { label: "rejects missing email", email: "", want: "required" },
+  { label: "rejects whitespace-only email", email: "   ", want: "required" },
+  { label: "rejects malformed email", email: "not-an-email", want: "invalid-email" },
+  { label: "rejects email without domain", email: "visitor@", want: "invalid-email" },
+  { label: "rejects email missing local part", email: "@example.com", want: "invalid-email" },
+  { label: "rejects email missing dot in domain", email: "visitor@example", want: "invalid-email" },
+  {
+    label: "rejects email above maximum length",
+    email: `${"a".repeat(243)}@example.com`,
+    want: "too-long",
+  },
+  {
+    label: "accepts email at maximum length",
+    email: `${"a".repeat(242)}@example.com`,
+    want: null,
+  },
+];
+
+for (const entry of table) {
+  test(`newsletter validation: ${entry.label}`, () => {
+    const errors = validateNewsletterSignup({ email: entry.email });
+    assert.equal(errors.email ?? null, entry.want);
+  });
+}

--- a/src/features/newsletter/validation.ts
+++ b/src/features/newsletter/validation.ts
@@ -1,0 +1,66 @@
+export type NewsletterFieldErrorCode =
+  | "required"
+  | "too-long"
+  | "invalid-email";
+
+export type NewsletterFieldErrors = Partial<{
+  email: NewsletterFieldErrorCode;
+}>;
+
+export interface NewsletterSignupInput {
+  email: string;
+}
+
+export const NEWSLETTER_EMAIL_MAX = 254;
+
+function isValidEmail(email: string): boolean {
+  if (email.length > NEWSLETTER_EMAIL_MAX) {
+    return false;
+  }
+
+  const atIndex = email.indexOf("@");
+  const lastAtIndex = email.lastIndexOf("@");
+
+  if (atIndex <= 0 || lastAtIndex !== atIndex) {
+    return false;
+  }
+
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1);
+
+  if (local.length === 0 || domain.length === 0) {
+    return false;
+  }
+
+  if (!domain.includes(".")) {
+    return false;
+  }
+
+  const invalidChars = /[^\w.!#$%&'*+/=?^`{|}~-]/;
+  if (invalidChars.test(local)) {
+    return false;
+  }
+
+  const domainPart = /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  return domainPart.test(domain);
+}
+
+export function validateNewsletterSignup(
+  input: NewsletterSignupInput,
+): NewsletterFieldErrors {
+  const email = input.email.trim();
+
+  if (email.length === 0) {
+    return { email: "required" };
+  }
+
+  if (email.length > NEWSLETTER_EMAIL_MAX) {
+    return { email: "too-long" };
+  }
+
+  if (!isValidEmail(email)) {
+    return { email: "invalid-email" };
+  }
+
+  return {};
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1911,6 +1911,261 @@ video {
   }
 }
 
+.site-footer {
+  padding-block: var(--space-16) var(--space-8);
+  border-block-start: 1px solid var(--color-border);
+  background:
+    radial-gradient(
+      circle at 85% 12%,
+      var(--color-accent-soft),
+      transparent 24rem
+    ),
+    var(--color-page);
+}
+
+.site-footer__grid {
+  display: grid;
+  gap: var(--space-10);
+}
+
+.site-footer__brand {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.site-footer__brand-name {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+}
+
+.site-footer__brand-description {
+  max-width: 20rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.site-footer__socials {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  gap: var(--space-3);
+  list-style: none;
+}
+
+.site-footer__social {
+  display: inline-flex;
+  min-height: 2.25rem;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.site-footer__social:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-accent-soft);
+}
+
+.site-footer__column {
+  display: grid;
+  align-content: start;
+  gap: var(--space-5);
+}
+
+.site-footer__heading {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.site-footer__links {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  gap: var(--space-3);
+  list-style: none;
+}
+
+.site-footer__link {
+  display: inline-flex;
+  width: fit-content;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  text-decoration: none;
+  transition: color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.site-footer__link:hover {
+  color: var(--color-text);
+}
+
+.site-footer__link-label {
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-semibold);
+}
+
+.newsletter-form {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.newsletter-form__description {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.newsletter-form__helper {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-style: italic;
+}
+
+.newsletter-form__field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.newsletter-form__field label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.newsletter-form__field input {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.newsletter-form__field input:hover {
+  border-color: var(--color-border-strong);
+}
+
+.newsletter-form__field input:focus-visible {
+  border-color: var(--color-focus);
+}
+
+.newsletter-form__field input[aria-invalid="true"] {
+  border-color: var(--color-error);
+}
+
+.newsletter-form__error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
+.newsletter-form__submit {
+  display: inline-flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.newsletter-form__submit:hover {
+  border-color: var(--color-accent-hover);
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+}
+
+.newsletter-form__status {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-surface-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.site-footer__bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-block-start: var(--space-10);
+  padding-block-start: var(--space-6);
+  border-block-start: 1px solid var(--color-border);
+}
+
+.site-footer__copyright {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.site-footer__back-to-top {
+  display: inline-grid;
+  width: 2.75rem;
+  height: 2.75rem;
+  flex: none;
+  padding: 0;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.site-footer__back-to-top:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-accent-soft);
+  transform: translateY(-1px);
+}
+
+@media (min-width: 48rem) {
+  .site-footer__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-12);
+  }
+}
+
+@media (min-width: 72rem) {
+  .site-footer {
+    padding-block: var(--space-20) var(--space-10);
+  }
+
+  .site-footer__grid {
+    grid-template-columns: minmax(0, 1.3fr) repeat(3, minmax(0, 1fr));
+    gap: var(--space-12);
+  }
+}
+
 .navigation-anchor--placeholder {
   display: grid;
   min-height: max(28rem, 65vh);


### PR DESCRIPTION
Closes #13

## What changed

- **Server footer** (`src/components/sections/footer/footer-section.tsx`) rendered in the locale layout as a `<footer>` landmark, outside `<main>`.
- **Typed content view** `getFooterContent(locale)` in `src/content/footer.ts`, reusing `contactDetails` (GitHub only — no invented email/phone).
- **Newsletter shell** (`newsletter-form.tsx`, client) — email field + Subscribe; client-side validation via new `src/features/newsletter/validation.ts`; on a valid submit shows a **truthful** "not available yet — nothing was sent or stored" informational note (`aria-live`/`role="status"`). No backend, no fake success.
- **Back-to-top** (`back-to-top.tsx`, client) — circular button, keyboard/pointer operable, reduced-motion aware.
- **Responsive grid**: 1 col mobile → 2×2 tablet (48rem) → 4 cols desktop (72rem); bottom row (copyright + back-to-top) stacks on mobile.
- **Canonical docs amended** (per execution contract + ChatGPT review) to record the accepted **legal-link deferral**: Privacy/Terms/Cookies are omitted because no routes exist (repo rule forbids fake `#` links); they will be added with their routes.

## Acceptance criteria

- [x] Desktop multi-column layout (brand/socials · navigation · contact · newsletter)
- [x] Mobile stacks logically; newsletter usable
- [x] Navigation/contact/socials accessible (locale-root-qualified hrefs: `/`, `/vi`, `/vi#skills`, …)
- [x] Back-to-top works by keyboard/pointer
- [x] Newsletter behavior truthful when backend deferred (pre-submit helper + post-submit note; no success semantics)
- [x] EN/VI strings and both themes supported
- [x] lint, typecheck, build pass

## Verification

- `npm test` — 63 tests pass (incl. 10 new newsletter validation tests)
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build -- --webpack` — passes (`/en`, `/vi`, `/_not-found`)
- Playwright smoke (chromium): tab order through footer focusables, back-to-top smooth→0 + reduced-motion instant→0, invalid email shows inline error with `aria-invalid`, valid submit shows truthful note, nav hrefs verified for en+vi.
- Screenshots reviewed by @vision at desktop/tablet/mobile + dark theme + newsletter state.

## Known limitations

- Legal links (Privacy/Terms/Cookies) intentionally not rendered until routes exist (recorded in issue comment + docs).
- Newsletter persistence deferred to the CMS/backend phase (issue scope); UI never fakes a subscription.

## Docs affected

- `docs/00-product-brief.md`, `docs/02-ui-ux-spec.md`, `docs/05-implementation-plan.md`
- Decision recorded on issue #13.