### PR TITLE
feat: add SEO metadata sitemap structured data and redirects (#14)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  skipTrailingSlashRedirect: true,
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/features/contact/*.test.ts src/features/newsletter/*.test.ts"
+    "test": "tsx --test src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts"
   },
   "dependencies": {
     "next": "16.3.0",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { SiteHeader } from "@/components/navigation/site-header";
+import { StructuredData } from "@/components/seo/structured-data";
 import { FooterSection } from "@/components/sections/footer/footer-section";
 import { getFooterContent } from "@/content/footer";
 import { portfolioProfile } from "@/content/profile";
@@ -35,6 +36,7 @@ export default async function LocaleLayout({
         <ThemeScript />
       </head>
       <body>
+        <StructuredData locale={locale} />
         <ThemeProvider>
           <SiteHeader
             githubUrl={portfolioProfile.githubUrl}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -14,6 +14,7 @@ import { getResumeContent } from "@/content/resume";
 import { getSkillsContent } from "@/content/skills";
 import { getMessages } from "@/features/i18n/messages";
 import { getLocaleFromParams } from "@/features/i18n/server";
+import { getSeoMetadata } from "@/features/seo/metadata";
 import { navigationSectionIds } from "@/features/navigation/config";
 
 interface LocalePageProps {
@@ -26,10 +27,11 @@ export async function generateMetadata({
   const locale = await getLocaleFromParams(params);
   const messages = await getMessages(locale);
 
-  return {
+  return getSeoMetadata({
+    locale,
     title: messages.metadata.title,
     description: messages.metadata.description,
-  };
+  });
 }
 
 export default async function LocalePage({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+import { getSiteUrl } from "@/features/seo/config";
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next";
+
+import { locales } from "@/features/i18n/config";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+import { getAbsoluteUrl } from "@/features/seo/config";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const defaultPathname = getLocalizedPathname("/", "en");
+  const languages: Record<string, string> = {};
+
+  for (const locale of locales) {
+    languages[locale] = getAbsoluteUrl(getLocalizedPathname("/", locale));
+  }
+
+  languages["x-default"] = getAbsoluteUrl(defaultPathname);
+
+  return [
+    {
+      url: getAbsoluteUrl(defaultPathname),
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+      alternates: { languages },
+    },
+    ...locales
+      .filter((locale) => locale !== "en")
+      .map((locale) => ({
+        url: getAbsoluteUrl(getLocalizedPathname("/", locale)),
+        lastModified: new Date(),
+        changeFrequency: "monthly" as const,
+        priority: 1,
+        alternates: { languages },
+      })),
+  ];
+}

--- a/src/components/seo/structured-data.tsx
+++ b/src/components/seo/structured-data.tsx
@@ -1,0 +1,48 @@
+import { getPortfolioProfile } from "@/content/profile";
+import type { Locale } from "@/features/i18n/config";
+import { getMessages } from "@/features/i18n/messages";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+import { getAbsoluteUrl } from "@/features/seo/config";
+
+interface StructuredDataProps {
+  locale: Locale;
+}
+
+export async function StructuredData({
+  locale,
+}: Readonly<StructuredDataProps>) {
+  const messages = await getMessages(locale);
+  const profile = getPortfolioProfile(locale);
+  const url = getAbsoluteUrl(getLocalizedPathname("/", locale));
+
+  const graph = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Person",
+        "@id": `${url}#person`,
+        name: profile.name,
+        url,
+        image: getAbsoluteUrl(profile.hero.image.src),
+        jobTitle: profile.role,
+        sameAs: [profile.githubUrl],
+      },
+      {
+        "@type": "WebSite",
+        "@id": `${url}#website`,
+        url,
+        name: messages.metadata.title,
+        description: messages.metadata.description,
+        inLanguage: locale,
+        publisher: { "@id": `${url}#person` },
+      },
+    ],
+  };
+
+  return (
+    <script
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(graph) }}
+      type="application/ld+json"
+    />
+  );
+}

--- a/src/features/seo/config.ts
+++ b/src/features/seo/config.ts
@@ -1,0 +1,12 @@
+export const productionSiteUrl = "https://quachvoanhkhoa.feaon.com";
+
+export function getSiteUrl(): string {
+  return (process.env.NEXT_PUBLIC_SITE_URL ?? productionSiteUrl).replace(
+    /\/+$/,
+    "",
+  );
+}
+
+export function getAbsoluteUrl(pathname: string): string {
+  return `${getSiteUrl()}${pathname === "/" ? "" : pathname}`;
+}

--- a/src/features/seo/metadata.ts
+++ b/src/features/seo/metadata.ts
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+
+import { getPortfolioProfile } from "@/content/profile";
+import { locales, type Locale } from "@/features/i18n/config";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+
+import { getAbsoluteUrl, getSiteUrl } from "./config";
+
+const ogLocaleBySiteLocale: Record<Locale, string> = {
+  en: "en_US",
+  vi: "vi_VN",
+};
+
+function getAlternateLanguages(): Record<string, string> {
+  const languages: Record<string, string> = {};
+
+  for (const locale of locales) {
+    languages[locale] = getAbsoluteUrl(getLocalizedPathname("/", locale));
+  }
+
+  languages["x-default"] = getAbsoluteUrl(getLocalizedPathname("/", "en"));
+
+  return languages;
+}
+
+export interface SeoMetadataInput {
+  locale: Locale;
+  title: string;
+  description: string;
+}
+
+export function getSeoMetadata({
+  locale,
+  title,
+  description,
+}: SeoMetadataInput): Metadata {
+  const pathname = getLocalizedPathname("/", locale);
+  const url = getAbsoluteUrl(pathname);
+  const profile = getPortfolioProfile(locale);
+  const ogImage = getAbsoluteUrl(profile.hero.image.src);
+
+  return {
+    metadataBase: new URL(getSiteUrl()),
+    title,
+    description,
+    alternates: {
+      canonical: pathname,
+      languages: getAlternateLanguages(),
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    openGraph: {
+      type: "website",
+      locale: ogLocaleBySiteLocale[locale],
+      url,
+      siteName: title,
+      title,
+      description,
+      images: [{ url: ogImage, width: 852, height: 1280, alt: profile.hero.image.alt }],
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}

--- a/src/features/seo/redirects.test.ts
+++ b/src/features/seo/redirects.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildRedirectUrl,
+  getLegacyRedirectTarget,
+  normalizeTrailingSlash,
+} from "./redirects";
+
+test("legacy redirect: /resume maps to #resume on en root", () => {
+  assert.deepEqual(getLegacyRedirectTarget("en", "/resume"), {
+    pathname: "/",
+    hash: "#resume",
+  });
+});
+
+test("legacy redirect: /resume/ maps to #resume on en root", () => {
+  assert.deepEqual(getLegacyRedirectTarget("en", "/resume/"), {
+    pathname: "/",
+    hash: "#resume",
+  });
+});
+
+test("legacy redirect: /case-studies maps to #projects on en root", () => {
+  assert.deepEqual(getLegacyRedirectTarget("en", "/case-studies"), {
+    pathname: "/",
+    hash: "#projects",
+  });
+});
+
+test("legacy redirect: vi locale resolves to /vi root", () => {
+  assert.deepEqual(getLegacyRedirectTarget("vi", "/case-studies/"), {
+    pathname: "/vi",
+    hash: "#projects",
+  });
+});
+
+test("legacy redirect: unknown path returns null", () => {
+  assert.equal(getLegacyRedirectTarget("en", "/blog"), null);
+});
+
+test("trailing slash: /vi/ normalizes to /vi", () => {
+  assert.equal(normalizeTrailingSlash("/vi/"), "/vi");
+});
+
+test("trailing slash: multiple slashes collapse", () => {
+  assert.equal(normalizeTrailingSlash("/vi//"), "/vi");
+});
+
+test("trailing slash: root is untouched", () => {
+  assert.equal(normalizeTrailingSlash("/"), null);
+});
+
+test("trailing slash: path without slash is untouched", () => {
+  assert.equal(normalizeTrailingSlash("/vi"), null);
+});
+
+test("redirect url: query string precedes the fragment", () => {
+  const target = buildRedirectUrl(
+    "http://localhost:3000",
+    "/",
+    "?utm_source=x",
+    "#resume",
+  );
+
+  assert.equal(target.pathname, "/");
+  assert.equal(target.search, "?utm_source=x");
+  assert.equal(target.hash, "#resume");
+  assert.equal(
+    target.toString(),
+    "http://localhost:3000/?utm_source=x#resume",
+  );
+});
+
+test("redirect url: vi locale keeps query before fragment", () => {
+  const target = buildRedirectUrl(
+    "http://localhost:3000",
+    "/vi",
+    "?utm_source=x",
+    "#projects",
+  );
+
+  assert.equal(
+    target.toString(),
+    "http://localhost:3000/vi?utm_source=x#projects",
+  );
+});

--- a/src/features/seo/redirects.ts
+++ b/src/features/seo/redirects.ts
@@ -1,0 +1,51 @@
+import type { Locale } from "@/features/i18n/config";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+
+export interface LegacyRedirectTarget {
+  pathname: string;
+  hash: string;
+}
+
+const legacyRedirects = {
+  "/resume": "#resume",
+  "/resume/": "#resume",
+  "/case-studies": "#projects",
+  "/case-studies/": "#projects",
+} as const;
+
+export function getLegacyRedirectTarget(
+  locale: Locale,
+  pathname: string,
+): LegacyRedirectTarget | null {
+  const fragment = legacyRedirects[pathname as keyof typeof legacyRedirects];
+
+  if (!fragment) {
+    return null;
+  }
+
+  return {
+    pathname: getLocalizedPathname("/", locale),
+    hash: fragment,
+  };
+}
+
+export function normalizeTrailingSlash(pathname: string): string | null {
+  if (pathname === "/" || !pathname.endsWith("/")) {
+    return null;
+  }
+
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+export function buildRedirectUrl(
+  origin: string,
+  pathname: string,
+  search: string,
+  hash: string,
+): URL {
+  const target = new URL(origin);
+  target.pathname = pathname;
+  target.search = search;
+  target.hash = hash;
+  return target;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,27 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { defaultLocale, locales } from "@/features/i18n/config";
+import { defaultLocale, locales, type Locale } from "@/features/i18n/config";
+import { getLocalizedPathname } from "@/features/i18n/routing";
 
 const localeRewriteHeader = "x-qvak-locale-rewrite";
+
+const legacyRedirects = {
+  "/resume": "#resume",
+  "/resume/": "#resume",
+  "/case-studies": "#projects",
+  "/case-studies/": "#projects",
+} as const;
+
+function getLegacyRedirect(locale: Locale, pathname: string): string | null {
+  const fragment = legacyRedirects[pathname as keyof typeof legacyRedirects];
+
+  if (!fragment) {
+    return null;
+  }
+
+  return `${getLocalizedPathname("/", locale)}${fragment}`;
+}
 
 export function proxy(request: NextRequest) {
   const url = request.nextUrl.clone();
@@ -20,6 +38,19 @@ export function proxy(request: NextRequest) {
 
     url.pathname = pathname.slice(defaultLocale.length + 1) || "/";
     return NextResponse.redirect(url);
+  }
+
+  const requestedLocale = pathnameLocale ?? defaultLocale;
+  const legacyPathname = pathnameLocale
+    ? pathname.slice(pathnameLocale.length + 1)
+    : pathname;
+  const redirectPath = getLegacyRedirect(requestedLocale, legacyPathname);
+
+  if (redirectPath) {
+    return NextResponse.redirect(
+      `${url.origin}${redirectPath}${url.search}`,
+      301,
+    );
   }
 
   if (pathnameLocale) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,27 +1,14 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { defaultLocale, locales, type Locale } from "@/features/i18n/config";
-import { getLocalizedPathname } from "@/features/i18n/routing";
+import { defaultLocale, locales } from "@/features/i18n/config";
+import {
+  buildRedirectUrl,
+  getLegacyRedirectTarget,
+  normalizeTrailingSlash,
+} from "@/features/seo/redirects";
 
 const localeRewriteHeader = "x-qvak-locale-rewrite";
-
-const legacyRedirects = {
-  "/resume": "#resume",
-  "/resume/": "#resume",
-  "/case-studies": "#projects",
-  "/case-studies/": "#projects",
-} as const;
-
-function getLegacyRedirect(locale: Locale, pathname: string): string | null {
-  const fragment = legacyRedirects[pathname as keyof typeof legacyRedirects];
-
-  if (!fragment) {
-    return null;
-  }
-
-  return `${getLocalizedPathname("/", locale)}${fragment}`;
-}
 
 export function proxy(request: NextRequest) {
   const url = request.nextUrl.clone();
@@ -44,12 +31,26 @@ export function proxy(request: NextRequest) {
   const legacyPathname = pathnameLocale
     ? pathname.slice(pathnameLocale.length + 1)
     : pathname;
-  const redirectPath = getLegacyRedirect(requestedLocale, legacyPathname);
+  const legacyTarget = getLegacyRedirectTarget(requestedLocale, legacyPathname);
 
-  if (redirectPath) {
+  if (legacyTarget) {
     return NextResponse.redirect(
-      `${url.origin}${redirectPath}${url.search}`,
+      buildRedirectUrl(
+        url.origin,
+        legacyTarget.pathname,
+        url.search,
+        legacyTarget.hash,
+      ),
       301,
+    );
+  }
+
+  const normalizedPathname = normalizeTrailingSlash(pathname);
+
+  if (normalizedPathname) {
+    return NextResponse.redirect(
+      buildRedirectUrl(url.origin, normalizedPathname, url.search, url.hash),
+      308,
     );
   }
 


### PR DESCRIPTION
Closes #14

## What changed

- **Locale-aware metadata**: `getSeoMetadata` in `src/features/seo/metadata.ts` — title/description, canonical URL, `alternates.languages` (en/vi/x-default), OpenGraph (type/locale/url/siteName/image), Twitter summary card, robots index/follow. Wired into `generateMetadata` in `[locale]/page.tsx`.
- **Structured data**: `src/components/seo/structured-data.tsx` renders JSON-LD Person + WebSite (truthful facts from `getPortfolioProfile`) once per locale in `[locale]/layout.tsx`.
- **Sitemap/robots**: `src/app/sitemap.ts` (en + vi with xhtml hreflang alternates), `src/app/robots.ts`.
- **Redirects (decided only)**: `/resume` and `/case-studies` (+ trailing-slash and `/vi` variants) → permanent 301 to `{localeRoot}#resume` / `#projects`. Query strings preserved **before** the fragment; no redirect chains.
- **Canonicalization**: `skipTrailingSlashRedirect` + explicit proxy handling keep one-hop 301s for legacy paths and Next-style 308 trailing-slash canonicalization for all other URLs (`/vi/` → `/vi`).
- **Pure redirect logic**: `src/features/seo/redirects.ts` extracted for unit testing (`redirects.test.ts`, 11 cases).

## Acceptance criteria

- [x] Metadata valid for EN/VI
- [x] Canonical/alternate strategy explicit and implemented (production origin, per-locale canonicals, x-default)
- [x] Sitemap and robots generated correctly
- [x] Structured data contains truthful profile facts only
- [x] Approved legacy redirects implemented and tested (/resume/, /case-studies/)
- [x] No indexed legacy route dropped without a documented decision (blog/category/block/CV retained per inventory)
- [x] lint, typecheck, build pass

## Verification

- `npm test` — 74 pass (incl. 11 new redirect tests)
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build -- --webpack` — passes (/en, /vi, /robots.txt, /sitemap.xml, proxy)
- curl smoke: sitemap XML well-formed + hreflang alternates; robots correct; per-locale canonical/hreflang/OG/Twitter/JSON-LD verified; redirect matrix verified (301 one-hop, `/vi/`→308 canonical, query-before-fragment on live responses)

## Known limitations

- Blog retention hosting mechanism, `/blocks/*` 410s, case-study post mappings, CV PDF URLs remain `Unknown`/`Candidate` in the inventory — not guessed, out of scope.
- Production domain used as fallback origin when `NEXT_PUBLIC_SITE_URL` is unset.
- This PR does not authorize WordPress cutover; remaining inventory gates apply.

## Docs affected

None changed; redirect decisions come from the committed `docs/migration/wordpress-content-inventory.md`. Verification recorded on issue #14.