### PR TITLE
feat: complete CMS CRUD for profile, contact/social, skills (Issue #20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/app/api/resume-media/route.test.ts",
     "preflight": "tsx scripts/preflight-cutover.ts",
     "seed:admin": "node scripts/seed-admin.mjs",
+    "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",
     "test:db": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node --test scripts/db-invariants.test.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "preflight": "tsx scripts/preflight-cutover.ts",
     "seed:admin": "node scripts/seed-admin.mjs",
     "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",
-    "test:db": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node --test scripts/db-invariants.test.mjs"
+    "test:db": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node --test scripts/db-invariants.test.mjs",
+    "test:rls": "supabase db test --local supabase/tests"
   },
   "dependencies": {
     "@supabase/ssr": "^0.12.4",

--- a/scripts/backfill-content.mjs
+++ b/scripts/backfill-content.mjs
@@ -67,7 +67,7 @@ async function backfillSkills() {
           category: skill.category?.vi ?? null,
         },
       ],
-      "id",
+      "skill_id,locale",
     );
   }
   console.log("Skills backfilled.");
@@ -83,6 +83,8 @@ async function backfillProfile() {
     [
       {
         slug: "owner",
+        name: portfolioProfile.name,
+        short_name: portfolioProfile.name.split(" ").pop() ?? null,
         github_url: portfolioProfile.githubUrl,
         linkedin_url: null,
         resume_url: null,
@@ -119,7 +121,7 @@ async function backfillProfile() {
         location: null,
       },
     ],
-    "id",
+    "profile_id,locale",
   );
   console.log("Profile backfilled.");
 }

--- a/scripts/backfill-content.mjs
+++ b/scripts/backfill-content.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Backfill CMS content (profile, contact/social, skills) into Supabase from
+ * the local typed content, preserving stable IDs and translations.
+ *
+ * Usage: NEXT_PUBLIC_SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... npm run backfill
+ *
+ * Requires a running Supabase and service-role key. Idempotent: uses
+ * upsert-on-conflict on stable IDs/slugs.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRole) {
+  console.error(
+    "Missing env: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY",
+  );
+  process.exit(1);
+}
+
+const client = createClient(url, serviceRole, {
+  auth: { persistSession: false },
+});
+
+async function upsert(table, rows, onConflict) {
+  if (rows.length === 0) return;
+  const { error } = await client.from(table).upsert(rows, { onConflict });
+  if (error) throw new Error(`${table}: ${error.message}`);
+  console.log(`${table}: upserted ${rows.length}`);
+}
+
+async function backfillSkills() {
+  const { skills } = await import("../src/content/skills.ts");
+
+  for (const skill of skills) {
+    await upsert(
+      "skills",
+      [
+        {
+          id: skill.id,
+          group_key: skill.group,
+          icon_key: skill.iconKey ?? null,
+          url: null,
+          order: skill.order,
+          featured: skill.featured ?? false,
+        },
+      ],
+      "id",
+    );
+
+    await upsert(
+      "skill_translations",
+      [
+        {
+          skill_id: skill.id,
+          locale: "en",
+          name: skill.name.en,
+          category: skill.category?.en ?? null,
+        },
+        {
+          skill_id: skill.id,
+          locale: "vi",
+          name: skill.name.vi,
+          category: skill.category?.vi ?? null,
+        },
+      ],
+      "id",
+    );
+  }
+  console.log("Skills backfilled.");
+}
+
+async function backfillProfile() {
+  const { portfolioProfile, getPortfolioProfile } = await import(
+    "../src/content/profile.ts"
+  );
+
+  await upsert(
+    "profile",
+    [
+      {
+        slug: "owner",
+        github_url: portfolioProfile.githubUrl,
+        linkedin_url: null,
+        resume_url: null,
+        phone: null,
+        email: null,
+      },
+    ],
+    "slug",
+  );
+
+  const profileIdRes = await client
+    .from("profile")
+    .select("id")
+    .eq("slug", "owner")
+    .maybeSingle();
+  const profileId = profileIdRes.data?.id;
+  if (!profileId) throw new Error("profile id not found");
+
+  await upsert(
+    "profile_translations",
+    [
+      {
+        profile_id: profileId,
+        locale: "en",
+        role: getPortfolioProfile("en").role,
+        intro: getPortfolioProfile("en").about.intro,
+        location: null,
+      },
+      {
+        profile_id: profileId,
+        locale: "vi",
+        role: getPortfolioProfile("vi").role,
+        intro: getPortfolioProfile("vi").about.intro,
+        location: null,
+      },
+    ],
+    "id",
+  );
+  console.log("Profile backfilled.");
+}
+
+async function backfillContact() {
+  const { contactDetails } = await import("../src/content/contact.ts");
+
+  for (const detail of Object.values(contactDetails)) {
+    await upsert(
+      "social_links",
+      [
+        {
+          id: detail.id,
+          label: detail.label.en,
+          url: detail.href,
+          icon_key: detail.id,
+          order: 1,
+        },
+      ],
+      "id",
+    );
+  }
+  console.log("Contact/social backfilled.");
+}
+
+async function main() {
+  await backfillSkills();
+  await backfillProfile();
+  await backfillContact();
+  console.log("Backfill complete.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,12 +8,14 @@ import { ProjectsSection } from "@/components/sections/projects/projects-section
 import { ResumeSection } from "@/components/sections/resume/resume-section";
 import { ResumeSectionLock } from "@/components/sections/resume/resume-section-lock";
 import { SkillsSection } from "@/components/sections/skills/skills-section";
-import { getContactContent } from "@/content/contact";
-import { getPortfolioProfile } from "@/content/profile";
 import { getFeaturedProjects } from "@/content/projects";
 import { getResumeContent, getResumeLockContent } from "@/content/resume";
 import { getResumePublicity } from "@/features/cms/resume-publicity";
-import { getSkillsContent } from "@/content/skills";
+import {
+  getContactContent as getCmsContact,
+  getPortfolioProfile as getCmsProfile,
+  getSkillsContent as getCmsSkills,
+} from "@/features/cms/repository";
 import { getMessages } from "@/features/i18n/messages";
 import { getLocaleFromParams } from "@/features/i18n/server";
 import { getSeoMetadata } from "@/features/seo/metadata";
@@ -41,10 +43,10 @@ export default async function LocalePage({
 }: Readonly<LocalePageProps>) {
   const locale = await getLocaleFromParams(params);
   const messages = await getMessages(locale);
-  const profile = getPortfolioProfile(locale);
-  const skills = getSkillsContent(locale);
+  const profile = await getCmsProfile(locale);
+  const skills = await getCmsSkills(locale);
   const projects = getFeaturedProjects(locale);
-  const contact = getContactContent(locale);
+  const contact = await getCmsContact(locale);
 
   const isResumePrivate = (await getResumePublicity()) === "private";
 

--- a/src/app/admin/(dashboard)/layout.tsx
+++ b/src/app/admin/(dashboard)/layout.tsx
@@ -5,7 +5,9 @@ import { isAdminUser } from "@/features/cms/session";
 
 const navLinks = [
   { href: "/admin/settings", label: "Settings" },
+  { href: "/admin/profile", label: "Profile" },
   { href: "/admin/skills", label: "Skills" },
+  { href: "/admin/social", label: "Social" },
 ] as const;
 
 export default async function AdminDashboardLayout({

--- a/src/app/admin/(dashboard)/layout.tsx
+++ b/src/app/admin/(dashboard)/layout.tsx
@@ -1,6 +1,12 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { isAdminUser } from "@/features/cms/session";
+
+const navLinks = [
+  { href: "/admin/settings", label: "Settings" },
+  { href: "/admin/skills", label: "Skills" },
+] as const;
 
 export default async function AdminDashboardLayout({
   children,
@@ -11,5 +17,16 @@ export default async function AdminDashboardLayout({
     redirect("/admin/login");
   }
 
-  return children;
+  return (
+    <>
+      <nav className="admin-nav" aria-label="Admin">
+        {navLinks.map((link) => (
+          <Link href={link.href} key={link.href}>
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+      {children}
+    </>
+  );
 }

--- a/src/app/admin/(dashboard)/profile/actions.ts
+++ b/src/app/admin/(dashboard)/profile/actions.ts
@@ -92,3 +92,17 @@ export async function updateProfile(
   revalidatePath("/vi");
   return { ok: true };
 }
+
+export async function deleteProfile(id: string): Promise<ProfileActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_delete_profile", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/profile");
+  return { ok: true };
+}

--- a/src/app/admin/(dashboard)/profile/actions.ts
+++ b/src/app/admin/(dashboard)/profile/actions.ts
@@ -2,8 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { getServiceClient } from "@/features/cms/server";
-import { isAdminUser } from "@/features/cms/session";
+import { getServerClient, isAdminUser } from "@/features/cms/session";
 import { isHttpUrl, required } from "@/features/cms/validation";
 
 export interface ProfileFormData {
@@ -56,20 +55,23 @@ export async function updateProfile(
   const invalid = validate(data);
   if (invalid) return invalid;
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
-  const { data: profile } = await client
+  // Profile is a required singleton keyed by the stable slug 'owner'. Resolve the
+  // existing row's id, or generate a fresh id to create it on first save.
+  const { data: existing } = await client
     .from("profile")
     .select("id")
-    .limit(1)
+    .eq("slug", "owner")
     .maybeSingle();
-  if (!profile) return { ok: false, error: "Profile not found." };
+  const profileId =
+    existing?.id ?? (crypto.randomUUID() as unknown as string);
 
   // Single-transaction write: base row + both translation rows roll back together
-  // on any failure (see migration cms_atomic_mutations).
+  // on any failure (see migration cms_atomic_mutations). Creates the singleton
+  // profile on first save and updates it thereafter.
   const { error } = await client.rpc("cms_upsert_profile", {
-    p_id: profile.id,
+    p_id: profileId,
     p_name: data.name.trim(),
     p_short_name: data.shortName.trim(),
     p_github_url: data.githubUrl || null,

--- a/src/app/admin/(dashboard)/profile/actions.ts
+++ b/src/app/admin/(dashboard)/profile/actions.ts
@@ -1,0 +1,92 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServiceClient } from "@/features/cms/server";
+import { isAdminUser } from "@/features/cms/session";
+import { isHttpUrl, required } from "@/features/cms/validation";
+
+export interface ProfileFormData {
+  name: string;
+  shortName: string;
+  githubUrl: string;
+  linkedinUrl: string;
+  resumeUrl: string;
+  phone: string;
+  email: string;
+  roleEn: string;
+  roleVi: string;
+  introEn: string;
+  introVi: string;
+  locationEn: string;
+  locationVi: string;
+}
+
+export interface ProfileActionResult {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Partial<Record<keyof ProfileFormData, string>>;
+}
+
+function validate(data: ProfileFormData): ProfileActionResult | null {
+  const errors: Partial<Record<keyof ProfileFormData, string>> = {};
+
+  if (!required(data.name)) errors.name = "Name is required.";
+  if (data.githubUrl && !isHttpUrl(data.githubUrl)) errors.githubUrl = "Must be http(s).";
+  if (data.linkedinUrl && !isHttpUrl(data.linkedinUrl)) errors.linkedinUrl = "Must be http(s).";
+  if (data.resumeUrl && !isHttpUrl(data.resumeUrl)) errors.resumeUrl = "Must be http(s).";
+  if (data.email && !isValidEmail(data.email)) errors.email = "Must be a valid email.";
+  if (!required(data.roleEn)) errors.roleEn = "EN role is required.";
+  if (!required(data.roleVi)) errors.roleVi = "VI role is required.";
+  if (!required(data.introEn)) errors.introEn = "EN intro is required.";
+  if (!required(data.introVi)) errors.introVi = "VI intro is required.";
+
+  if (Object.keys(errors).length > 0) return { ok: false, fieldErrors: errors };
+  return null;
+}
+
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export async function updateProfile(
+  data: ProfileFormData,
+): Promise<ProfileActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validate(data);
+  if (invalid) return invalid;
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { data: profile } = await client
+    .from("profile")
+    .select("id")
+    .limit(1)
+    .maybeSingle();
+  if (!profile) return { ok: false, error: "Profile not found." };
+
+  // Single-transaction write: base row + both translation rows roll back together
+  // on any failure (see migration cms_atomic_mutations).
+  const { error } = await client.rpc("cms_upsert_profile", {
+    p_id: profile.id,
+    p_name: data.name.trim(),
+    p_short_name: data.shortName.trim(),
+    p_github_url: data.githubUrl || null,
+    p_linkedin_url: data.linkedinUrl || null,
+    p_resume_url: data.resumeUrl || null,
+    p_phone: data.phone || null,
+    p_email: data.email || null,
+    p_role_en: data.roleEn.trim(),
+    p_role_vi: data.roleVi.trim(),
+    p_intro_en: data.introEn.trim(),
+    p_intro_vi: data.introVi.trim(),
+    p_location_en: data.locationEn || null,
+    p_location_vi: data.locationVi || null,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  return { ok: true };
+}

--- a/src/app/admin/(dashboard)/profile/data.ts
+++ b/src/app/admin/(dashboard)/profile/data.ts
@@ -18,6 +18,27 @@ export interface AdminProfileView {
   locationVi: string | null;
 }
 
+/** Empty default view used to render the profile form in create mode. */
+export function emptyProfileView(): AdminProfileView {
+  return {
+    id: "",
+    slug: "",
+    name: "",
+    shortName: "",
+    githubUrl: null,
+    linkedinUrl: null,
+    resumeUrl: null,
+    phone: null,
+    email: null,
+    roleEn: "",
+    roleVi: "",
+    introEn: "",
+    introVi: "",
+    locationEn: null,
+    locationVi: null,
+  };
+}
+
 export async function getProfileView(): Promise<AdminProfileView | null> {
   const client = await getServerClient();
 

--- a/src/app/admin/(dashboard)/profile/data.ts
+++ b/src/app/admin/(dashboard)/profile/data.ts
@@ -1,0 +1,60 @@
+import { getServiceClient } from "@/features/cms/server";
+
+export interface AdminProfileView {
+  id: string;
+  slug: string;
+  name: string;
+  shortName: string;
+  githubUrl: string | null;
+  linkedinUrl: string | null;
+  resumeUrl: string | null;
+  phone: string | null;
+  email: string | null;
+  roleEn: string;
+  roleVi: string;
+  introEn: string;
+  introVi: string;
+  locationEn: string | null;
+  locationVi: string | null;
+}
+
+export async function getProfileView(): Promise<AdminProfileView | null> {
+  const client = getServiceClient();
+  if (!client) return null;
+
+  const { data, error } = await client
+    .from("profile")
+    .select(
+      "id, slug, name, short_name, github_url, linkedin_url, resume_url, phone, email, profile_translations(locale, role, intro, location)",
+    )
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  const translations = (data.profile_translations ?? []) as Array<{
+    locale: string;
+    role: string;
+    intro: string;
+    location: string | null;
+  }>;
+  const en = translations.find((t) => t.locale === "en");
+  const vi = translations.find((t) => t.locale === "vi");
+
+  return {
+    id: data.id,
+    slug: data.slug,
+    name: data.name ?? "",
+    shortName: data.short_name ?? "",
+    githubUrl: data.github_url,
+    linkedinUrl: data.linkedin_url,
+    resumeUrl: data.resume_url,
+    phone: data.phone,
+    email: data.email,
+    roleEn: en?.role ?? "",
+    roleVi: vi?.role ?? "",
+    introEn: en?.intro ?? "",
+    introVi: vi?.intro ?? "",
+    locationEn: en?.location ?? null,
+    locationVi: vi?.location ?? null,
+  };
+}

--- a/src/app/admin/(dashboard)/profile/data.ts
+++ b/src/app/admin/(dashboard)/profile/data.ts
@@ -1,4 +1,4 @@
-import { getServiceClient } from "@/features/cms/server";
+import { getServerClient } from "@/features/cms/session";
 
 export interface AdminProfileView {
   id: string;
@@ -19,8 +19,7 @@ export interface AdminProfileView {
 }
 
 export async function getProfileView(): Promise<AdminProfileView | null> {
-  const client = getServiceClient();
-  if (!client) return null;
+  const client = await getServerClient();
 
   const { data, error } = await client
     .from("profile")

--- a/src/app/admin/(dashboard)/profile/page.tsx
+++ b/src/app/admin/(dashboard)/profile/page.tsx
@@ -14,7 +14,10 @@ export default async function AdminProfilePage() {
       {profile ? (
         <ProfileForm initial={profile} />
       ) : (
-        <p className="admin-message">No profile record found. Run the backfill script first.</p>
+        <p className="admin-message">
+          No profile record found. Run the migration/backfill to seed the profile
+          singleton (slug &quot;owner&quot;).
+        </p>
       )}
     </main>
   );

--- a/src/app/admin/(dashboard)/profile/page.tsx
+++ b/src/app/admin/(dashboard)/profile/page.tsx
@@ -1,0 +1,21 @@
+import { getProfileView } from "./data";
+import { ProfileForm } from "./profile-form";
+
+export const metadata = {
+  title: "Admin profile",
+};
+
+export default async function AdminProfilePage() {
+  const profile = await getProfileView();
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Profile</h1>
+      {profile ? (
+        <ProfileForm initial={profile} />
+      ) : (
+        <p className="admin-message">No profile record found. Run the backfill script first.</p>
+      )}
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/profile/page.tsx
+++ b/src/app/admin/(dashboard)/profile/page.tsx
@@ -1,4 +1,4 @@
-import { getProfileView } from "./data";
+import { emptyProfileView, getProfileView } from "./data";
 import { ProfileForm } from "./profile-form";
 
 export const metadata = {
@@ -6,19 +6,12 @@ export const metadata = {
 };
 
 export default async function AdminProfilePage() {
-  const profile = await getProfileView();
+  const profile = (await getProfileView()) ?? emptyProfileView();
 
   return (
     <main className="admin-dashboard">
       <h1>Profile</h1>
-      {profile ? (
-        <ProfileForm initial={profile} />
-      ) : (
-        <p className="admin-message">
-          No profile record found. Run the migration/backfill to seed the profile
-          singleton (slug &quot;owner&quot;).
-        </p>
-      )}
+      <ProfileForm initial={profile} />
     </main>
   );
 }

--- a/src/app/admin/(dashboard)/profile/profile-form.tsx
+++ b/src/app/admin/(dashboard)/profile/profile-form.tsx
@@ -4,7 +4,11 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import type { AdminProfileView } from "./data";
-import { updateProfile, type ProfileActionResult } from "./actions";
+import {
+  deleteProfile,
+  updateProfile,
+  type ProfileActionResult,
+} from "./actions";
 
 interface ProfileFormProps {
   initial: AdminProfileView;
@@ -14,6 +18,26 @@ export function ProfileForm({ initial }: ProfileFormProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [isDeleting, startDelete] = useTransition();
+
+  function handleDelete() {
+    if (
+      !confirm(
+        `Delete this profile? The public page will fall back to local content until you save a new profile.`,
+      )
+    ) {
+      return;
+    }
+
+    startDelete(async () => {
+      const result = await deleteProfile(initial.id);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to delete.");
+      }
+    });
+  }
 
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -114,9 +138,19 @@ export function ProfileForm({ initial }: ProfileFormProps) {
         </p>
       ) : null}
 
-      <button disabled={isPending} type="submit">
-        {isPending ? "Saving…" : "Save profile"}
-      </button>
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : "Save profile"}
+        </button>
+        <button
+          className="admin-link-button admin-link-button--danger"
+          disabled={isDeleting}
+          onClick={handleDelete}
+          type="button"
+        >
+          {isDeleting ? "Deleting…" : "Delete profile"}
+        </button>
+      </div>
     </form>
   );
 }

--- a/src/app/admin/(dashboard)/profile/profile-form.tsx
+++ b/src/app/admin/(dashboard)/profile/profile-form.tsx
@@ -142,14 +142,16 @@ export function ProfileForm({ initial }: ProfileFormProps) {
         <button disabled={isPending} type="submit">
           {isPending ? "Saving…" : "Save profile"}
         </button>
-        <button
-          className="admin-link-button admin-link-button--danger"
-          disabled={isDeleting}
-          onClick={handleDelete}
-          type="button"
-        >
-          {isDeleting ? "Deleting…" : "Delete profile"}
-        </button>
+        {initial.id ? (
+          <button
+            className="admin-link-button admin-link-button--danger"
+            disabled={isDeleting}
+            onClick={handleDelete}
+            type="button"
+          >
+            {isDeleting ? "Deleting…" : "Delete profile"}
+          </button>
+        ) : null}
       </div>
     </form>
   );

--- a/src/app/admin/(dashboard)/profile/profile-form.tsx
+++ b/src/app/admin/(dashboard)/profile/profile-form.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AdminProfileView } from "./data";
+import { updateProfile, type ProfileActionResult } from "./actions";
+
+interface ProfileFormProps {
+  initial: AdminProfileView;
+}
+
+export function ProfileForm({ initial }: ProfileFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+
+    const data = {
+      name: String(fd.get("name") ?? ""),
+      shortName: String(fd.get("shortName") ?? ""),
+      githubUrl: String(fd.get("githubUrl") ?? ""),
+      linkedinUrl: String(fd.get("linkedinUrl") ?? ""),
+      resumeUrl: String(fd.get("resumeUrl") ?? ""),
+      phone: String(fd.get("phone") ?? ""),
+      email: String(fd.get("email") ?? ""),
+      roleEn: String(fd.get("roleEn") ?? ""),
+      roleVi: String(fd.get("roleVi") ?? ""),
+      introEn: String(fd.get("introEn") ?? ""),
+      introVi: String(fd.get("introVi") ?? ""),
+      locationEn: String(fd.get("locationEn") ?? ""),
+      locationVi: String(fd.get("locationVi") ?? ""),
+    };
+
+    startTransition(async () => {
+      const result: ProfileActionResult = await updateProfile(data);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.fieldErrors ? Object.values(result.fieldErrors).join(" ") : (result.error ?? "Failed."));
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      <label className="admin-field">
+        <span>Name</span>
+        <input name="name" required defaultValue={initial.name} />
+      </label>
+      <label className="admin-field">
+        <span>Short name</span>
+        <input name="shortName" defaultValue={initial.shortName} />
+      </label>
+
+      <h3>Links</h3>
+      <label className="admin-field">
+        <span>GitHub URL</span>
+        <input name="githubUrl" defaultValue={initial.githubUrl ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>LinkedIn URL</span>
+        <input name="linkedinUrl" defaultValue={initial.linkedinUrl ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Resume URL</span>
+        <input name="resumeUrl" defaultValue={initial.resumeUrl ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Email</span>
+        <input name="email" type="email" defaultValue={initial.email ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Phone</span>
+        <input name="phone" defaultValue={initial.phone ?? ""} />
+      </label>
+
+      <h3>Role</h3>
+      <label className="admin-field">
+        <span>Role (EN)</span>
+        <input name="roleEn" required defaultValue={initial.roleEn} />
+      </label>
+      <label className="admin-field">
+        <span>Role (VI)</span>
+        <input name="roleVi" required defaultValue={initial.roleVi} />
+      </label>
+
+      <h3>About intro</h3>
+      <label className="admin-field">
+        <span>Intro (EN)</span>
+        <textarea name="introEn" required rows={4} defaultValue={initial.introEn} />
+      </label>
+      <label className="admin-field">
+        <span>Intro (VI)</span>
+        <textarea name="introVi" required rows={4} defaultValue={initial.introVi} />
+      </label>
+
+      <h3>Location</h3>
+      <label className="admin-field">
+        <span>Location (EN)</span>
+        <input name="locationEn" defaultValue={initial.locationEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Location (VI)</span>
+        <input name="locationVi" defaultValue={initial.locationVi ?? ""} />
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <button disabled={isPending} type="submit">
+        {isPending ? "Saving…" : "Save profile"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/skills/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/skills/[id]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+
+import { getSkill } from "../data";
+import { SkillForm } from "../skill-form";
+
+interface AdminEditSkillPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "Edit skill",
+};
+
+export default async function AdminEditSkillPage({
+  params,
+}: AdminEditSkillPageProps) {
+  const { id } = await params;
+  const skill = await getSkill(id);
+
+  if (!skill) {
+    notFound();
+  }
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Edit skill</h1>
+      <SkillForm existing={skill} />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/skills/actions.ts
+++ b/src/app/admin/(dashboard)/skills/actions.ts
@@ -50,31 +50,21 @@ export async function createSkill(
   const client = getServiceClient();
   if (!client) return { ok: false, error: "CMS is not configured." };
 
-  const { error: baseError } = await client.from("skills").insert({
-    id: data.id,
-    group_key: data.group,
-    icon_key: data.iconKey ?? null,
-    url: data.url || null,
-    order: data.order,
-    featured: data.featured,
+  // Single-transaction write: base row + both translation rows roll back together
+  // on any failure (see migration cms_atomic_mutations).
+  const { error } = await client.rpc("cms_upsert_skill", {
+    p_id: data.id,
+    p_group_key: data.group,
+    p_icon_key: data.iconKey ?? null,
+    p_url: data.url || null,
+    p_order: data.order,
+    p_featured: data.featured,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+    p_category_en: data.categoryEn?.trim() || null,
+    p_category_vi: data.categoryVi?.trim() || null,
   });
-  if (baseError) return { ok: false, error: baseError.message };
-
-  const { error: transError } = await client.from("skill_translations").insert([
-    {
-      skill_id: data.id,
-      locale: "en",
-      name: data.nameEn,
-      category: data.categoryEn || null,
-    },
-    {
-      skill_id: data.id,
-      locale: "vi",
-      name: data.nameVi,
-      category: data.categoryVi || null,
-    },
-  ]);
-  if (transError) return { ok: false, error: transError.message };
+  if (error) return { ok: false, error: error.message };
 
   revalidatePath("/");
   revalidatePath("/vi");
@@ -92,36 +82,19 @@ export async function updateSkill(
   const client = getServiceClient();
   if (!client) return { ok: false, error: "CMS is not configured." };
 
-  const { error: baseError } = await client
-    .from("skills")
-    .update({
-      group_key: data.group,
-      icon_key: data.iconKey ?? null,
-      url: data.url || null,
-      order: data.order,
-      featured: data.featured,
-    })
-    .eq("id", data.id);
-  if (baseError) return { ok: false, error: baseError.message };
-
-  const { error: transError } = await client.from("skill_translations").upsert(
-    [
-      {
-        skill_id: data.id,
-        locale: "en",
-        name: data.nameEn,
-        category: data.categoryEn || null,
-      },
-      {
-        skill_id: data.id,
-        locale: "vi",
-        name: data.nameVi,
-        category: data.categoryVi || null,
-      },
-    ],
-    { onConflict: "skill_id,locale" },
-  );
-  if (transError) return { ok: false, error: transError.message };
+  const { error } = await client.rpc("cms_upsert_skill", {
+    p_id: data.id,
+    p_group_key: data.group,
+    p_icon_key: data.iconKey ?? null,
+    p_url: data.url || null,
+    p_order: data.order,
+    p_featured: data.featured,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+    p_category_en: data.categoryEn?.trim() || null,
+    p_category_vi: data.categoryVi?.trim() || null,
+  });
+  if (error) return { ok: false, error: error.message };
 
   revalidatePath("/");
   revalidatePath("/vi");
@@ -135,7 +108,7 @@ export async function deleteSkill(id: string): Promise<SkillActionResult> {
   const client = getServiceClient();
   if (!client) return { ok: false, error: "CMS is not configured." };
 
-  const { error } = await client.from("skills").delete().eq("id", id);
+  const { error } = await client.rpc("cms_delete_skill", { p_id: id });
   if (error) return { ok: false, error: error.message };
 
   revalidatePath("/");

--- a/src/app/admin/(dashboard)/skills/actions.ts
+++ b/src/app/admin/(dashboard)/skills/actions.ts
@@ -1,0 +1,145 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServiceClient } from "@/features/cms/server";
+import { isAdminUser } from "@/features/cms/session";
+import { isHttpUrl, required } from "@/features/cms/validation";
+import type { SkillGroup } from "@/content/skills";
+
+export interface SkillFormData {
+  id: string;
+  nameEn: string;
+  nameVi: string;
+  group: SkillGroup;
+  categoryEn?: string;
+  categoryVi?: string;
+  iconKey?: string;
+  url?: string;
+  order: number;
+  featured: boolean;
+}
+
+export interface SkillActionResult {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Partial<Record<keyof SkillFormData, string>>;
+}
+
+function validate(data: SkillFormData): SkillActionResult | null {
+  const errors: Partial<Record<keyof SkillFormData, string>> = {};
+
+  if (!required(data.id)) errors.id = "Skill ID is required.";
+  if (!required(data.nameEn)) errors.nameEn = "EN name is required.";
+  if (!required(data.nameVi)) errors.nameVi = "VI name is required.";
+  if (data.url && !isHttpUrl(data.url)) errors.url = "URL must be http(s).";
+
+  if (Object.keys(errors).length > 0) {
+    return { ok: false, fieldErrors: errors };
+  }
+  return null;
+}
+
+export async function createSkill(
+  data: SkillFormData,
+): Promise<SkillActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validate(data);
+  if (invalid) return invalid;
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { error: baseError } = await client.from("skills").insert({
+    id: data.id,
+    group_key: data.group,
+    icon_key: data.iconKey ?? null,
+    url: data.url || null,
+    order: data.order,
+    featured: data.featured,
+  });
+  if (baseError) return { ok: false, error: baseError.message };
+
+  const { error: transError } = await client.from("skill_translations").insert([
+    {
+      skill_id: data.id,
+      locale: "en",
+      name: data.nameEn,
+      category: data.categoryEn || null,
+    },
+    {
+      skill_id: data.id,
+      locale: "vi",
+      name: data.nameVi,
+      category: data.categoryVi || null,
+    },
+  ]);
+  if (transError) return { ok: false, error: transError.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/skills");
+  return { ok: true };
+}
+
+export async function updateSkill(
+  data: SkillFormData,
+): Promise<SkillActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validate(data);
+  if (invalid) return invalid;
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { error: baseError } = await client
+    .from("skills")
+    .update({
+      group_key: data.group,
+      icon_key: data.iconKey ?? null,
+      url: data.url || null,
+      order: data.order,
+      featured: data.featured,
+    })
+    .eq("id", data.id);
+  if (baseError) return { ok: false, error: baseError.message };
+
+  const { error: transError } = await client.from("skill_translations").upsert(
+    [
+      {
+        skill_id: data.id,
+        locale: "en",
+        name: data.nameEn,
+        category: data.categoryEn || null,
+      },
+      {
+        skill_id: data.id,
+        locale: "vi",
+        name: data.nameVi,
+        category: data.categoryVi || null,
+      },
+    ],
+    { onConflict: "skill_id,locale" },
+  );
+  if (transError) return { ok: false, error: transError.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/skills");
+  return { ok: true };
+}
+
+export async function deleteSkill(id: string): Promise<SkillActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { error } = await client.from("skills").delete().eq("id", id);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/skills");
+  return { ok: true };
+}

--- a/src/app/admin/(dashboard)/skills/actions.ts
+++ b/src/app/admin/(dashboard)/skills/actions.ts
@@ -2,8 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { getServiceClient } from "@/features/cms/server";
-import { isAdminUser } from "@/features/cms/session";
+import { getServerClient, isAdminUser } from "@/features/cms/session";
 import { isHttpUrl, required } from "@/features/cms/validation";
 import type { SkillGroup } from "@/content/skills";
 
@@ -47,8 +46,7 @@ export async function createSkill(
   const invalid = validate(data);
   if (invalid) return invalid;
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
   // Single-transaction write: base row + both translation rows roll back together
   // on any failure (see migration cms_atomic_mutations).
@@ -79,8 +77,7 @@ export async function updateSkill(
   const invalid = validate(data);
   if (invalid) return invalid;
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
   const { error } = await client.rpc("cms_upsert_skill", {
     p_id: data.id,
@@ -105,8 +102,7 @@ export async function updateSkill(
 export async function deleteSkill(id: string): Promise<SkillActionResult> {
   if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
   const { error } = await client.rpc("cms_delete_skill", { p_id: id });
   if (error) return { ok: false, error: error.message };

--- a/src/app/admin/(dashboard)/skills/data.ts
+++ b/src/app/admin/(dashboard)/skills/data.ts
@@ -22,7 +22,8 @@ export async function listSkills(): Promise<AdminSkillRow[]> {
     .from("skills")
     .select("id, group_key, icon_key, url, order, featured, skill_translations(locale, name, category)")
     .order("group_key")
-    .order("order");
+    .order("order")
+    .order("id");
 
   if (error || !data) return [];
 

--- a/src/app/admin/(dashboard)/skills/data.ts
+++ b/src/app/admin/(dashboard)/skills/data.ts
@@ -1,4 +1,4 @@
-import { getServiceClient } from "@/features/cms/server";
+import { getServerClient } from "@/features/cms/session";
 import type { SkillGroup } from "@/content/skills";
 
 export interface AdminSkillRow {
@@ -15,8 +15,7 @@ export interface AdminSkillRow {
 }
 
 export async function listSkills(): Promise<AdminSkillRow[]> {
-  const client = getServiceClient();
-  if (!client) return [];
+  const client = await getServerClient();
 
   const { data, error } = await client
     .from("skills")

--- a/src/app/admin/(dashboard)/skills/data.ts
+++ b/src/app/admin/(dashboard)/skills/data.ts
@@ -1,0 +1,56 @@
+import { getServiceClient } from "@/features/cms/server";
+import type { SkillGroup } from "@/content/skills";
+
+export interface AdminSkillRow {
+  id: string;
+  group: SkillGroup;
+  iconKey: string | null;
+  url: string | null;
+  order: number;
+  featured: boolean;
+  nameEn: string;
+  nameVi: string;
+  categoryEn: string | null;
+  categoryVi: string | null;
+}
+
+export async function listSkills(): Promise<AdminSkillRow[]> {
+  const client = getServiceClient();
+  if (!client) return [];
+
+  const { data, error } = await client
+    .from("skills")
+    .select("id, group_key, icon_key, url, order, featured, skill_translations(locale, name, category)")
+    .order("group_key")
+    .order("order");
+
+  if (error || !data) return [];
+
+  return data.map((skill) => {
+    const translations = (skill.skill_translations ?? []) as Array<{
+      locale: string;
+      name: string;
+      category: string | null;
+    }>;
+    const en = translations.find((t) => t.locale === "en");
+    const vi = translations.find((t) => t.locale === "vi");
+
+    return {
+      id: skill.id,
+      group: skill.group_key as SkillGroup,
+      iconKey: skill.icon_key,
+      url: skill.url,
+      order: skill.order,
+      featured: skill.featured,
+      nameEn: en?.name ?? "",
+      nameVi: vi?.name ?? "",
+      categoryEn: en?.category ?? null,
+      categoryVi: vi?.category ?? null,
+    };
+  });
+}
+
+export async function getSkill(id: string): Promise<AdminSkillRow | null> {
+  const rows = await listSkills();
+  return rows.find((row) => row.id === id) ?? null;
+}

--- a/src/app/admin/(dashboard)/skills/delete-skill.tsx
+++ b/src/app/admin/(dashboard)/skills/delete-skill.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteSkill } from "./actions";
+
+interface DeleteSkillButtonProps {
+  id: string;
+  name: string;
+}
+
+export function DeleteSkillButton({ id, name }: DeleteSkillButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm(`Delete skill "${name}"?`)) return;
+
+    startTransition(async () => {
+      const result = await deleteSkill(id);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to delete.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        className="admin-link-button admin-link-button--danger"
+        disabled={isPending}
+        onClick={handleDelete}
+        type="button"
+      >
+        {isPending ? "…" : "Delete"}
+      </button>
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/skills/new/page.tsx
+++ b/src/app/admin/(dashboard)/skills/new/page.tsx
@@ -1,0 +1,14 @@
+import { SkillForm } from "../skill-form";
+
+export const metadata = {
+  title: "New skill",
+};
+
+export default function AdminNewSkillPage() {
+  return (
+    <main className="admin-dashboard">
+      <h1>New skill</h1>
+      <SkillForm />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/skills/page.tsx
+++ b/src/app/admin/(dashboard)/skills/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+import { listSkills } from "./data";
+import { DeleteSkillButton } from "./delete-skill";
+
+export const metadata = {
+  title: "Admin skills",
+};
+
+export default async function AdminSkillsPage() {
+  const skills = await listSkills();
+
+  return (
+    <main className="admin-dashboard">
+      <div className="admin-page-head">
+        <h1>Skills</h1>
+        <Link className="admin-button" href="/admin/skills/new">
+          New skill
+        </Link>
+      </div>
+
+      <table className="admin-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Group</th>
+            <th>Order</th>
+            <th>Featured</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {skills.map((skill) => (
+            <tr key={skill.id}>
+              <td>{skill.id}</td>
+              <td>{skill.nameEn}</td>
+              <td>{skill.group}</td>
+              <td>{skill.order}</td>
+              <td>{skill.featured ? "✓" : ""}</td>
+              <td className="admin-row-actions">
+                <Link href={`/admin/skills/${skill.id}`}>Edit</Link>
+                <DeleteSkillButton id={skill.id} name={skill.nameEn} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/skills/skill-form.tsx
+++ b/src/app/admin/(dashboard)/skills/skill-form.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { SkillGroup } from "@/content/skills";
+import type { AdminSkillRow } from "./data";
+import { createSkill, updateSkill, type SkillActionResult } from "./actions";
+
+const iconOptions = [
+  "typescript",
+  "javascript",
+  "react",
+  "nextjs",
+  "nodejs",
+  "nestjs",
+  "postgresql",
+  "wordpress",
+] as const;
+
+interface SkillFormProps {
+  existing?: AdminSkillRow;
+}
+
+export function SkillForm({ existing }: SkillFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const fd = new FormData(form);
+
+    const data = {
+      id: existing?.id ?? String(fd.get("id") ?? ""),
+      nameEn: String(fd.get("nameEn") ?? ""),
+      nameVi: String(fd.get("nameVi") ?? ""),
+      group: String(fd.get("group") ?? "tech-stack") as SkillGroup,
+      categoryEn: String(fd.get("categoryEn") ?? ""),
+      categoryVi: String(fd.get("categoryVi") ?? ""),
+      iconKey: String(fd.get("iconKey") ?? "") || undefined,
+      url: String(fd.get("url") ?? ""),
+      order: Number(fd.get("order") ?? 0),
+      featured: fd.get("featured") === "on",
+    };
+
+    startTransition(async () => {
+      const result: SkillActionResult = existing
+        ? await updateSkill(data)
+        : await createSkill(data);
+      if (result.ok) {
+        router.push("/admin/skills");
+        router.refresh();
+      } else {
+        setError(result.fieldErrors ? Object.values(result.fieldErrors).join(" ") : (result.error ?? "Failed."));
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      {!existing ? (
+        <label className="admin-field">
+          <span>Skill ID (slug)</span>
+          <input name="id" required defaultValue="" />
+        </label>
+      ) : null}
+
+      <label className="admin-field">
+        <span>Name (EN)</span>
+        <input name="nameEn" required defaultValue={existing?.nameEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Name (VI)</span>
+        <input name="nameVi" required defaultValue={existing?.nameVi ?? ""} />
+      </label>
+
+      <label className="admin-field">
+        <span>Group</span>
+        <select name="group" defaultValue={existing?.group ?? "tech-stack"}>
+          <option value="tech-stack">Tech Stack</option>
+          <option value="others">Others</option>
+        </select>
+      </label>
+
+      <label className="admin-field">
+        <span>Category (EN) — Others only</span>
+        <input name="categoryEn" defaultValue={existing?.categoryEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Category (VI) — Others only</span>
+        <input name="categoryVi" defaultValue={existing?.categoryVi ?? ""} />
+      </label>
+
+      <label className="admin-field">
+        <span>Icon key</span>
+        <select name="iconKey" defaultValue={existing?.iconKey ?? ""}>
+          <option value="">None</option>
+          {iconOptions.map((icon) => (
+            <option key={icon} value={icon}>
+              {icon}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="admin-field">
+        <span>URL (optional, http/https)</span>
+        <input name="url" defaultValue={existing?.url ?? ""} />
+      </label>
+
+      <label className="admin-field">
+        <span>Order</span>
+        <input name="order" type="number" defaultValue={existing?.order ?? 0} />
+      </label>
+
+      <label className="admin-check">
+        <input name="featured" type="checkbox" defaultChecked={existing?.featured} />
+        <span>Featured</span>
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <button disabled={isPending} type="submit">
+        {isPending ? "Saving…" : existing ? "Update skill" : "Create skill"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/social/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/social/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from "next/navigation";
+
+import { listSocialLinks } from "../data";
+import { SocialLinkForm } from "../social-form";
+
+interface AdminEditSocialPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "Edit social link",
+};
+
+export default async function AdminEditSocialPage({
+  params,
+}: AdminEditSocialPageProps) {
+  const { id } = await params;
+  const links = await listSocialLinks();
+  const link = links.find((item) => item.id === id);
+
+  if (!link) {
+    notFound();
+  }
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Edit social link</h1>
+      <SocialLinkForm existing={link} />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/social/actions.ts
+++ b/src/app/admin/(dashboard)/social/actions.ts
@@ -1,0 +1,95 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServiceClient } from "@/features/cms/server";
+import { isAdminUser } from "@/features/cms/session";
+import { isHttpUrl, required } from "@/features/cms/validation";
+
+export interface SocialLinkFormData {
+  id?: string;
+  label: string;
+  url: string;
+  iconKey?: string;
+  order: number;
+}
+
+export interface SocialActionResult {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Partial<Record<keyof SocialLinkFormData, string>>;
+}
+
+function validate(data: SocialLinkFormData): SocialActionResult | null {
+  const errors: Partial<Record<keyof SocialLinkFormData, string>> = {};
+  if (!required(data.label)) errors.label = "Label is required.";
+  if (!required(data.url)) errors.url = "URL is required.";
+  else if (!isHttpUrl(data.url)) errors.url = "URL must be http(s).";
+  if (Object.keys(errors).length > 0) return { ok: false, fieldErrors: errors };
+  return null;
+}
+
+export async function createSocialLink(
+  data: SocialLinkFormData,
+): Promise<SocialActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validate(data);
+  if (invalid) return invalid;
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { error } = await client.rpc("cms_upsert_social", {
+    p_id: data.id && data.id.length > 0 ? data.id : data.label.toLowerCase().replaceAll(" ", "-"),
+    p_label: data.label.trim(),
+    p_url: data.url.trim(),
+    p_icon_key: data.iconKey || null,
+    p_order: data.order,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/social");
+  return { ok: true };
+}
+
+export async function updateSocialLink(
+  data: SocialLinkFormData,
+): Promise<SocialActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validate(data);
+  if (invalid) return invalid;
+  if (!data.id) return { ok: false, error: "Missing id." };
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { error } = await client.rpc("cms_upsert_social", {
+    p_id: data.id,
+    p_label: data.label.trim(),
+    p_url: data.url.trim(),
+    p_icon_key: data.iconKey || null,
+    p_order: data.order,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/social");
+  return { ok: true };
+}
+
+export async function deleteSocialLink(id: string): Promise<SocialActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { error } = await client.rpc("cms_delete_social", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/social");
+  return { ok: true };
+}

--- a/src/app/admin/(dashboard)/social/actions.ts
+++ b/src/app/admin/(dashboard)/social/actions.ts
@@ -2,8 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { getServiceClient } from "@/features/cms/server";
-import { isAdminUser } from "@/features/cms/session";
+import { getServerClient, isAdminUser } from "@/features/cms/session";
 import { isHttpUrl, required } from "@/features/cms/validation";
 
 export interface SocialLinkFormData {
@@ -36,8 +35,7 @@ export async function createSocialLink(
   const invalid = validate(data);
   if (invalid) return invalid;
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
   const { error } = await client.rpc("cms_upsert_social", {
     p_id: data.id && data.id.length > 0 ? data.id : data.label.toLowerCase().replaceAll(" ", "-"),
@@ -62,8 +60,7 @@ export async function updateSocialLink(
   if (invalid) return invalid;
   if (!data.id) return { ok: false, error: "Missing id." };
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
   const { error } = await client.rpc("cms_upsert_social", {
     p_id: data.id,
@@ -82,8 +79,7 @@ export async function updateSocialLink(
 
 export async function deleteSocialLink(id: string): Promise<SocialActionResult> {
   if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
   const { error } = await client.rpc("cms_delete_social", { p_id: id });
   if (error) return { ok: false, error: error.message };

--- a/src/app/admin/(dashboard)/social/data.ts
+++ b/src/app/admin/(dashboard)/social/data.ts
@@ -1,4 +1,4 @@
-import { getServiceClient } from "@/features/cms/server";
+import { getServerClient } from "@/features/cms/session";
 
 export interface AdminSocialLink {
   id: string;
@@ -9,8 +9,7 @@ export interface AdminSocialLink {
 }
 
 export async function listSocialLinks(): Promise<AdminSocialLink[]> {
-  const client = getServiceClient();
-  if (!client) return [];
+  const client = await getServerClient();
 
   const { data, error } = await client
     .from("social_links")

--- a/src/app/admin/(dashboard)/social/data.ts
+++ b/src/app/admin/(dashboard)/social/data.ts
@@ -1,0 +1,30 @@
+import { getServiceClient } from "@/features/cms/server";
+
+export interface AdminSocialLink {
+  id: string;
+  label: string;
+  url: string;
+  iconKey: string | null;
+  order: number;
+}
+
+export async function listSocialLinks(): Promise<AdminSocialLink[]> {
+  const client = getServiceClient();
+  if (!client) return [];
+
+  const { data, error } = await client
+    .from("social_links")
+    .select("id, label, url, icon_key, order")
+    .order("order")
+    .order("id");
+
+  if (error || !data) return [];
+
+  return data.map((link) => ({
+    id: link.id,
+    label: link.label,
+    url: link.url,
+    iconKey: link.icon_key,
+    order: link.order,
+  }));
+}

--- a/src/app/admin/(dashboard)/social/delete-social.tsx
+++ b/src/app/admin/(dashboard)/social/delete-social.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteSocialLink } from "./actions";
+
+interface DeleteSocialButtonProps {
+  id: string;
+  label: string;
+}
+
+export function DeleteSocialButton({ id, label }: DeleteSocialButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm(`Delete social link "${label}"?`)) return;
+    startTransition(async () => {
+      const result = await deleteSocialLink(id);
+      if (result.ok) router.refresh();
+      else setError(result.error ?? "Failed to delete.");
+    });
+  }
+
+  return (
+    <>
+      <button
+        className="admin-link-button admin-link-button--danger"
+        disabled={isPending}
+        onClick={handleDelete}
+        type="button"
+      >
+        {isPending ? "…" : "Delete"}
+      </button>
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/social/new/page.tsx
+++ b/src/app/admin/(dashboard)/social/new/page.tsx
@@ -1,0 +1,14 @@
+import { SocialLinkForm } from "../social-form";
+
+export const metadata = {
+  title: "New social link",
+};
+
+export default function AdminNewSocialPage() {
+  return (
+    <main className="admin-dashboard">
+      <h1>New social link</h1>
+      <SocialLinkForm />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/social/page.tsx
+++ b/src/app/admin/(dashboard)/social/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+
+import { listSocialLinks } from "./data";
+import { DeleteSocialButton } from "./delete-social";
+
+export const metadata = {
+  title: "Admin social links",
+};
+
+export default async function AdminSocialPage() {
+  const links = await listSocialLinks();
+
+  return (
+    <main className="admin-dashboard">
+      <div className="admin-page-head">
+        <h1>Social links</h1>
+        <Link className="admin-button" href="/admin/social/new">
+          New link
+        </Link>
+      </div>
+
+      <table className="admin-table">
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>URL</th>
+            <th>Order</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {links.map((link) => (
+            <tr key={link.id}>
+              <td>{link.label}</td>
+              <td>{link.url}</td>
+              <td>{link.order}</td>
+              <td className="admin-row-actions">
+                <Link href={`/admin/social/${link.id}`}>Edit</Link>
+                <DeleteSocialButton id={link.id} label={link.label} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/social/social-form.tsx
+++ b/src/app/admin/(dashboard)/social/social-form.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AdminSocialLink } from "./data";
+import { createSocialLink, updateSocialLink, type SocialActionResult } from "./actions";
+
+interface SocialLinkFormProps {
+  existing?: AdminSocialLink;
+}
+
+export function SocialLinkForm({ existing }: SocialLinkFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+
+    const data = {
+      id: existing?.id ?? String(fd.get("id") ?? ""),
+      label: String(fd.get("label") ?? ""),
+      url: String(fd.get("url") ?? ""),
+      iconKey: String(fd.get("iconKey") ?? "") || undefined,
+      order: Number(fd.get("order") ?? 0),
+    };
+
+    startTransition(async () => {
+      const result: SocialActionResult = existing
+        ? await updateSocialLink(data)
+        : await createSocialLink(data);
+      if (result.ok) {
+        router.push("/admin/social");
+        router.refresh();
+      } else {
+        setError(result.fieldErrors ? Object.values(result.fieldErrors).join(" ") : (result.error ?? "Failed."));
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      {!existing ? (
+        <label className="admin-field">
+          <span>ID (slug, optional)</span>
+          <input name="id" defaultValue="" />
+        </label>
+      ) : null}
+
+      <label className="admin-field">
+        <span>Label</span>
+        <input name="label" required defaultValue={existing?.label ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>URL (http/https)</span>
+        <input name="url" required defaultValue={existing?.url ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Icon key</span>
+        <input name="iconKey" defaultValue={existing?.iconKey ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Order</span>
+        <input name="order" type="number" defaultValue={existing?.order ?? 0} />
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <button disabled={isPending} type="submit">
+        {isPending ? "Saving…" : existing ? "Update link" : "Create link"}
+      </button>
+    </form>
+  );
+}

--- a/src/features/cms/repository.ts
+++ b/src/features/cms/repository.ts
@@ -1,0 +1,235 @@
+import type { Locale } from "@/features/i18n/config";
+import {
+  getPortfolioProfile as getLocalProfile,
+  type PortfolioProfileView,
+} from "@/content/profile";
+import {
+  getSkillsContent as getLocalSkills,
+  type SkillGroup,
+  type SkillIconKey,
+  type SkillsContentView,
+} from "@/content/skills";
+import {
+  getContactContent as getLocalContact,
+  type ContactContentView,
+} from "@/content/contact";
+import { getServiceClient } from "./server";
+import { hasCmsConfig } from "./config";
+
+/**
+ * Repository boundary for the public read path (Issue #20 / #18).
+ *
+ * The public, unauthenticated SSR page reads CMS-managed content through this
+ * adapter. Per the accepted #18 design, the public runtime read path uses the
+ * narrow server-only service-role client (anon has zero privileges and RLS
+ * would deny it). This is intentionally separate from the authenticated-owner
+ * CRUD path used by the admin dashboard.
+ *
+ * Each accessor returns the existing typed view model: CMS data overrides the
+ * CMS-managed fields, and the static copy (hero/contact/skills copy, form
+ * labels, images) falls back to the local typed content when the CMS is not
+ * configured or a record is missing. The public UI never sees raw Supabase rows.
+ */
+
+interface ProfileRow {
+  name: string | null;
+  github_url: string | null;
+  profile_translations: Array<{
+    locale: string;
+    role: string;
+    intro: string;
+  }>;
+}
+
+interface SkillTranslation {
+  locale: string;
+  name: string;
+  category: string | null;
+}
+
+interface SkillRow {
+  id: string;
+  group_key: SkillGroup;
+  icon_key: SkillIconKey | null;
+  url: string | null;
+  order: number;
+  skill_translations: SkillTranslation[];
+}
+
+interface SocialRow {
+  id: string;
+  label: string;
+  url: string;
+  icon_key: string | null;
+  order: number;
+}
+
+export async function getPortfolioProfile(
+  locale: Locale,
+): Promise<PortfolioProfileView> {
+  const base = getLocalProfile(locale);
+
+  if (!hasCmsConfig()) {
+    return base;
+  }
+
+  const client = getServiceClient();
+  if (!client) return base;
+
+  try {
+    const { data, error } = await client
+      .from("profile")
+      .select(
+        "name, github_url, profile_translations(locale, role, intro)",
+      )
+      .maybeSingle();
+
+    if (error || !data) return base;
+
+    const row = data as ProfileRow;
+    const en = row.profile_translations.find((t) => t.locale === "en");
+    const vi = row.profile_translations.find((t) => t.locale === "vi");
+    const active = locale === "vi" ? vi : en;
+
+    return {
+      ...base,
+      name: row.name || base.name,
+      role: active?.role || base.role,
+      githubUrl: row.github_url || base.githubUrl,
+      about: {
+        ...base.about,
+        intro: active?.intro || base.about.intro,
+      },
+    };
+  } catch {
+    return base;
+  }
+}
+
+export async function getSkillsContent(
+  locale: Locale,
+): Promise<SkillsContentView> {
+  const base = getLocalSkills(locale);
+
+  if (!hasCmsConfig()) {
+    return base;
+  }
+
+  const client = getServiceClient();
+  if (!client) return base;
+
+  try {
+    const { data, error } = await client
+      .from("skills")
+      .select(
+        "id, group_key, icon_key, url, order, skill_translations(locale, name, category)",
+      )
+      .order("group_key")
+      .order("order")
+      .order("id");
+
+    if (error || !data) return base;
+
+    const rows = data as SkillRow[];
+
+    const techStack = rows
+      .filter((r) => r.group_key === "tech-stack")
+      .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+      .map((r) => ({
+        id: r.id,
+        name: pickTranslation(r.skill_translations, "name", locale),
+        iconKey: r.icon_key ?? undefined,
+      }));
+
+    const otherRows = rows
+      .filter((r) => r.group_key === "others")
+      .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+
+    const categories = new Map<
+      string,
+      { id: string; name: string; skills: Array<{ id: string; name: string; iconKey?: SkillIconKey }> }
+    >();
+
+    for (const row of otherRows) {
+      const categoryEn =
+        row.skill_translations.find((t) => t.locale === "en")?.category ?? null;
+      const categoryName =
+        row.skill_translations.find((t) => t.locale === locale)?.category ??
+        categoryEn;
+
+      if (!categoryName) continue;
+
+      const existing = categories.get(categoryName);
+      const skill = {
+        id: row.id,
+        name: pickTranslation(row.skill_translations, "name", locale),
+        iconKey: row.icon_key ?? undefined,
+      };
+
+      if (existing) {
+        existing.skills.push(skill);
+      } else {
+        categories.set(categoryName, {
+          id: categoryEn?.toLowerCase().replaceAll(" ", "-") ?? row.id,
+          name: categoryName,
+          skills: [skill],
+        });
+      }
+    }
+
+    return {
+      ...base,
+      techStack,
+      otherCategories: [...categories.values()],
+    };
+  } catch {
+    return base;
+  }
+}
+
+export async function getContactContent(
+  locale: Locale,
+): Promise<ContactContentView> {
+  const base = getLocalContact(locale);
+
+  if (!hasCmsConfig()) {
+    return base;
+  }
+
+  const client = getServiceClient();
+  if (!client) return base;
+
+  try {
+    const { data, error } = await client
+      .from("social_links")
+      .select("id, label, url, icon_key, order")
+      .order("order")
+      .order("id");
+
+    if (error || !data) return base;
+
+    const rows = data as SocialRow[];
+
+    return {
+      ...base,
+      details: rows.map((row) => ({
+        id: row.id,
+        label: row.label,
+        value: row.label,
+        href: row.url,
+      })),
+    };
+  } catch {
+    return base;
+  }
+}
+
+function pickTranslation(
+  translations: SkillTranslation[],
+  key: "name" | "category",
+  locale: Locale,
+): string {
+  const en = translations.find((t) => t.locale === "en");
+  const active = translations.find((t) => t.locale === locale);
+  return active?.[key] ?? en?.[key] ?? "";
+}

--- a/src/features/cms/validation.ts
+++ b/src/features/cms/validation.ts
@@ -1,0 +1,12 @@
+export function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function required(value: string): boolean {
+  return value.trim().length > 0;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2837,3 +2837,127 @@ video {
 .admin-card dd {
   margin: 0;
 }
+
+/* Admin CRUD */
+.admin-page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.admin-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 0.5rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.admin-table th,
+.admin-table td {
+  text-align: left;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-table thead th {
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.admin-row-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.admin-row-actions a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.admin-link-button {
+  border: 0;
+  background: none;
+  padding: 0;
+  color: var(--color-accent);
+  font: inherit;
+  cursor: pointer;
+}
+
+.admin-link-button--danger {
+  color: var(--color-error);
+}
+
+.admin-form {
+  display: grid;
+  gap: 1rem;
+  max-width: 32rem;
+}
+
+.admin-form select,
+.admin-form input[type="text"],
+.admin-form input[type="number"],
+.admin-form input:not([type]) {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.admin-form select:focus-visible,
+.admin-form input:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.admin-form button[type="submit"] {
+  justify-self: start;
+  padding: 0.5rem 1rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-form button[type="submit"]:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.admin-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.admin-nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem clamp(1.25rem, 5vw, 3rem);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-nav a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.admin-nav a:hover {
+  color: var(--color-text);
+}

--- a/supabase/migrations/20260819204707_cms_schema.sql
+++ b/supabase/migrations/20260819204707_cms_schema.sql
@@ -223,6 +223,14 @@ grant select, insert, update, delete on profile, profile_translations,
 -- (not the content tables).
 grant select, insert, update on app_settings to service_role;
 
+-- Server-side ops (backfill/seed scripts) write content via service-role. The
+-- service-role key is server-only and never exposed to the browser.
+grant select, insert, update, delete on profile, profile_translations,
+  social_links, skills, skill_translations, projects, project_translations,
+  project_media, project_media_translations, resume_categories,
+  resume_category_translations, resume_entries, resume_entry_translations,
+  resume_media, resume_media_translations to service_role;
+
 -- RLS enabled on every content table (deny-by-default).
 alter table profile enable row level security;
 alter table profile_translations enable row level security;

--- a/supabase/migrations/20260819212704_content_slug_ids.sql
+++ b/supabase/migrations/20260819212704_content_slug_ids.sql
@@ -1,0 +1,19 @@
+-- Convert content entity primary keys from uuid to stable text slugs, matching
+-- the local content's stable string IDs (e.g. skills use 'typescript'). This
+-- preserves stable IDs across the CMS and makes backfill/repository mapping
+-- direct. Applied per-entity as each CRUD slice lands.
+
+-- Skills
+alter table skill_translations drop constraint skill_translations_skill_id_fkey;
+alter table skills alter column id type text;
+alter table skills drop constraint skills_pkey;
+alter table skills add primary key (id);
+alter table skill_translations alter column skill_id type text;
+alter table skill_translations
+  add constraint skill_translations_skill_id_fkey
+  foreign key (skill_id) references skills(id) on delete cascade;
+
+-- Social links (contact details use stable string ids, e.g. 'github')
+alter table social_links drop constraint social_links_pkey;
+alter table social_links alter column id type text;
+alter table social_links add primary key (id);

--- a/supabase/migrations/20260820140000_cms_atomic_mutations.sql
+++ b/supabase/migrations/20260820140000_cms_atomic_mutations.sql
@@ -1,0 +1,154 @@
+-- Issue #20 review follow-up:
+-- 1. Reconcile the Profile contract with the schema: the local Profile contract
+--    carries stable identity fields (name / shortName) that the schema omitted.
+--    Add them to the base profile table so the admin CRUD does not silently drop
+--    them from the editable contract. Social links stay locale-neutral by design
+--    (no social_translations table is introduced).
+-- 2. Atomic base-row + translation-row mutations. The server actions previously
+--    issued separate base and translation writes; a failure between them could
+--    leave a partial write reported as a failed action. These SECURITY DEFINER
+--    functions run each mutation inside a single transaction (PL/pgSQL function
+--    bodies are transactional), so a failure rolls back the whole operation.
+
+-- --- Profile reconciliation: stable identity fields -----------------------------
+alter table profile add column if not exists name text;
+alter table profile add column if not exists short_name text;
+
+-- --- Atomic mutations (schema-qualified, hardened search_path) ------------------
+-- These live in the `public` schema so PostgREST exposes them as RPC endpoints for
+-- the server-side service-role client. They are SECURITY DEFINER and only
+-- executable by service_role (revoked from public/anon/authenticated), so the
+-- browser can never invoke them.
+
+create or replace function public.cms_upsert_skill(
+  p_id text,
+  p_group_key text,
+  p_icon_key text,
+  p_url text,
+  p_order integer,
+  p_featured boolean,
+  p_name_en text,
+  p_name_vi text,
+  p_category_en text,
+  p_category_vi text
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into public.skills (id, group_key, icon_key, url, "order", featured)
+  values (p_id, p_group_key, p_icon_key, p_url, p_order, p_featured)
+  on conflict (id) do update set
+    group_key = excluded.group_key,
+    icon_key = excluded.icon_key,
+    url = excluded.url,
+    "order" = excluded."order",
+    featured = excluded.featured;
+
+  insert into public.skill_translations (skill_id, locale, name, category)
+  values
+    (p_id, 'en', p_name_en, p_category_en),
+    (p_id, 'vi', p_name_vi, p_category_vi)
+  on conflict (skill_id, locale) do update set
+    name = excluded.name,
+    category = excluded.category;
+end;
+$$;
+
+create or replace function public.cms_delete_skill(p_id text)
+returns void
+language sql
+security definer
+set search_path = ''
+as $$
+  delete from public.skills where id = p_id;
+$$;
+
+create or replace function public.cms_upsert_profile(
+  p_id uuid,
+  p_name text,
+  p_short_name text,
+  p_github_url text,
+  p_linkedin_url text,
+  p_resume_url text,
+  p_phone text,
+  p_email text,
+  p_role_en text,
+  p_role_vi text,
+  p_intro_en text,
+  p_intro_vi text,
+  p_location_en text,
+  p_location_vi text
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update public.profile set
+    name = p_name,
+    short_name = p_short_name,
+    github_url = p_github_url,
+    linkedin_url = p_linkedin_url,
+    resume_url = p_resume_url,
+    phone = p_phone,
+    email = p_email,
+    updated_at = now()
+  where id = p_id;
+
+  insert into public.profile_translations (profile_id, locale, role, intro, location)
+  values
+    (p_id, 'en', p_role_en, p_intro_en, p_location_en),
+    (p_id, 'vi', p_role_vi, p_intro_vi, p_location_vi)
+  on conflict (profile_id, locale) do update set
+    role = excluded.role,
+    intro = excluded.intro,
+    location = excluded.location;
+end;
+$$;
+
+create or replace function public.cms_upsert_social(
+  p_id text,
+  p_label text,
+  p_url text,
+  p_icon_key text,
+  p_order integer
+)
+returns void
+language sql
+security definer
+set search_path = ''
+as $$
+  insert into public.social_links (id, label, url, icon_key, "order")
+  values (p_id, p_label, p_url, p_icon_key, p_order)
+  on conflict (id) do update set
+    label = excluded.label,
+    url = excluded.url,
+    icon_key = excluded.icon_key,
+    "order" = excluded."order";
+$$;
+
+create or replace function public.cms_delete_social(p_id text)
+returns void
+language sql
+security definer
+set search_path = ''
+as $$
+  delete from public.social_links where id = p_id;
+$$;
+
+-- Restrict execution to the server-side service-role client only.
+revoke all on function public.cms_upsert_skill(text, text, text, text, integer, boolean, text, text, text, text) from public;
+revoke all on function public.cms_delete_skill(text) from public;
+revoke all on function public.cms_upsert_profile(uuid, text, text, text, text, text, text, text, text, text, text, text, text, text) from public;
+revoke all on function public.cms_upsert_social(text, text, text, text, integer) from public;
+revoke all on function public.cms_delete_social(text) from public;
+
+grant execute on function public.cms_upsert_skill(text, text, text, text, integer, boolean, text, text, text, text) to service_role;
+grant execute on function public.cms_delete_skill(text) to service_role;
+grant execute on function public.cms_upsert_profile(uuid, text, text, text, text, text, text, text, text, text, text, text, text, text) to service_role;
+grant execute on function public.cms_upsert_social(text, text, text, text, integer) to service_role;
+grant execute on function public.cms_delete_social(text) to service_role;

--- a/supabase/migrations/20260820150000_cms_rls_invoker_rpc.sql
+++ b/supabase/migrations/20260820150000_cms_rls_invoker_rpc.sql
@@ -147,6 +147,15 @@ as $$
   delete from public.social_links where id = p_id;
 $$;
 
+create or replace function public.cms_delete_profile(p_id uuid)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from public.profile where id = p_id;
+$$;
+
 -- Execute is granted to authenticated so the admin (owner) can call them with
 -- their JWT; RLS on the content tables then authorizes each operation. service_role
 -- keeps its existing execute grant for the server-side backfill/seed path.
@@ -155,20 +164,22 @@ revoke all on function public.cms_delete_skill(text) from public;
 revoke all on function public.cms_upsert_profile(uuid, text, text, text, text, text, text, text, text, text, text, text, text, text) from public;
 revoke all on function public.cms_upsert_social(text, text, text, text, integer) from public;
 revoke all on function public.cms_delete_social(text) from public;
+revoke all on function public.cms_delete_profile(uuid) from public;
 
 grant execute on function public.cms_upsert_skill(text, text, text, text, integer, boolean, text, text, text, text) to authenticated, service_role;
 grant execute on function public.cms_delete_skill(text) to authenticated, service_role;
 grant execute on function public.cms_upsert_profile(uuid, text, text, text, text, text, text, text, text, text, text, text, text, text) to authenticated, service_role;
 grant execute on function public.cms_upsert_social(text, text, text, text, integer) to authenticated, service_role;
 grant execute on function public.cms_delete_social(text) to authenticated, service_role;
+grant execute on function public.cms_delete_profile(uuid) to authenticated, service_role;
 
 -- Deterministic ordering is guaranteed by the queries in the admin data layer
 -- (order by group_key/order/id and order/id); no schema change required.
 
--- Profile is a required singleton (unique slug, single owner). Create is handled
--- by the admin form upserting on the stable slug; delete is intentionally not
--- offered because a portfolio cannot render without its profile row. This is the
--- documented interpretation of the Issue #20 Profile CRUD criterion.
+-- Profile is a required singleton (unique slug, single owner). It can be created,
+-- updated, and deleted by the admin; the public page falls back to local typed
+-- content when the profile row is absent. The stable slug 'owner' is seeded so the
+-- admin can create the record on first save.
 insert into public.profile (slug, github_url)
   values ('owner', 'https://github.com/Akbi47')
   on conflict (slug) do nothing;

--- a/supabase/migrations/20260820150000_cms_rls_invoker_rpc.sql
+++ b/supabase/migrations/20260820150000_cms_rls_invoker_rpc.sql
@@ -1,0 +1,174 @@
+-- Issue #20 review follow-up (request-changes):
+-- Route admin Profile/Social/Skills reads and mutations through the
+-- authenticated owner/RLS path. The previous migration made the atomic RPCs
+-- SECURITY DEFINER and executable by service_role only, which bypasses RLS.
+-- This migration converts them to SECURITY INVOKER (they then run with the
+-- caller's role, so the RLS policies on the content tables are evaluated) and
+-- grants execute to `authenticated`. Server actions now call them through the
+-- authenticated server client, so the owner JWT is present and RLS is the
+-- authoritative check for each mutation.
+--
+-- The public runtime read path (app_settings, publicity) is unchanged: it stays
+-- on the narrow service-role path per the accepted #18 design.
+
+create or replace function public.cms_upsert_skill(
+  p_id text,
+  p_group_key text,
+  p_icon_key text,
+  p_url text,
+  p_order integer,
+  p_featured boolean,
+  p_name_en text,
+  p_name_vi text,
+  p_category_en text,
+  p_category_vi text
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  insert into public.skills (id, group_key, icon_key, url, "order", featured)
+  values (p_id, p_group_key, p_icon_key, p_url, p_order, p_featured)
+  on conflict (id) do update set
+    group_key = excluded.group_key,
+    icon_key = excluded.icon_key,
+    url = excluded.url,
+    "order" = excluded."order",
+    featured = excluded.featured;
+
+  insert into public.skill_translations (skill_id, locale, name, category)
+  values
+    (p_id, 'en', p_name_en, p_category_en),
+    (p_id, 'vi', p_name_vi, p_category_vi)
+  on conflict (skill_id, locale) do update set
+    name = excluded.name,
+    category = excluded.category;
+end;
+$$;
+
+create or replace function public.cms_delete_skill(p_id text)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from public.skills where id = p_id;
+$$;
+
+create or replace function public.cms_upsert_profile(
+  p_id uuid,
+  p_name text,
+  p_short_name text,
+  p_github_url text,
+  p_linkedin_url text,
+  p_resume_url text,
+  p_phone text,
+  p_email text,
+  p_role_en text,
+  p_role_vi text,
+  p_intro_en text,
+  p_intro_vi text,
+  p_location_en text,
+  p_location_vi text
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_profile_id uuid;
+begin
+  -- Profile is a required singleton keyed by the stable slug 'owner'. Update the
+  -- existing row (or insert the singleton if it does not yet exist) so the admin
+  -- can both create and update the single profile record. The caller's RLS
+  -- policy (owner all) authorizes the write. The caller-provided p_id is used
+  -- only for a brand-new insert; when the row already exists we keep its real id
+  -- so the translation rows link to the actual profile.
+  insert into public.profile (id, slug, name, short_name, github_url, linkedin_url, resume_url, phone, email, updated_at)
+  values (p_id, 'owner', p_name, p_short_name, p_github_url, p_linkedin_url, p_resume_url, p_phone, p_email, now())
+  on conflict (slug) do update set
+    name = excluded.name,
+    short_name = excluded.short_name,
+    github_url = excluded.github_url,
+    linkedin_url = excluded.linkedin_url,
+    resume_url = excluded.resume_url,
+    phone = excluded.phone,
+    email = excluded.email,
+    updated_at = now()
+  returning id into v_profile_id;
+
+  -- Resolve the real id (covers the conflict-update path where the row keeps its
+  -- original id rather than the caller-provided p_id).
+  if v_profile_id is null then
+    select id into v_profile_id from public.profile where slug = 'owner';
+  end if;
+
+  insert into public.profile_translations (profile_id, locale, role, intro, location)
+  values
+    (v_profile_id, 'en', p_role_en, p_intro_en, p_location_en),
+    (v_profile_id, 'vi', p_role_vi, p_intro_vi, p_location_vi)
+  on conflict (profile_id, locale) do update set
+    role = excluded.role,
+    intro = excluded.intro,
+    location = excluded.location;
+end;
+$$;
+
+create or replace function public.cms_upsert_social(
+  p_id text,
+  p_label text,
+  p_url text,
+  p_icon_key text,
+  p_order integer
+)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  insert into public.social_links (id, label, url, icon_key, "order")
+  values (p_id, p_label, p_url, p_icon_key, p_order)
+  on conflict (id) do update set
+    label = excluded.label,
+    url = excluded.url,
+    icon_key = excluded.icon_key,
+    "order" = excluded."order";
+$$;
+
+create or replace function public.cms_delete_social(p_id text)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from public.social_links where id = p_id;
+$$;
+
+-- Execute is granted to authenticated so the admin (owner) can call them with
+-- their JWT; RLS on the content tables then authorizes each operation. service_role
+-- keeps its existing execute grant for the server-side backfill/seed path.
+revoke all on function public.cms_upsert_skill(text, text, text, text, integer, boolean, text, text, text, text) from public;
+revoke all on function public.cms_delete_skill(text) from public;
+revoke all on function public.cms_upsert_profile(uuid, text, text, text, text, text, text, text, text, text, text, text, text, text) from public;
+revoke all on function public.cms_upsert_social(text, text, text, text, integer) from public;
+revoke all on function public.cms_delete_social(text) from public;
+
+grant execute on function public.cms_upsert_skill(text, text, text, text, integer, boolean, text, text, text, text) to authenticated, service_role;
+grant execute on function public.cms_delete_skill(text) to authenticated, service_role;
+grant execute on function public.cms_upsert_profile(uuid, text, text, text, text, text, text, text, text, text, text, text, text, text) to authenticated, service_role;
+grant execute on function public.cms_upsert_social(text, text, text, text, integer) to authenticated, service_role;
+grant execute on function public.cms_delete_social(text) to authenticated, service_role;
+
+-- Deterministic ordering is guaranteed by the queries in the admin data layer
+-- (order by group_key/order/id and order/id); no schema change required.
+
+-- Profile is a required singleton (unique slug, single owner). Create is handled
+-- by the admin form upserting on the stable slug; delete is intentionally not
+-- offered because a portfolio cannot render without its profile row. This is the
+-- documented interpretation of the Issue #20 Profile CRUD criterion.
+insert into public.profile (slug, github_url)
+  values ('owner', 'https://github.com/Akbi47')
+  on conflict (slug) do nothing;

--- a/supabase/tests/rls_crud_test.sql
+++ b/supabase/tests/rls_crud_test.sql
@@ -1,0 +1,128 @@
+-- RLS verification for Issue #20 (CMS CRUD slices).
+--
+-- Requirement (review follow-up): authorization/RLS must be verified through
+-- authenticated OWNER credentials plus negative anonymous / non-owner cases.
+-- Service-role tests do not verify RLS because the service role bypasses it.
+--
+-- These tests run as the database superuser (pgTAP) and switch the effective
+-- role + JWT claims to simulate real clients:
+--   - anonymous client      -> role anon, no claims
+--   - owner (admin) client  -> role authenticated, claims.sub = owner auth_uid
+--   - non-owner client      -> role authenticated, claims.sub = some other uid
+--
+-- The owner auth_uid is read from the seeded admin_owner row so the test adapts
+-- to whichever auth user is the configured single owner.
+
+begin;
+select plan(9);
+
+-- Capture the owner uid while still superuser (admin_owner is RLS-filtered for
+-- other roles), then set claims session-wide so they survive the role switch.
+select set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', (select auth_uid from public.admin_owner limit 1)::text,
+    'role', 'authenticated'
+  )::text,
+  false
+);
+
+-- Fixture rows for CRUD assertions (created as superuser, before switching).
+insert into public.profile (id, slug, github_url)
+  values ('00000000-0000-0000-0000-000000000001', 'rls-test', 'https://github.com/test')
+  on conflict (slug) do nothing;
+
+insert into public.social_links (id, label, url, icon_key, "order")
+  values ('rls-test', 'Test', 'https://example.com', 'test', 1)
+  on conflict (id) do nothing;
+
+insert into public.skills (id, group_key, "order")
+  values ('rls-test', 'tech-stack', 1)
+  on conflict (id) do nothing;
+
+-- --- Owner: SELECT succeeds ------------------------------------------------
+set local role authenticated;
+
+select is(
+  (select count(*) from public.profile where slug = 'rls-test'),
+  1::bigint,
+  'owner can SELECT profile'
+);
+
+select is(
+  (select count(*) from public.social_links where id = 'rls-test'),
+  1::bigint,
+  'owner can SELECT social_links'
+);
+
+select is(
+  (select count(*) from public.skills where id = 'rls-test'),
+  1::bigint,
+  'owner can SELECT skills'
+);
+
+-- --- Owner: INSERT succeeds -----------------------------------------------
+insert into public.skills (id, group_key, "order")
+  values ('rls-test-insert', 'tech-stack', 99);
+select ok(
+  exists (select 1 from public.skills where id = 'rls-test-insert'),
+  'owner can INSERT into skills'
+);
+
+-- --- Owner: UPDATE succeeds -----------------------------------------------
+update public.skills set "order" = 100 where id = 'rls-test-insert';
+select is(
+  (select "order" from public.skills where id = 'rls-test-insert'),
+  100,
+  'owner can UPDATE skills'
+);
+
+-- --- Owner: DELETE succeeds -----------------------------------------------
+delete from public.skills where id = 'rls-test-insert';
+select ok(
+  not exists (select 1 from public.skills where id = 'rls-test-insert'),
+  'owner can DELETE skills'
+);
+
+-- --- Anonymous: denied (zero privileges, deny-by-default) -------------------
+reset role;
+set local role anon;
+select set_config('request.jwt.claims', '{}', true);
+
+select throws_ok(
+  $$ select * from public.skills $$,
+  null,
+  'permission denied for table skills',
+  'anonymous cannot SELECT skills'
+);
+
+-- --- Non-owner authenticated: denied by RLS (owner-only policy) -------------
+reset role;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  json_build_object('sub', 'ffffffff-ffff-ffff-ffff-ffffffffffff', 'role', 'authenticated')::text,
+  true
+);
+
+select is(
+  (select count(*) from public.profile),
+  0::bigint,
+  'non-owner sees zero profile rows (RLS filters)'
+);
+
+select throws_ok(
+  $$ insert into public.skills (id, group_key) values ('intruder', 'tech-stack') $$,
+  null,
+  null,
+  'non-owner cannot INSERT into skills (RLS with-check)'
+);
+
+-- --- Cleanup fixtures ------------------------------------------------
+reset role;
+delete from public.social_links where id = 'rls-test';
+delete from public.skills where id = 'rls-test';
+delete from public.profile where id = '00000000-0000-0000-0000-000000000001';
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #20

## Summary
Completes the first CMS CRUD slice (Profile, Contact/Social, Skills) on the
Supabase-backed admin area built in #19. Admin CRUD routes through the
authenticated owner/RLS path, and the public site reads CMS content through a
repository adapter that maps Supabase rows into the existing typed view models.

## What changed

### Schema / migrations
- `profile` gains `name` / `short_name` columns to reconcile the Profile contract.
  Social links remain locale-neutral — no `social_translations` table.
- Atomic `cms_upsert_skill` / `cms_delete_skill` / `cms_upsert_profile` /
  `cms_upsert_social` / `cms_delete_social` / `cms_delete_profile` functions run
  each base-row + translation-row mutation in a single transaction. They are
  **SECURITY INVOKER** and granted to `authenticated`, so RLS policies evaluate
  on every mutation (no service-role bypass). service_role keeps a grant for the
  backfill/seed path.
- Profile is a required singleton keyed by the stable slug `owner`; the RPC
  inserts-or-updates it (resolving the real row id on conflict).
- `scripts/backfill-content.mjs` upserts translations on their natural composite
  key so re-runs are idempotent, and fills the new name/short_name fields.

### Admin UI (authenticated owner/RLS path)
- **Profile**: create/update/delete the singleton with name, short name, links,
  email, phone, and EN/VI role/intro/location. A missing row renders a
  create-capable form; delete is offered only for a persisted row.
- **Social**: list/create/edit/delete links with URL validation.
- **Skills**: list/create/edit/delete with deterministic ordering.
- All reads/writes use `getServerClient()` (authenticated) so owner RLS is
  authoritative.

### Public read path
- New `src/features/cms/repository.ts` maps Supabase rows to the existing
  `PortfolioProfileView` / `SkillsContentView` / `ContactContentView`, overriding
  CMS-managed fields over the static copy, with a local-content fallback when the
  CMS is not configured or a record is missing.
- The public locale page consumes the adapter (narrow service-role public read
  path per the accepted #18 design, separate from the authenticated admin path).
- Admin edits in Supabase now change the rendered portfolio.

### Deterministic ordering
- Skills and social list queries add `id` as a stable secondary sort key.

## Verification
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` — 99 pass
- `npm run test:db` — 2 pass
- `supabase db test --local supabase/tests` — RLS pgTAP suite (9 assertions):
  owner CRUD succeeds; anonymous and non-owner authenticated clients denied.
- `npm run build` — pass
- Live owner-path checks: skill upsert/delete (204), profile delete (204) then
  recreate via singleton upsert (204); non-owner/anonymous denied.

## Known limitations
- Profile media/avatar editing is out of scope (Issue #21).
- Projects and Resume CRUD are out of scope (Issues #51 / #52).

## Docs affected
- `docs/superpowers/specs/2026-08-20-supabase-cms-schema-design.md` (profile
  identity fields reconciled).