### PR TITLE
docs: record revised Phase 6 CMS plan and reshape CMS issues (closes #53)

### DIFF
--- a/docs/05-implementation-plan.md
+++ b/docs/05-implementation-plan.md
@@ -167,17 +167,36 @@
 
 ## Phase 6 — CMS (post-MVP)
 
-### Deliverables
+Phase 6 starts only after the Phase 5 production cutover (#17) is complete and the live site has shown stable IA/data behavior. It is an owner-operated, single-user admin — no teams/roles beyond owner, no public signup, no workflow approvals, no generic page builder.
 
-- Supabase schema
-- translation-aware content tables
-- admin authentication
-- CRUD for skills/projects/resume
-- media management
-- ordering/featured controls
-- publishing workflow as needed
-- preview/revalidation strategy
+### Goals
+
+- Runtime content management for profile, skills, projects, resume/CV, and links/contact — editable without commit + deploy.
+- Runtime resume publicity control (`private | visible`) without redeploy.
+- Content stays normalized behind the existing typed repository/view-model layer; the public UI never queries Supabase rows directly.
+
+### Architecture
+
+- Supabase is the runtime persistence layer for CMS-managed content and settings. A repository/service adapter converts database records into the same normalized typed view models the public components consume (locale validation, component contracts, accessibility, testability preserved).
+- Runtime settings (e.g. `resume.publicity`) are stored server-side and read from one authoritative source by the public page and the gated `/api/resume-media/*` route.
+- Resume privacy uses two independent gates: per-entity draft/published state, plus a global section `private | visible` publicity setting. Public rendering requires published AND visible; any read/config failure fails closed to private. Admin preview renders drafts only inside authenticated routes.
+- Media stays in private/managed storage and is served only through gated/server-authorized routes.
+
+### Slice sequencing
+
+1. #18 — Supabase schema, security, permissions (common design authority).
+2. #19 — single-owner authenticated admin foundation + runtime resume publicity setting.
+3. CRUD slice 1 (#20) — Profile + Contact/Social + Skills (establishes the DB/repository/editing pattern).
+4. CRUD slice 2 (#51) — Projects (featured/order, Live Demo/Code URL validation).
+5. CRUD slice 3 (#52) — Resume/CV with draft/preview/privacy controls (most security-sensitive; last).
+6. #21 — managed media/storage/publishing.
+
+### Exit criteria
+
+- Owner can update content and flip resume publicity in production without redeploying.
+- Public site behavior is unchanged or improved (view models still validated; accessibility/theme/locale preserved).
+- Resume stays fail-closed private by default; no private data reachable through public routes, storage URLs, or cache.
 
 ### Rule
 
-Do not start this phase merely because a field is inconvenient to edit locally. Start it after the public information architecture and data schema have stabilized.
+Do not start Phase 6 code before the Phase 5 cutover (#17) is complete and the live site has shown stable IA/data behavior.

--- a/docs/06-issue-breakdown.md
+++ b/docs/06-issue-breakdown.md
@@ -95,11 +95,27 @@ Requires rollback notes and redirect verification.
 
 ### Issue 18 — `design: specify Supabase portfolio CMS schema and permissions`
 
-### Issue 19 — `feat: implement authenticated portfolio admin shell`
+Common design authority. Translation-aware tables, RLS, runtime settings (resume publicity), the two-gate resume privacy model (per-entity draft/published + global private/visible publicity), repository/view-model adapter contract, media strategy, migration/backfill.
 
-### Issue 20 — `feat: add CMS management for projects skills and resume`
+### Issue 19 — `feat: implement authenticated portfolio admin foundation and runtime resume publicity`
+
+Owner-only auth + server-side authorization, no public signup, no browser secrets. Admin Settings screen toggling `resume.publicity = private | visible` (confirmation + changed-at/owner audit), fail-closed to private; public page and `/api/resume-media/*` read one authoritative value.
+
+### Issue 20 — `feat: add CMS CRUD for profile contact and skills`
+
+First CRUD slice (lowest risk): Profile, Contact/Social, Skills — EN/VI translations, URL validation, deterministic ordering, server-side reads/writes mapped into existing typed view models. Establishes the DB/repository/editing pattern.
+
+### Issue 51 — `feat: add CMS CRUD for projects`
+
+Second CRUD slice: featured/order, Live Demo/Code URL validation.
+
+### Issue 52 — `feat: add CMS CRUD for resume and CV`
+
+Third CRUD slice (most security-sensitive; last): resume categories/entries with draft/preview and the global publicity gate; private media served only through the gated route.
 
 ### Issue 21 — `feat: add CMS media management and publishing workflow`
+
+Postponed after the CRUD slices; expands the storage/security surface (permissions, private/public buckets, orphan cleanup, alt/caption translations, publishing behavior).
 
 ## Dependency graph
 


### PR DESCRIPTION
## Summary

Records the owner-approved revised Phase 6 CMS plan (content CRUD is an explicit core goal) and reshapes the CMS issues into bounded slices, per the ChatGPT review recommendation. No CMS code.

- `docs/05-implementation-plan.md` — Phase 6 rewritten: goals (runtime content + resume publicity control), architecture (Supabase runtime persistence + repository/view-model adapter contract; two-gate resume privacy fail-closed to private), slice sequencing (#18 → #19 → #20 → #51 → #52 → #21), exit criteria, #17-gated start rule.
- `docs/06-issue-breakdown.md` — post-MVP epic matches the new slice plan.
- GitHub issues reshaped: #18 (runtime settings + two-gate resume privacy added), #19 (auth foundation + runtime resume publicity), #20 (first CRUD slice: Profile + Contact/Social + Skills), new #51 (Projects CRUD) and #52 (Resume/CV CRUD, sequenced last).

## Acceptance criteria

- [x] Phase 6 plan and issue breakdown match the approved shape.
- [x] CMS issues split into bounded slices; resume/CV sequenced last.
- [x] No CMS code changes.

## Verification

Docs-only change (no code): `lint`, `typecheck`, tests, and build are not affected.

## Risks / follow-ups

- CMS implementation remains gated behind Issue #17 cutover per the plan.
- Issue #18 is the design authority; #19/#20/#51/#52/#21 all depend on its accepted schema.

Closes #53