### PR TITLE
test: accessibility responsive and performance hardening (#15)

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,52 @@
+import { headers } from "next/headers";
+
+import { Container } from "@/components/layout/container";
+import {
+  defaultLocale,
+  isLocale,
+  type Locale,
+} from "@/features/i18n/config";
+import { getMessages } from "@/features/i18n/messages";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+import { ThemeScript } from "@/features/theme/theme-script";
+
+const localeRewriteHeader = "x-qvak-locale-rewrite";
+
+export default async function NotFound() {
+  const headerStore = await headers();
+  const headerLocale = headerStore.get(localeRewriteHeader);
+  const locale: Locale =
+    headerLocale !== null && isLocale(headerLocale)
+      ? headerLocale
+      : defaultLocale;
+  const messages = await getMessages(locale);
+  const homePath = getLocalizedPathname("/", locale);
+
+  return (
+    <html data-theme="light" lang={locale} suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
+      <body>
+        <main className="page-shell">
+          <section className="not-found">
+            <Container size="narrow">
+              <div className="not-found__card">
+                <p className="not-found__eyebrow" role="text">
+                  {messages.notFound.eyebrow}
+                </p>
+                <h1 className="not-found__title">{messages.notFound.title}</h1>
+                <p className="not-found__description">
+                  {messages.notFound.description}
+                </p>
+                <a className="not-found__action" href={homePath}>
+                  {messages.notFound.homeAction}
+                </a>
+              </div>
+            </Container>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,6 +10,8 @@ import { getMessages } from "@/features/i18n/messages";
 import { getLocalizedPathname } from "@/features/i18n/routing";
 import { ThemeScript } from "@/features/theme/theme-script";
 
+import "@/styles/globals.css";
+
 const localeRewriteHeader = "x-qvak-locale-rewrite";
 
 export default async function NotFound() {

--- a/src/features/i18n/messages/en.ts
+++ b/src/features/i18n/messages/en.ts
@@ -31,6 +31,13 @@ const messages = {
     switchToLight: "Switch to light theme",
     switchToDark: "Switch to dark theme",
   },
+  notFound: {
+    eyebrow: "404",
+    title: "This page could not be found",
+    description:
+      "The page you are looking for may have moved or no longer exists.",
+    homeAction: "Back to Home",
+  },
   foundation: {
     eyebrow: "Portfolio foundation",
     title: "A clear frame for the work ahead.",

--- a/src/features/i18n/messages/types.ts
+++ b/src/features/i18n/messages/types.ts
@@ -30,6 +30,12 @@ export interface PortfolioMessages {
   localeSwitcher: LocaleSwitcherMessages;
   header: HeaderMessages;
   themeToggle: ThemeToggleMessages;
+  notFound: {
+    eyebrow: string;
+    title: string;
+    description: string;
+    homeAction: string;
+  };
   foundation: {
     eyebrow: string;
     title: string;

--- a/src/features/i18n/messages/vi.ts
+++ b/src/features/i18n/messages/vi.ts
@@ -31,6 +31,12 @@ const messages = {
     switchToLight: "Chuyển sang giao diện sáng",
     switchToDark: "Chuyển sang giao diện tối",
   },
+  notFound: {
+    eyebrow: "404",
+    title: "Không tìm thấy trang này",
+    description: "Trang bạn đang tìm có thể đã di chuyển hoặc không còn tồn tại.",
+    homeAction: "Về Trang chủ",
+  },
   foundation: {
     eyebrow: "Nền tảng portfolio",
     title: "Một khung nền rõ ràng cho hành trình phía trước.",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,9 +18,11 @@ export function proxy(request: NextRequest) {
       pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
   );
 
+  const requestHeaders = new Headers(request.headers);
+
   if (pathnameLocale === defaultLocale) {
-    if (request.headers.get(localeRewriteHeader) === defaultLocale) {
-      return NextResponse.next();
+    if (requestHeaders.get(localeRewriteHeader) === defaultLocale) {
+      return NextResponse.next({ request: { headers: requestHeaders } });
     }
 
     url.pathname = pathname.slice(defaultLocale.length + 1) || "/";
@@ -54,12 +56,13 @@ export function proxy(request: NextRequest) {
     );
   }
 
+  requestHeaders.set(localeRewriteHeader, requestedLocale);
+
   if (pathnameLocale) {
-    return NextResponse.next();
+    return NextResponse.next({ request: { headers: requestHeaders } });
   }
 
   url.pathname = `/${defaultLocale}${pathname === "/" ? "" : pathname}`;
-  const requestHeaders = new Headers(request.headers);
   requestHeaders.set(localeRewriteHeader, defaultLocale);
 
   return NextResponse.rewrite(url, {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -44,7 +44,7 @@
   --color-surface-subtle: var(--palette-neutral-100);
   --color-surface-elevated: var(--palette-neutral-0);
   --color-text: var(--palette-neutral-950);
-  --color-text-muted: var(--palette-neutral-500);
+  --color-text-muted: oklch(52% 0.025 270);
   --color-text-inverse: var(--palette-neutral-0);
   --color-border: var(--palette-neutral-200);
   --color-border-strong: oklch(78% 0.02 270);
@@ -2166,12 +2166,78 @@ video {
   }
 }
 
+.not-found {
+  display: grid;
+  min-height: max(32rem, 70vh);
+  align-items: center;
+  padding-block: var(--section-space);
+  background:
+    radial-gradient(
+      circle at 12% 12%,
+      var(--color-accent-soft),
+      transparent 24rem
+    ),
+    var(--color-page);
+}
+
+.not-found__card {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.not-found__eyebrow {
+  color: var(--color-accent);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.not-found__title {
+  font-size: var(--font-size-display);
+  font-weight: var(--font-weight-bold);
+}
+
+.not-found__description {
+  max-width: 34rem;
+  color: var(--color-text-muted);
+}
+
+.not-found__action {
+  display: inline-flex;
+  width: fit-content;
+  min-height: 3.25rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-6);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.not-found__action:hover {
+  border-color: var(--color-accent-hover);
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+}
+
 .navigation-anchor--placeholder {
   display: grid;
   min-height: max(28rem, 65vh);
   align-items: center;
   border-block-start: 1px solid var(--color-border);
-}.navigation-anchor--placeholder:nth-of-type(odd) {
+}
+
+.navigation-anchor--placeholder:nth-of-type(odd) {
   background: var(--color-surface-subtle);
 }
 


### PR DESCRIPTION
Closes #15

## What changed

Cross-cutting accessibility/responsive/performance quality pass over the integrated MVP. Audited and fixed the concrete defects found; the rest already met the acceptance criteria.

1. **Locale-aware themed 404 page** (only error-state gap found): added `src/app/not-found.tsx` (root not-found) with a full html shell + `ThemeScript` + direct `globals.css` import. It reads the resolved locale from the proxy's `x-qvak-locale-rewrite` request header and renders localized EN/VI copy + locale-rooted "Back to Home" link. Previously `/nonexistent` showed Next's bare built-in 404 (no theme, no lang, no styles).
   - Proxy now always sets that header on both `next()` and `rewrite()` paths.
   - Note: a segment-level `[locale]/not-found.tsx` does not receive unmatched URLs in Next 16 (verified empirically), so the root page is the correct boundary.
2. **Light-theme muted text contrast fix**: `--color-text-muted` light changed `oklch(54%)` → `oklch(52%)`. The selected project's category label was 4.19:1 (FAIL AA); now 4.53:1. Improves muted text everywhere in light theme.
3. **i18n**: `notFound` block added to `en.ts`, `vi.ts`, `types.ts`.

## Acceptance criteria

- [x] Primary navigation and interactive sections keyboard operable (tabs/projects/resume roving focus + arrows; lightbox focus trap/Escape/restore; forms aria-invalid + live regions) — audited, already passing
- [x] Resume lightbox focus behavior verified (code-reviewed; no media entries in current data to trigger end-to-end)
- [x] Contact errors/states accessible — audited passing
- [x] Major layouts work at mobile/tablet/desktop (no horizontal overflow at 390/820/1440, en + vi)
- [x] No obvious CLS (all image containers use aspect-ratio + next/image fill/dimensions) — audited passing
- [x] Reduced-motion respected (animations disabled, scroll auto under prefers-reduced-motion; aura confirmed none)
- [x] Performance triaged by user impact — no score-chasing; client-JS already minimal (server shells + small client islands)
- [x] lint, typecheck, tests, build pass

## Verification

- `npm test` — 74 pass
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build -- --webpack` — passes (/_not-found ƒ dynamic, /[locale], /robots.txt, /sitemap.xml, proxy)
- Playwright: muted contrast re-measured 4.53:1 (was 4.19); cold `/nonexistent` + `/vi/nonexistent` render fully styled (display title, accent pill button, page bg) via computed styles; responsive overflow=false at 3 breakpoints both locales; mobile menu opens/closes via Escape
- curl: EN/VI 404 status + locale + theme verified; legacy redirects unchanged (301 → #resume/#projects)

## Known limitations

- `@vision` subagent was unavailable (model misconfiguration) during this pass; screenshots saved to `/tmp/opencode/q15-*.png` and layout/contrast verified programmatically instead.
- 404 page renders outside the `[locale]` layout (root boundary), so it does not include site header/footer — it is a clean on-brand themed page with localized copy + home link, matching issue scope ("404/error-state checks where relevant").
- Resume lightbox verified via code review (no media entries in current data to exercise it end-to-end).

## Docs affected

None.