### PR TITLE
ops: rename production domain to khoawatt.vercel.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quach Vo Anh Khoa — Portfolio Next.js
 
-Planning and implementation source of truth for migrating `quachvoanhkhoa.feaon.com` from WordPress to Next.js.
+Planning and implementation source of truth for migrating the legacy `quachvoanhkhoa.feaon.com` WordPress portfolio to Next.js at the production domain `khoawatt.vercel.app`.
 
 ## Goal
 

--- a/docs/00-product-brief.md
+++ b/docs/00-product-brief.md
@@ -4,7 +4,7 @@
 
 Personal portfolio for **Quach Vo Anh Khoa**, migrating from WordPress to Next.js at:
 
-- Production domain: `https://quachvoanhkhoa.feaon.com`
+- Production domain: `https://khoawatt.vercel.app`
 - Legacy resume: `https://quachvoanhkhoa.feaon.com/resume/`
 
 ## Problem

--- a/docs/06-issue-breakdown.md
+++ b/docs/06-issue-breakdown.md
@@ -87,7 +87,7 @@ Keep lightbox reusable and separately testable.
 
 Requires owner decisions captured in `docs/migration/owner-decision-capture.md` (created via issue #46). Do not guess unresolved inventory decisions.
 
-### Issue 17 — `ops: cut over quachvoanhkhoa.feaon.com to Next.js`
+### Issue 17 — `ops: cut over quachvoanhkhoa.feaon.com to khoawatt.vercel.app`
 
 Requires rollback notes and redirect verification.
 

--- a/docs/migration/cutover-runbook.md
+++ b/docs/migration/cutover-runbook.md
@@ -6,7 +6,7 @@ Owner policy source: `docs/migration/owner-decision-capture.md` (D7 redirect pol
 
 ## When to run
 
-Run before and immediately after the production release cutover for `quachvoanhkhoa.feaon.com`. The automated preflight should be **green** (no `FAIL` entries) before DNS/cutover, and re-run after cutover to confirm the live domain behaves as intended.
+Run before and immediately after the production release cutover to `khoawatt.vercel.app` (replacing the legacy WordPress site at `quachvoanhkhoa.feaon.com`). The automated preflight should be **green** (no `FAIL` entries) before DNS/cutover, and re-run after cutover to confirm the live domain behaves as intended.
 
 ## Prerequisites (external, human-executed)
 

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -9,7 +9,7 @@
 
   // Supabase MCP: remote, DEV project only, read-only, project-scoped.
   // Authenticate with: opencode mcp auth supabase (browser OAuth).
-  // Vercel MCP: remote, project-scoped to qvak-portfolio (watt6 team).
+  // Vercel MCP: remote, project-scoped to khoawatt (watt6 team).
   // Authenticate with: opencode mcp auth vercel (browser OAuth).
   "mcp": {
     "supabase": {
@@ -19,7 +19,7 @@
     },
     "vercel": {
       "type": "remote",
-      "url": "https://mcp.vercel.com/watt6/qvak-portfolio",
+      "url": "https://mcp.vercel.com/watt6/khoawatt",
       "enabled": true
     }
   },

--- a/scripts/preflight-cutover.ts
+++ b/scripts/preflight-cutover.ts
@@ -1,6 +1,6 @@
 import { argv, env, exit } from "node:process";
 
-const DEFAULT_ORIGIN = "https://quachvoanhkhoa.feaon.com";
+const DEFAULT_ORIGIN = "https://khoawatt.vercel.app";
 
 type Severity = "fail" | "info";
 

--- a/src/features/seo/config.ts
+++ b/src/features/seo/config.ts
@@ -1,4 +1,4 @@
-export const productionSiteUrl = "https://quachvoanhkhoa.feaon.com";
+export const productionSiteUrl = "https://khoawatt.vercel.app";
 
 export function getSiteUrl(): string {
   return (process.env.NEXT_PUBLIC_SITE_URL ?? productionSiteUrl).replace(


### PR DESCRIPTION
## What
Rename the production domain from `quachvoanhkhoa.feaon.com` to `khoawatt.vercel.app` (owner decision, confirmed in session).

- `src/features/seo/config.ts` — `productionSiteUrl` → `https://khoawatt.vercel.app`
- `scripts/preflight-cutover.ts` — `DEFAULT_ORIGIN` → `https://khoawatt.vercel.app`
- `opencode.jsonc` — Vercel MCP URL → `https://mcp.vercel.com/watt6/khoawatt`
- Docs updated (production-target references only): product brief, issue #17 breakdown, cutover runbook

**Kept as legacy-source references** (not changed): `wordpress-content-inventory.md` source site, product brief legacy resume line, issue #17 legacy domain in title.

## Vercel (already applied)
- Project renamed `qvak-portfolio` → `khoawatt` (`vercel project rename`, hosted-resource; safe — project ID immutable, local link + CI intact).

## Verification
- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm test` — 99/99 ✓

## Docs affected
- `docs/00-product-brief.md`, `docs/06-issue-breakdown.md`, `docs/migration/cutover-runbook.md`

## Note
Rename does not create a new custom domain; `khoawatt.vercel.app` is the Vercel-generated domain. New deployment required to serve at the new project name.