### PR TITLE
feat(seo): implement D7 legacy redirect matrix and cutover preflight (closes #49)

### DIFF
--- a/docs/migration/cutover-runbook.md
+++ b/docs/migration/cutover-runbook.md
@@ -1,0 +1,74 @@
+# Cutover Preflight Runbook
+
+This runbook defines the in-repo, version-controlled verification for the WordPress → Next.js cutover (Issue #17). It pairs the automated preflight script with the manual operator gates that require external access.
+
+Owner policy source: `docs/migration/owner-decision-capture.md` (D7 redirect policy) and `docs/migration/wordpress-content-inventory.md` (redirect worksheet, pre-cutover preservation gates).
+
+## When to run
+
+Run before and immediately after the production release cutover for `quachvoanhkhoa.feaon.com`. The automated preflight should be **green** (no `FAIL` entries) before DNS/cutover, and re-run after cutover to confirm the live domain behaves as intended.
+
+## Prerequisites (external, human-executed)
+
+These gates are **not** automated and remain outside this repository. They must be satisfied before the destructive cutover steps in Issue #17:
+
+- [ ] Verified WordPress database and `wp-content/uploads` backups exist and can be restored.
+- [ ] Current sitemap XML, REST metadata, redirect/plugin configuration, and permalink settings are preserved.
+- [ ] Search Console indexed URLs, top landing pages, backlinks, and recent 404s are exported.
+- [ ] Backup owner, storage location, retention period, rollback owner, and rollback decision point are recorded outside the repo.
+- [ ] A pre-cutover re-crawl of the legacy sitemaps is diffed against the 2026-08-12 inventory snapshot.
+- [ ] The blog-retention mechanism (D6: no blog in the MVP) is confirmed and any transition is agreed.
+- [ ] Contact delivery is configured with the production provider credentials (never committed to the repo).
+- [ ] Hosting/Vercel, DNS/TLS, and domain registrar access are available to the operator.
+
+## Run the automated preflight
+
+```bash
+npm run preflight                 # default: production origin
+npm run preflight -- --origin=https://example.com   # any origin
+PREFLIGHT_ORIGIN=https://example.com npm run preflight
+```
+
+The script performs no writes and stores no credentials. Exit code `0` means no `FAIL` checks; exit code `1` means at least one `FAIL` check.
+
+### Checks performed
+
+| Check | Verifies |
+|---|---|
+| EN root `/`, VI root `/vi` | Both locale roots render with HTTP 200 |
+| Legacy redirects (`/resume/`, `/case-studies/`, `/atm-seeking/`, `/vi/case-studies/`, `/blog/`, `/blocks/footer/`, `/tag/nextjs/`) | Permanent `301` with the exact `Location` from the D7 matrix |
+| Homepage metadata | `<title>`, canonical link, hreflang `en`/`vi`/`x-default` |
+| `/sitemap.xml`, `/robots.txt` | 200 and correct content (urlset + sitemap reference) |
+| Public image asset | A production image returns 200 |
+| Resume-media gate (`/api/resume-media/transcript.jpg`) | Reports 404 (private default) or 200 (visible); 5xx is a failure |
+| Contact section | The homepage renders `id="contact"` |
+
+## Manual smoke checklist (post-cutover)
+
+The automated script cannot cover interactive behavior. Confirm in a browser at mobile/tablet/desktop widths:
+
+- [ ] EN and VI navigation, theme toggle, and locale switcher work.
+- [ ] `/#projects` selector shows all six projects with live demo/code links.
+- [ ] Resume section lock overlay shows while publicity is `private`.
+- [ ] While publicity is `visible`: certificate lightbox opens and images load.
+- [ ] Contact form submits and delivers through the production provider (requires provider credentials).
+- [ ] Newsletter form behaves (validation/subscribe result).
+- [ ] No legacy WordPress secrets, backups, or private files are reachable.
+
+## Expected behaviors to note
+
+- Resume-media returns `404` by default (`sections.resume.publicity = "private"`) and `200` only while `visible`. The preflight reports this as informational; treat a `404` as correct unless you intend to publish the resume.
+- The D7 policy is: legacy URL with a meaningful equivalent → that equivalent; no equivalent → the homepage. A `301` to `/#projects`/`/#resume` or to `/` (localized) is correct per the matrix.
+
+## Known limitations
+
+- **Old WordPress CV PDF URLs** are not in the matrix — the exact upload paths are not recorded in the inventory. They are not redirected; a future decision (D5) must supply a stable CV URL or a retention/redirect rule before any redirect is added.
+- **Contact delivery** is only reachability-checked (section renders). Live delivery requires a manual form submit against the production provider.
+- **Search Console/backlink evidence** for tags and archives remains a human gate (owner-decision §5); the automated checks only confirm the redirect response.
+- **Blog** is not served by the MVP (D6); legacy blog URLs redirect to the homepage per D7. If a blog migration is later approved, remove those routes from the homepage group in `src/features/seo/redirects.ts`.
+
+## Related
+
+- Issue #17 (operational cutover) — this runbook is its preflight input.
+- `docs/migration/owner-decision-capture.md` (D1–D10).
+- `docs/migration/wordpress-content-inventory.md` (§ redirect worksheet, § pre-cutover preservation gates).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/app/api/resume-media/route.test.ts"
+    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/app/api/resume-media/route.test.ts",
+    "preflight": "tsx scripts/preflight-cutover.ts"
   },
   "dependencies": {
     "next": "16.3.0",

--- a/scripts/preflight-cutover.ts
+++ b/scripts/preflight-cutover.ts
@@ -1,0 +1,263 @@
+import { argv, env, exit } from "node:process";
+
+const DEFAULT_ORIGIN = "https://quachvoanhkhoa.feaon.com";
+
+type Severity = "fail" | "info";
+
+interface CheckResult {
+  name: string;
+  pass: boolean;
+  severity: Severity;
+  detail?: string;
+}
+
+const results: CheckResult[] = [];
+
+function record(
+  name: string,
+  pass: boolean,
+  severity: Severity,
+  detail?: string,
+): void {
+  results.push({ name, pass, severity, detail });
+}
+
+async function runCheck(
+  name: string,
+  fn: () => Promise<{ pass: boolean; detail?: string }>,
+  severity: Severity = "fail",
+): Promise<void> {
+  try {
+    const outcome = await fn();
+    record(name, outcome.pass, severity, outcome.detail);
+  } catch (error) {
+    record(
+      name,
+      false,
+      severity,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+async function fetchText(
+  url: string,
+  init?: RequestInit,
+): Promise<{ status: number; text: string }> {
+  const response = await fetch(url, init);
+  return { status: response.status, text: await response.text() };
+}
+
+async function checkRoots(origin: string): Promise<void> {
+  const roots: ReadonlyArray<[string, string]> = [
+    ["en root", "/"],
+    ["vi root", "/vi"],
+  ];
+
+  for (const [label, pathname] of roots) {
+    await runCheck(`${label} returns 200`, async () => {
+      const { status } = await fetchText(`${origin}${pathname}`);
+      return { pass: status === 200, detail: `status ${status}` };
+    });
+  }
+}
+
+const legacyRedirectChecks: ReadonlyArray<{
+  pathname: string;
+  expectedLocation: string;
+}> = [
+  { pathname: "/resume/", expectedLocation: "/#resume" },
+  { pathname: "/case-studies/", expectedLocation: "/#projects" },
+  { pathname: "/atm-seeking/", expectedLocation: "/#projects" },
+  { pathname: "/vi/case-studies/", expectedLocation: "/vi#projects" },
+  { pathname: "/blog/", expectedLocation: "/" },
+  { pathname: "/blocks/footer/", expectedLocation: "/" },
+  { pathname: "/tag/nextjs/", expectedLocation: "/" },
+];
+
+async function checkLegacyRedirects(origin: string): Promise<void> {
+  for (const check of legacyRedirectChecks) {
+    await runCheck(
+      `legacy redirect ${check.pathname} -> ${check.expectedLocation}`,
+      async () => {
+        const response = await fetch(`${origin}${check.pathname}`, {
+          redirect: "manual",
+        });
+        const rawLocation = response.headers.get("location") ?? "";
+        const location = rawLocation.startsWith(origin)
+          ? rawLocation.slice(origin.length)
+          : rawLocation;
+        return {
+          pass: response.status === 301 && location === check.expectedLocation,
+          detail: `status ${response.status}, location ${rawLocation || "none"}`,
+        };
+      },
+    );
+  }
+}
+
+async function checkMetadata(origin: string): Promise<void> {
+  const checks: ReadonlyArray<{ name: string; pattern: RegExp }> = [
+    { name: "title present", pattern: /<title[^>]*>[\s\S]*?<\/title>/i },
+    { name: "canonical link present", pattern: /rel="canonical"/i },
+    { name: "hreflang en present", pattern: /hreflang="en"/i },
+    { name: "hreflang vi present", pattern: /hreflang="vi"/i },
+    { name: "hreflang x-default present", pattern: /hreflang="x-default"/i },
+  ];
+
+  let status: number;
+  let text: string;
+  try {
+    const page = await fetchText(`${origin}/`);
+    status = page.status;
+    text = page.text;
+  } catch (error) {
+    record(
+      "metadata: homepage fetch",
+      false,
+      "fail",
+      error instanceof Error ? error.message : String(error),
+    );
+    return;
+  }
+
+  for (const check of checks) {
+    record(
+      `metadata: ${check.name}`,
+      status === 200 && check.pattern.test(text),
+      "fail",
+      status === 200 ? undefined : `status ${status}`,
+    );
+  }
+}
+
+async function checkSitemapAndRobots(origin: string): Promise<void> {
+  await runCheck("/sitemap.xml returns 200 with https urlset", async () => {
+    const { status, text } = await fetchText(`${origin}/sitemap.xml`);
+    return {
+      pass: status === 200 && text.includes("<urlset") && /https:\/\//.test(text),
+      detail: `status ${status}, urlset ${text.includes("<urlset")}`,
+    };
+  });
+
+  await runCheck("/robots.txt returns 200 with sitemap reference", async () => {
+    const { status, text } = await fetchText(`${origin}/robots.txt`);
+    return {
+      pass: status === 200 && /sitemap:/i.test(text),
+      detail: `status ${status}`,
+    };
+  });
+}
+
+async function checkPublicAsset(origin: string): Promise<void> {
+  await runCheck("public image asset loads", async () => {
+    const response = await fetch(
+      `${origin}/images/profile/portrait-hero-banner.jpg`,
+    );
+    return {
+      pass: response.status === 200,
+      detail: `status ${response.status}`,
+    };
+  });
+}
+
+async function checkResumePublicity(origin: string): Promise<void> {
+  try {
+    const response = await fetch(
+      `${origin}/api/resume-media/transcript.jpg`,
+      { redirect: "manual" },
+    );
+    const ok = response.status === 404 || response.status === 200;
+    record(
+      "resume-media gate behaves (404 private / 200 visible)",
+      ok,
+      response.status >= 500 ? "fail" : "info",
+      `status ${response.status}`,
+    );
+  } catch (error) {
+    record(
+      "resume-media gate behaves (404 private / 200 visible)",
+      false,
+      "fail",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+async function checkContact(origin: string): Promise<void> {
+  await runCheck("contact section renders on the homepage", async () => {
+    const { status, text } = await fetchText(`${origin}/`);
+    return {
+      pass: status === 200 && text.includes('id="contact"'),
+      detail: `status ${status}`,
+    };
+  });
+}
+
+function printSummary(origin: string): void {
+  const failures = results.filter(
+    (result) => !result.pass && result.severity === "fail",
+  );
+  const warnings = results.filter(
+    (result) => !result.pass && result.severity === "info",
+  );
+  const passed = results.filter((result) => result.pass).length;
+
+  console.log(`\nPreflight report for ${origin}\n`);
+
+  for (const result of results) {
+    const label = result.pass
+      ? "PASS"
+      : result.severity === "info"
+        ? "WARN"
+        : "FAIL";
+    console.log(
+      `  [${label}] ${result.name}${result.detail ? ` — ${result.detail}` : ""}`,
+    );
+  }
+
+  console.log(
+    `\n${passed}/${results.length} checks passed, ${warnings.length} warnings, ${failures.length} failed.`,
+  );
+
+  if (failures.length > 0) {
+    console.error("\nPreflight FAILED. Resolve the failures before cutover.");
+  } else {
+    console.log(
+      "\nPreflight passed. Review warnings and complete the manual gates before cutover.",
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const originArg = argv
+    .map((arg) => arg.match(/^--origin=(.+)$/)?.[1])
+    .find((value) => value !== undefined);
+  const origin = (
+    originArg ??
+    env.PREFLIGHT_ORIGIN ??
+    DEFAULT_ORIGIN
+  ).replace(/\/+$/, "");
+
+  await checkRoots(origin);
+  await checkLegacyRedirects(origin);
+  await checkMetadata(origin);
+  await checkSitemapAndRobots(origin);
+  await checkPublicAsset(origin);
+  await checkResumePublicity(origin);
+  await checkContact(origin);
+
+  printSummary(origin);
+
+  const failures = results.filter(
+    (result) => !result.pass && result.severity === "fail",
+  );
+  if (failures.length > 0) {
+    exit(1);
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error("Preflight crashed:", error);
+  exit(1);
+});

--- a/scripts/preflight-cutover.ts
+++ b/scripts/preflight-cutover.ts
@@ -96,15 +96,35 @@ async function checkLegacyRedirects(origin: string): Promise<void> {
   }
 }
 
-async function checkMetadata(origin: string): Promise<void> {
-  const checks: ReadonlyArray<{ name: string; pattern: RegExp }> = [
-    { name: "title present", pattern: /<title[^>]*>[\s\S]*?<\/title>/i },
-    { name: "canonical link present", pattern: /rel="canonical"/i },
-    { name: "hreflang en present", pattern: /hreflang="en"/i },
-    { name: "hreflang vi present", pattern: /hreflang="vi"/i },
-    { name: "hreflang x-default present", pattern: /hreflang="x-default"/i },
-  ];
+function hrefInLink(
+  html: string,
+  options: { rel?: string; hreflang?: string },
+): string | null {
+  const linkPattern = /<link\b[^>]*>/gi;
+  let match: RegExpExecArray | null;
 
+  while ((match = linkPattern.exec(html)) !== null) {
+    const tag = match[0];
+    const hasRel =
+      options.rel === undefined ||
+      new RegExp(`rel=["']${options.rel}["']`, "i").test(tag);
+    const hasHreflang =
+      options.hreflang === undefined ||
+      new RegExp(`hreflang=["']${options.hreflang}["']`, "i").test(tag);
+
+    if (hasRel && hasHreflang) {
+      return tag.match(/href=["']([^"']+)["']/i)?.[1] ?? null;
+    }
+  }
+
+  return null;
+}
+
+function isAbsoluteHref(href: string): boolean {
+  return /^https?:\/\//i.test(href);
+}
+
+async function checkMetadata(origin: string): Promise<void> {
   let status: number;
   let text: string;
   try {
@@ -121,12 +141,35 @@ async function checkMetadata(origin: string): Promise<void> {
     return;
   }
 
-  for (const check of checks) {
+  const pageOk = status === 200;
+
+  record(
+    "metadata: title present",
+    pageOk && /<title[^>]*>[\s\S]*?<\/title>/i.test(text),
+    "fail",
+    pageOk ? undefined : `status ${status}`,
+  );
+
+  const canonical = hrefInLink(text, { rel: "canonical" });
+  record(
+    "metadata: canonical href is an absolute root URL",
+    pageOk &&
+      canonical !== null &&
+      isAbsoluteHref(canonical) &&
+      new URL(canonical).pathname === "/",
+    "fail",
+    pageOk
+      ? `href ${canonical ?? "missing"}`
+      : `status ${status}`,
+  );
+
+  for (const locale of ["en", "vi", "x-default"]) {
+    const href = hrefInLink(text, { rel: "alternate", hreflang: locale });
     record(
-      `metadata: ${check.name}`,
-      status === 200 && check.pattern.test(text),
+      `metadata: hreflang "${locale}" has an absolute href`,
+      pageOk && href !== null && isAbsoluteHref(href),
       "fail",
-      status === 200 ? undefined : `status ${status}`,
+      pageOk ? `href ${href ?? "missing"}` : `status ${status}`,
     );
   }
 }

--- a/src/features/seo/redirects.test.ts
+++ b/src/features/seo/redirects.test.ts
@@ -162,6 +162,33 @@ test("legacy redirect: proxy redirect preserves the query string", () => {
   );
 });
 
+test("legacy redirect: en-prefixed legacy URL redirects directly (no chain)", () => {
+  const request = new NextRequest("https://example.com/en/resume/?x=1");
+  const response = proxy(request);
+  assert.equal(response.status, 301);
+  assert.equal(
+    response.headers.get("location"),
+    "https://example.com/?x=1#resume",
+  );
+});
+
+test("legacy redirect: en-prefixed blog URL redirects directly to the root", () => {
+  const request = new NextRequest("https://example.com/en/blog/");
+  const response = proxy(request);
+  assert.equal(response.status, 301);
+  assert.equal(response.headers.get("location"), "https://example.com/");
+});
+
+test("legacy redirect: en-prefixed case-studies URL redirects directly", () => {
+  const request = new NextRequest("https://example.com/en/case-studies/");
+  const response = proxy(request);
+  assert.equal(response.status, 301);
+  assert.equal(
+    response.headers.get("location"),
+    "https://example.com/#projects",
+  );
+});
+
 test("trailing slash: /vi/ normalizes to /vi", () => {
   assert.equal(normalizeTrailingSlash("/vi/"), "/vi");
 });

--- a/src/features/seo/redirects.test.ts
+++ b/src/features/seo/redirects.test.ts
@@ -1,42 +1,165 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { NextRequest } from "next/server";
+
+import { proxy } from "@/proxy";
+
 import {
   buildRedirectUrl,
   getLegacyRedirectTarget,
   normalizeTrailingSlash,
 } from "./redirects";
 
-test("legacy redirect: /resume maps to #resume on en root", () => {
-  assert.deepEqual(getLegacyRedirectTarget("en", "/resume"), {
-    pathname: "/",
-    hash: "#resume",
-  });
+type RedirectCase = {
+  legacy: string;
+  expectedHash: string;
+};
+
+const equivalentCases: RedirectCase[] = [
+  { legacy: "/resume", expectedHash: "#resume" },
+  { legacy: "/resume/", expectedHash: "#resume" },
+  { legacy: "/case-studies", expectedHash: "#projects" },
+  { legacy: "/case-studies/", expectedHash: "#projects" },
+  { legacy: "/category/case-studies", expectedHash: "#projects" },
+  { legacy: "/category/case-studies/", expectedHash: "#projects" },
+  { legacy: "/atm-seeking", expectedHash: "#projects" },
+  { legacy: "/readingtime/", expectedHash: "#projects" },
+  { legacy: "/comestic-beauty-store", expectedHash: "#projects" },
+  { legacy: "/bakery-store", expectedHash: "#projects" },
+  {
+    legacy: "/dynamic-global-solution-landing-page",
+    expectedHash: "#projects",
+  },
+  { legacy: "/scented-candles-store", expectedHash: "#projects" },
+];
+
+const homepageCases: RedirectCase[] = [
+  { legacy: "/blog", expectedHash: "" },
+  { legacy: "/blog/", expectedHash: "" },
+  { legacy: "/what-is-a-web-server", expectedHash: "" },
+  { legacy: "/identify-a-seo-standard-website", expectedHash: "" },
+  { legacy: "/javascript-code-compilation-process", expectedHash: "" },
+  { legacy: "/a-brief-introduction-to-nextjs", expectedHash: "" },
+  { legacy: "/category/tech-blog", expectedHash: "" },
+  { legacy: "/category/tech-blog/", expectedHash: "" },
+  { legacy: "/author/superuser", expectedHash: "" },
+  { legacy: "/tag/cloud", expectedHash: "" },
+  { legacy: "/tag/ecommerce", expectedHash: "" },
+  { legacy: "/tag/edtech", expectedHash: "" },
+  { legacy: "/tag/fb", expectedHash: "" },
+  { legacy: "/tag/health-beauty", expectedHash: "" },
+  { legacy: "/tag/javascript-news", expectedHash: "" },
+  { legacy: "/tag/landing-page", expectedHash: "" },
+  { legacy: "/tag/lifestyle", expectedHash: "" },
+  { legacy: "/tag/lms", expectedHash: "" },
+  { legacy: "/tag/nestjs", expectedHash: "" },
+  { legacy: "/tag/nextjs", expectedHash: "" },
+  { legacy: "/tag/nextjs-news", expectedHash: "" },
+  { legacy: "/tag/reactjs", expectedHash: "" },
+  { legacy: "/tag/seo-news", expectedHash: "" },
+  { legacy: "/tag/utility", expectedHash: "" },
+  { legacy: "/tag/web", expectedHash: "" },
+  { legacy: "/tag/web-news", expectedHash: "" },
+  { legacy: "/tag/wordpress", expectedHash: "" },
+  { legacy: "/blocks/header", expectedHash: "" },
+  { legacy: "/blocks/footer", expectedHash: "" },
+  { legacy: "/blocks/recent-case-studies", expectedHash: "" },
+  { legacy: "/blocks/recent-posts", expectedHash: "" },
+  { legacy: "/blocks/header/deeper", expectedHash: "" },
+];
+
+const redirectCases: ReadonlyArray<RedirectCase> = [
+  ...equivalentCases,
+  ...homepageCases,
+];
+
+test("legacy redirect matrix: en resolves to the localized root", () => {
+  for (const redirectCase of redirectCases) {
+    assert.deepEqual(
+      getLegacyRedirectTarget("en", redirectCase.legacy),
+      { pathname: "/", hash: redirectCase.expectedHash },
+      `legacy path "${redirectCase.legacy}" should redirect on en`,
+    );
+  }
 });
 
-test("legacy redirect: /resume/ maps to #resume on en root", () => {
-  assert.deepEqual(getLegacyRedirectTarget("en", "/resume/"), {
-    pathname: "/",
-    hash: "#resume",
-  });
+test("legacy redirect matrix: vi resolves to the /vi root", () => {
+  for (const redirectCase of redirectCases) {
+    assert.deepEqual(
+      getLegacyRedirectTarget("vi", redirectCase.legacy),
+      { pathname: "/vi", hash: redirectCase.expectedHash },
+      `legacy path "${redirectCase.legacy}" should redirect on vi`,
+    );
+  }
 });
 
-test("legacy redirect: /case-studies maps to #projects on en root", () => {
-  assert.deepEqual(getLegacyRedirectTarget("en", "/case-studies"), {
-    pathname: "/",
-    hash: "#projects",
-  });
+test("no legacy rule targets another legacy route (no redirect chains)", () => {
+  for (const redirectCase of redirectCases) {
+    const target = getLegacyRedirectTarget("en", redirectCase.legacy);
+    assert.ok(target, `legacy path "${redirectCase.legacy}" should match`);
+    assert.equal(target.pathname, "/");
+    assert.equal(
+      getLegacyRedirectTarget("en", target.pathname),
+      null,
+      `"${target.pathname}" must never be a legacy input`,
+    );
+  }
 });
 
-test("legacy redirect: vi locale resolves to /vi root", () => {
-  assert.deepEqual(getLegacyRedirectTarget("vi", "/case-studies/"), {
-    pathname: "/vi",
-    hash: "#projects",
-  });
+test("legacy redirect: unknown and unlisted paths return null", () => {
+  for (const pathname of [
+    "/",
+    "/contact",
+    "/skills",
+    "/blogging",
+    "/tag",
+    "/blocks",
+  ]) {
+    assert.equal(getLegacyRedirectTarget("en", pathname), null, pathname);
+  }
 });
 
-test("legacy redirect: unknown path returns null", () => {
-  assert.equal(getLegacyRedirectTarget("en", "/blog"), null);
+test("legacy redirect: query string is preserved through the redirect URL", () => {
+  const target = getLegacyRedirectTarget("en", "/resume/");
+  assert.ok(target);
+  const url = buildRedirectUrl(
+    "https://example.com",
+    target.pathname,
+    "?utm_source=x",
+    target.hash,
+  );
+  assert.equal(url.toString(), "https://example.com/?utm_source=x#resume");
+});
+
+test("legacy redirect: homepage fallback keeps the query string", () => {
+  const target = getLegacyRedirectTarget("vi", "/blog/");
+  assert.ok(target);
+  const url = buildRedirectUrl(
+    "https://example.com",
+    target.pathname,
+    "?from=wp",
+    target.hash,
+  );
+  assert.equal(url.toString(), "https://example.com/vi?from=wp");
+});
+
+test("legacy redirect: permanent 301 status at the proxy boundary", () => {
+  const request = new NextRequest("https://example.com/resume/");
+  const response = proxy(request);
+  assert.equal(response.status, 301);
+});
+
+test("legacy redirect: proxy redirect preserves the query string", () => {
+  const request = new NextRequest(
+    "https://example.com/case-studies/?utm_source=x",
+  );
+  const response = proxy(request);
+  assert.equal(response.status, 301);
+  assert.equal(
+    response.headers.get("location"),
+    "https://example.com/?utm_source=x#projects",
+  );
 });
 
 test("trailing slash: /vi/ normalizes to /vi", () => {

--- a/src/features/seo/redirects.ts
+++ b/src/features/seo/redirects.ts
@@ -6,26 +6,130 @@ export interface LegacyRedirectTarget {
   hash: string;
 }
 
-const legacyRedirects = {
-  "/resume": "#resume",
-  "/resume/": "#resume",
-  "/case-studies": "#projects",
-  "/case-studies/": "#projects",
-} as const;
+interface LegacyRedirectRule {
+  /** Legacy pathname key. A trailing `*` matches any pathname with that prefix. */
+  legacy: string;
+  /** Locale-independent logical destination and fragment. */
+  destination: {
+    pathname: string;
+    hash: string;
+  };
+}
+
+const caseStudySlugs = [
+  "atm-seeking",
+  "readingtime",
+  "comestic-beauty-store",
+  "bakery-store",
+  "dynamic-global-solution-landing-page",
+  "scented-candles-store",
+] as const;
+
+const blogPostSlugs = [
+  "what-is-a-web-server",
+  "identify-a-seo-standard-website",
+  "javascript-code-compilation-process",
+  "a-brief-introduction-to-nextjs",
+] as const;
+
+const tagSlugs = [
+  "cloud",
+  "ecommerce",
+  "edtech",
+  "fb",
+  "health-beauty",
+  "javascript-news",
+  "landing-page",
+  "lifestyle",
+  "lms",
+  "nestjs",
+  "nextjs",
+  "nextjs-news",
+  "reactjs",
+  "seo-news",
+  "utility",
+  "web",
+  "web-news",
+  "wordpress",
+] as const;
+
+/**
+ * Legacy WordPress redirect matrix per owner decision D7
+ * (`docs/migration/owner-decision-capture.md`):
+ * legacy URL with a meaningful equivalent → that new equivalent;
+ * legacy URL with no equivalent → the homepage.
+ *
+ * Every destination is a logical root plus an optional fragment, so a
+ * redirect can never point at another legacy route (no chains). Locale
+ * prefixes are applied at lookup time.
+ */
+const legacyRedirectRules: ReadonlyArray<LegacyRedirectRule> = [
+  ...caseStudySlugs.map(
+    (slug) =>
+      ({
+        legacy: `/${slug}`,
+        destination: { pathname: "/", hash: "#projects" },
+      }) satisfies LegacyRedirectRule,
+  ),
+  { legacy: "/resume", destination: { pathname: "/", hash: "#resume" } },
+  { legacy: "/case-studies", destination: { pathname: "/", hash: "#projects" } },
+  {
+    legacy: "/category/case-studies",
+    destination: { pathname: "/", hash: "#projects" },
+  },
+  { legacy: "/blog", destination: { pathname: "/", hash: "" } },
+  ...blogPostSlugs.map(
+    (slug) =>
+      ({
+        legacy: `/${slug}`,
+        destination: { pathname: "/", hash: "" },
+      }) satisfies LegacyRedirectRule,
+  ),
+  { legacy: "/category/tech-blog", destination: { pathname: "/", hash: "" } },
+  { legacy: "/author/superuser", destination: { pathname: "/", hash: "" } },
+  ...tagSlugs.map(
+    (slug) =>
+      ({
+        legacy: `/tag/${slug}`,
+        destination: { pathname: "/", hash: "" },
+      }) satisfies LegacyRedirectRule,
+  ),
+  { legacy: "/blocks/*", destination: { pathname: "/", hash: "" } },
+];
+
+function normalizeLegacyPathname(pathname: string): string {
+  if (pathname.length <= 1) {
+    return pathname;
+  }
+
+  return pathname.replace(/\/+$/, "");
+}
+
+function matchesRule(pathname: string, legacy: string): boolean {
+  const normalized = normalizeLegacyPathname(pathname);
+
+  if (legacy.endsWith("*")) {
+    return normalized.startsWith(legacy.slice(0, -1));
+  }
+
+  return normalized === legacy;
+}
 
 export function getLegacyRedirectTarget(
   locale: Locale,
   pathname: string,
 ): LegacyRedirectTarget | null {
-  const fragment = legacyRedirects[pathname as keyof typeof legacyRedirects];
+  const rule = legacyRedirectRules.find((candidate) =>
+    matchesRule(pathname, candidate.legacy),
+  );
 
-  if (!fragment) {
+  if (!rule) {
     return null;
   }
 
   return {
-    pathname: getLocalizedPathname("/", locale),
-    hash: fragment,
+    pathname: getLocalizedPathname(rule.destination.pathname, locale),
+    hash: rule.destination.hash,
   };
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,15 +20,6 @@ export function proxy(request: NextRequest) {
 
   const requestHeaders = new Headers(request.headers);
 
-  if (pathnameLocale === defaultLocale) {
-    if (requestHeaders.get(localeRewriteHeader) === defaultLocale) {
-      return NextResponse.next({ request: { headers: requestHeaders } });
-    }
-
-    url.pathname = pathname.slice(defaultLocale.length + 1) || "/";
-    return NextResponse.redirect(url);
-  }
-
   const requestedLocale = pathnameLocale ?? defaultLocale;
   const legacyPathname = pathnameLocale
     ? pathname.slice(pathnameLocale.length + 1)
@@ -45,6 +36,15 @@ export function proxy(request: NextRequest) {
       ),
       301,
     );
+  }
+
+  if (pathnameLocale === defaultLocale) {
+    if (requestHeaders.get(localeRewriteHeader) === defaultLocale) {
+      return NextResponse.next({ request: { headers: requestHeaders } });
+    }
+
+    url.pathname = pathname.slice(defaultLocale.length + 1) || "/";
+    return NextResponse.redirect(url);
   }
 
   const normalizedPathname = normalizeTrailingSlash(pathname);


### PR DESCRIPTION
## Summary

Implements the owner-approved D7 redirect policy in the SEO/proxy layer plus a version-controlled cutover preflight tool, converting the remaining Phase 5 behavior into reviewable repo work so Issue #17 becomes a clean operational cutover.

- `src/features/seo/redirects.ts` — table-driven legacy redirect matrix per D7:
  - equivalent → equivalent (301): the six case-study slugs, `/resume`, `/case-studies`, `/category/case-studies` → `/#projects` / `/#resume`;
  - no equivalent → homepage (301): `/blog`, four tech-blog posts, `/category/tech-blog`, `/author/superuser`, the 18 inventory tags, and `/blocks/*` (wildcard).
  - Trailing-slash-insensitive matching; destinations are always localized roots with a fragment, so no chains.
- `src/proxy.ts` — legacy resolution now runs before default-`en` prefix canonicalization so `/en/<legacy>` URLs get one direct 301 (previously a chain).
- `src/features/seo/redirects.test.ts` — table-driven matrix tests (all rows × en/vi), query preservation, no-chain invariant, unknown-path guard, proxy-boundary 301/Location coverage including en-prefixed direct redirects.
- `scripts/preflight-cutover.ts` + `npm run preflight` — credential-free checks: EN/VI roots, seven legacy redirect spot checks, title/canonical/hreflang href validation, sitemap/robots, public asset, resume-media publicity gate, contact section render; exit 1 on failures.
- `docs/migration/cutover-runbook.md` — runbook with manual operator gates, check reference, post-cutover smoke checklist, and known limitations.

## Acceptance criteria

- [x] Full D7 redirect matrix implemented and table-tested.
- [x] Redirects preserve query strings, are locale-aware, permanent (301), and chain-free (including `/en/<legacy>` single-hop 301).
- [x] Cutover preflight script and runbook exist in-repo and run without credentials.
- [x] `lint`, `typecheck`, relevant tests, and production build pass.

## Verification

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 99/99 pass
- `npm run build` — passes (compiled + static pages generated; Turbopack path used, webpack fallback documented)
- Preflight: 19/19 green against local dev server; graceful fail (exit 1) against unreachable origin
- Direct curl: `/en/resume/?x=1` → 301 `/?x=1#resume`; `/en/blog/` → 301 `/` (single hop)

## Screenshots

N/A — no visual/UI change (redirect and ops tooling only).

## Risks / follow-ups

- Old WordPress CV PDF URLs are not in the matrix (exact upload paths unrecorded) — documented in the runbook; needs a D5 decision before any redirect.
- Contact delivery is only reachability-checked; live delivery requires a manual form submit against the production provider during #17.
- Preflight results are locally verified; GitHub Actions CI will confirm once this PR exists.

Closes #49