### PR TITLE
ops: set canonical production domain to khoawatt.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quach Vo Anh Khoa — Portfolio Next.js
 
-Planning and implementation source of truth for migrating the legacy `quachvoanhkhoa.feaon.com` WordPress portfolio to Next.js at the production domain `khoawatt.vercel.app`.
+Planning and implementation source of truth for migrating the legacy `quachvoanhkhoa.feaon.com` WordPress portfolio to Next.js at the production domain `khoawatt.com`.
 
 ## Goal
 

--- a/docs/00-product-brief.md
+++ b/docs/00-product-brief.md
@@ -4,7 +4,7 @@
 
 Personal portfolio for **Quach Vo Anh Khoa**, migrating from WordPress to Next.js at:
 
-- Production domain: `https://khoawatt.vercel.app`
+- Production domain: `https://khoawatt.com`
 - Legacy resume: `https://quachvoanhkhoa.feaon.com/resume/`
 
 ## Problem

--- a/docs/migration/cutover-runbook.md
+++ b/docs/migration/cutover-runbook.md
@@ -6,7 +6,7 @@ Owner policy source: `docs/migration/owner-decision-capture.md` (D7 redirect pol
 
 ## When to run
 
-Run before and immediately after the production release cutover to `khoawatt.vercel.app` (replacing the legacy WordPress site at `quachvoanhkhoa.feaon.com`). The automated preflight should be **green** (no `FAIL` entries) before DNS/cutover, and re-run after cutover to confirm the live domain behaves as intended.
+Run before and immediately after the production release cutover to `khoawatt.com` (replacing the legacy WordPress site at `quachvoanhkhoa.feaon.com`). The automated preflight should be **green** (no `FAIL` entries) before DNS/cutover, and re-run after cutover to confirm the live domain behaves as intended.
 
 ## Prerequisites (external, human-executed)
 

--- a/scripts/preflight-cutover.ts
+++ b/scripts/preflight-cutover.ts
@@ -1,6 +1,6 @@
 import { argv, env, exit } from "node:process";
 
-const DEFAULT_ORIGIN = "https://khoawatt.vercel.app";
+const DEFAULT_ORIGIN = "https://khoawatt.com";
 
 type Severity = "fail" | "info";
 

--- a/src/features/seo/config.ts
+++ b/src/features/seo/config.ts
@@ -1,4 +1,4 @@
-export const productionSiteUrl = "https://khoawatt.vercel.app";
+export const productionSiteUrl = "https://khoawatt.com";
 
 export function getSiteUrl(): string {
   return (process.env.NEXT_PUBLIC_SITE_URL ?? productionSiteUrl).replace(


### PR DESCRIPTION
## What changed

Production domain changed to `khoawatt.com` (custom domain, verified, serves the site). The previous default `khoawatt.vercel.app` alias was released and now returns 404, but canonical/sitemap/robots still pointed at it.

- `src/features/seo/config.ts`: `productionSiteUrl` → `https://khoawatt.com` (canonical, `/sitemap.xml`, `/robots.txt` Sitemap line)
- `scripts/preflight-cutover.ts`: `DEFAULT_ORIGIN` → `https://khoawatt.com`
- Docs updated: `README.md`, `docs/00-product-brief.md`, `docs/migration/cutover-runbook.md`

`NEXT_PUBLIC_SITE_URL` is not set on Vercel, so `productionSiteUrl` is the effective source.

## Tests run

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm test` — 99/99 pass ✓
- `npm run build` (Turbopack) ✓

## Visual verification

Config-only change (SEO metadata strings). No UI/visual change; sitemap/robots/canonical on production will reflect `khoawatt.com` after deploy.

## Known limitations

- Deployed to production only after merge (Vercel git integration auto-deploys `main`). Before that, the stale canonical references persist on the live site.
- Issue #17 remains open and is tracked separately: legacy hostname `quachvoanhkhoa.feaon.com` still serves WordPress, and the manual cutover gates (browser smoke, live contact submit, backup/rollback, preservation evidence) are not yet confirmed.

## Docs affected

`README.md`, `docs/00-product-brief.md`, `docs/migration/cutover-runbook.md` (production domain references). Issue title #17 and `docs/06-issue-breakdown.md` left as historical reference.

Refs #17
