### PR TITLE
chore(setup): add Supabase + Vercel MCP servers to opencode config

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -7,6 +7,23 @@
   // See https://github.com/obra/superpowers (docs/README.opencode.md).
   "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"],
 
+  // Supabase MCP: remote, DEV project only, read-only, project-scoped.
+  // Authenticate with: opencode mcp auth supabase (browser OAuth).
+  // Vercel MCP: remote, project-scoped to qvak-portfolio (watt6 team).
+  // Authenticate with: opencode mcp auth vercel (browser OAuth).
+  "mcp": {
+    "supabase": {
+      "type": "remote",
+      "url": "https://mcp.supabase.com/mcp?project_ref=lpxpzxbmmxnikerptcfq&read_only=true",
+      "enabled": true
+    },
+    "vercel": {
+      "type": "remote",
+      "url": "https://mcp.vercel.com/watt6/qvak-portfolio",
+      "enabled": true
+    }
+  },
+
   // Approved safe Git/GitHub permission policy.
   //
   // - Safe repository inspection, staging, and commits run without confirmation.


### PR DESCRIPTION
## What
Adds two remote MCP servers to `opencode.jsonc` (additive merge only — `plugin` and `permission` blocks untouched):

- `supabase`: `https://mcp.supabase.com/mcp?project_ref=lpxpzxbmmxnikerptcfq&read_only=true` — **DEV** project (`qvak-portfolio-dev`), **read-only**, project-scoped.
- `vercel`: `https://mcp.vercel.com/watt6/qvak-portfolio` — project-scoped to `qvak-portfolio` on the `watt6` team (project created 2026-08-18).

## Why
Configures OpenCode MCP access for the upcoming Supabase CMS phase per `~/OPENCODE_SUPABASE_VERCEL_SETUP_HANDOFF.md`. Supabase MCP is intentionally dev-only, read-only, and project-scoped per the plan's security policy.

## Verification
- `opencode mcp list` → both servers recognized ("needs authentication", expected — OAuth not yet completed).
- `vercel whoami` → `watt6` logged in.
- Supabase CLI `supabase projects list` confirms DEV project `qvak-portfolio-dev` (ref `lpxpzxbmmxnikerptcfq`).
- Config diff is additive; no secrets in diff (no tokens/keys, only public project refs/slugs).

## Follow-up (human-gated)
- `opencode mcp auth supabase` (browser OAuth)
- `opencode mcp auth vercel` (browser OAuth)
- Restart opencode; verify `opencode mcp list`

## Docs affected
- `~/OPENCODE_SUPABASE_VERCEL_SETUP_HANDOFF.md` — inputs table resolved.