### PR TITLE
feat: CMS CRUD for projects (Issue #51)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "seed:admin": "node scripts/seed-admin.mjs",
     "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",
     "test:db": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node --test scripts/db-invariants.test.mjs",
+    "test:cms": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} tsx --test src/features/cms/repository.test.ts",
     "test:rls": "supabase db test --local supabase/tests"
   },
   "dependencies": {

--- a/scripts/backfill-content.mjs
+++ b/scripts/backfill-content.mjs
@@ -147,10 +147,94 @@ async function backfillContact() {
   console.log("Contact/social backfilled.");
 }
 
+async function backfillProjects() {
+  const { projects } = await import("../src/content/projects.ts");
+
+  for (const project of projects) {
+    await upsert(
+      "projects",
+      [
+        {
+          id: project.id,
+          slug: project.slug,
+          tech_stack: project.techStack,
+          live_demo_url: project.liveDemoUrl ?? null,
+          code_url: project.codeUrl ?? null,
+          featured: project.featured,
+          order: project.order,
+          status: project.status ?? "active",
+          published: true,
+        },
+      ],
+      "id",
+    );
+
+    await upsert(
+      "project_translations",
+      [
+        {
+          project_id: project.id,
+          locale: "en",
+          title: project.title.en,
+          category: project.category.en,
+          summary: project.summary.en,
+          description: null,
+        },
+        {
+          project_id: project.id,
+          locale: "vi",
+          title: project.title.vi,
+          category: project.category.vi,
+          summary: project.summary.vi,
+          description: null,
+        },
+      ],
+      "project_id,locale",
+    );
+
+    for (const media of project.media) {
+      await upsert(
+        "project_media",
+        [
+          {
+            id: media.id,
+            project_id: project.id,
+            src: media.src,
+            kind: "image",
+            width: media.width,
+            height: media.height,
+            order: media.order,
+          },
+        ],
+        "id",
+      );
+
+      await upsert(
+        "project_media_translations",
+        [
+          {
+            project_media_id: media.id,
+            locale: "en",
+            alt: media.alt.en,
+          },
+          {
+            project_media_id: media.id,
+            locale: "vi",
+            alt: media.alt.vi,
+          },
+        ],
+        "project_media_id,locale",
+      );
+    }
+  }
+  console.log("Projects backfilled.");
+}
+
 async function main() {
   await backfillSkills();
   await backfillProfile();
   await backfillContact();
+  await backfillProjects();
   console.log("Backfill complete.");
 }
 

--- a/scripts/backfill-content.mjs
+++ b/scripts/backfill-content.mjs
@@ -179,6 +179,7 @@ async function backfillProjects() {
           category: project.category.en,
           summary: project.summary.en,
           description: null,
+          highlights: (project.highlights ?? []).map((h) => h.en),
         },
         {
           project_id: project.id,
@@ -187,6 +188,7 @@ async function backfillProjects() {
           category: project.category.vi,
           summary: project.summary.vi,
           description: null,
+          highlights: (project.highlights ?? []).map((h) => h.vi),
         },
       ],
       "project_id,locale",
@@ -204,6 +206,7 @@ async function backfillProjects() {
             width: media.width,
             height: media.height,
             order: media.order,
+            focal_point: media.focalPoint,
           },
         ],
         "id",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,11 +8,11 @@ import { ProjectsSection } from "@/components/sections/projects/projects-section
 import { ResumeSection } from "@/components/sections/resume/resume-section";
 import { ResumeSectionLock } from "@/components/sections/resume/resume-section-lock";
 import { SkillsSection } from "@/components/sections/skills/skills-section";
-import { getFeaturedProjects } from "@/content/projects";
 import { getResumeContent, getResumeLockContent } from "@/content/resume";
 import { getResumePublicity } from "@/features/cms/resume-publicity";
 import {
   getContactContent as getCmsContact,
+  getFeaturedProjects as getCmsFeaturedProjects,
   getPortfolioProfile as getCmsProfile,
   getSkillsContent as getCmsSkills,
 } from "@/features/cms/repository";
@@ -45,7 +45,7 @@ export default async function LocalePage({
   const messages = await getMessages(locale);
   const profile = await getCmsProfile(locale);
   const skills = await getCmsSkills(locale);
-  const projects = getFeaturedProjects(locale);
+  const projects = await getCmsFeaturedProjects(locale);
   const contact = await getCmsContact(locale);
 
   const isResumePrivate = (await getResumePublicity()) === "private";

--- a/src/app/admin/(dashboard)/layout.tsx
+++ b/src/app/admin/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ const navLinks = [
   { href: "/admin/profile", label: "Profile" },
   { href: "/admin/skills", label: "Skills" },
   { href: "/admin/social", label: "Social" },
+  { href: "/admin/projects", label: "Projects" },
 ] as const;
 
 export default async function AdminDashboardLayout({

--- a/src/app/admin/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/projects/[id]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+
+import { getProject } from "../data";
+import { ProjectForm } from "../project-form";
+
+interface AdminEditProjectPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "Edit project",
+};
+
+export default async function AdminEditProjectPage({
+  params,
+}: AdminEditProjectPageProps) {
+  const { id } = await params;
+  const project = await getProject(id);
+
+  if (!project) {
+    notFound();
+  }
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Edit project</h1>
+      <ProjectForm existing={project} />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/projects/actions.ts
+++ b/src/app/admin/(dashboard)/projects/actions.ts
@@ -1,0 +1,150 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServerClient, isAdminUser } from "@/features/cms/session";
+import { isHttpUrl, required } from "@/features/cms/validation";
+
+export interface ProjectFormData {
+  id?: string;
+  slug: string;
+  techStack: string;
+  liveDemoUrl: string;
+  codeUrl: string;
+  featured: boolean;
+  order: number;
+  status: string;
+  published: boolean;
+  titleEn: string;
+  titleVi: string;
+  categoryEn: string;
+  categoryVi: string;
+  summaryEn: string;
+  summaryVi: string;
+  descriptionEn: string;
+  descriptionVi: string;
+}
+
+export interface ProjectActionResult {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Partial<Record<keyof ProjectFormData, string>>;
+}
+
+function validate(data: ProjectFormData): ProjectActionResult | null {
+  const errors: Partial<Record<keyof ProjectFormData, string>> = {};
+
+  if (!required(data.slug)) errors.slug = "Slug is required.";
+  if (data.liveDemoUrl && !isHttpUrl(data.liveDemoUrl)) {
+    errors.liveDemoUrl = "Live Demo URL must be http(s).";
+  }
+  if (data.codeUrl && !isHttpUrl(data.codeUrl)) {
+    errors.codeUrl = "Code URL must be http(s).";
+  }
+  if (!required(data.titleEn)) errors.titleEn = "EN title is required.";
+  if (!required(data.titleVi)) errors.titleVi = "VI title is required.";
+  if (!required(data.categoryEn)) errors.categoryEn = "EN category is required.";
+  if (!required(data.categoryVi)) errors.categoryVi = "VI category is required.";
+  if (!required(data.summaryEn)) errors.summaryEn = "EN summary is required.";
+  if (!required(data.summaryVi)) errors.summaryVi = "VI summary is required.";
+
+  if (Object.keys(errors).length > 0) return { ok: false, fieldErrors: errors };
+  return null;
+}
+
+function splitTechStack(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export async function createProject(
+  data: ProjectFormData,
+): Promise<ProjectActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validate(data);
+  if (invalid) return invalid;
+
+  const id =
+    data.id && data.id.length > 0 ? data.id : data.slug.toLowerCase().replaceAll(" ", "-");
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_upsert_project", {
+    p_id: id,
+    p_slug: data.slug.trim(),
+    p_tech_stack: splitTechStack(data.techStack),
+    p_live_demo_url: data.liveDemoUrl || null,
+    p_code_url: data.codeUrl || null,
+    p_featured: data.featured,
+    p_order: data.order,
+    p_status: data.status || "active",
+    p_published: data.published,
+    p_title_en: data.titleEn.trim(),
+    p_title_vi: data.titleVi.trim(),
+    p_category_en: data.categoryEn.trim(),
+    p_category_vi: data.categoryVi.trim(),
+    p_summary_en: data.summaryEn.trim(),
+    p_summary_vi: data.summaryVi.trim(),
+    p_description_en: data.descriptionEn.trim() || null,
+    p_description_vi: data.descriptionVi.trim() || null,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/projects");
+  return { ok: true };
+}
+
+export async function updateProject(
+  data: ProjectFormData,
+): Promise<ProjectActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validate(data);
+  if (invalid) return invalid;
+  if (!data.id) return { ok: false, error: "Missing id." };
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_upsert_project", {
+    p_id: data.id,
+    p_slug: data.slug.trim(),
+    p_tech_stack: splitTechStack(data.techStack),
+    p_live_demo_url: data.liveDemoUrl || null,
+    p_code_url: data.codeUrl || null,
+    p_featured: data.featured,
+    p_order: data.order,
+    p_status: data.status || "active",
+    p_published: data.published,
+    p_title_en: data.titleEn.trim(),
+    p_title_vi: data.titleVi.trim(),
+    p_category_en: data.categoryEn.trim(),
+    p_category_vi: data.categoryVi.trim(),
+    p_summary_en: data.summaryEn.trim(),
+    p_summary_vi: data.summaryVi.trim(),
+    p_description_en: data.descriptionEn.trim() || null,
+    p_description_vi: data.descriptionVi.trim() || null,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/projects");
+  return { ok: true };
+}
+
+export async function deleteProject(id: string): Promise<ProjectActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_delete_project", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/projects");
+  return { ok: true };
+}

--- a/src/app/admin/(dashboard)/projects/actions.ts
+++ b/src/app/admin/(dashboard)/projects/actions.ts
@@ -23,6 +23,8 @@ export interface ProjectFormData {
   summaryVi: string;
   descriptionEn: string;
   descriptionVi: string;
+  highlightsEn: string;
+  highlightsVi: string;
 }
 
 export interface ProjectActionResult {
@@ -59,6 +61,13 @@ function splitTechStack(value: string): string[] {
     .filter(Boolean);
 }
 
+function splitLines(value: string): string[] {
+  return value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 export async function createProject(
   data: ProjectFormData,
 ): Promise<ProjectActionResult> {
@@ -89,6 +98,8 @@ export async function createProject(
     p_summary_vi: data.summaryVi.trim(),
     p_description_en: data.descriptionEn.trim() || null,
     p_description_vi: data.descriptionVi.trim() || null,
+    p_highlights_en: splitLines(data.highlightsEn),
+    p_highlights_vi: splitLines(data.highlightsVi),
   });
   if (error) return { ok: false, error: error.message };
 
@@ -126,6 +137,8 @@ export async function updateProject(
     p_summary_vi: data.summaryVi.trim(),
     p_description_en: data.descriptionEn.trim() || null,
     p_description_vi: data.descriptionVi.trim() || null,
+    p_highlights_en: splitLines(data.highlightsEn),
+    p_highlights_vi: splitLines(data.highlightsVi),
   });
   if (error) return { ok: false, error: error.message };
 

--- a/src/app/admin/(dashboard)/projects/data.ts
+++ b/src/app/admin/(dashboard)/projects/data.ts
@@ -1,0 +1,104 @@
+import { getServerClient } from "@/features/cms/session";
+
+export interface AdminProjectRow {
+  id: string;
+  slug: string;
+  techStack: string[];
+  liveDemoUrl: string | null;
+  codeUrl: string | null;
+  featured: boolean;
+  order: number;
+  status: string;
+  published: boolean;
+  titleEn: string;
+  titleVi: string;
+  categoryEn: string;
+  categoryVi: string;
+  summaryEn: string;
+  summaryVi: string;
+  descriptionEn: string | null;
+  descriptionVi: string | null;
+}
+
+interface ProjectTranslation {
+  locale: string;
+  title: string;
+  category: string;
+  summary: string;
+  description: string | null;
+}
+
+interface ProjectRowWithTranslations {
+  id: string;
+  slug: string;
+  tech_stack: string[] | string;
+  live_demo_url: string | null;
+  code_url: string | null;
+  featured: boolean;
+  order: number;
+  status: string;
+  published: boolean;
+  project_translations: ProjectTranslation[];
+}
+
+export async function listProjects(): Promise<AdminProjectRow[]> {
+  const client = await getServerClient();
+
+  const { data, error } = await client
+    .from("projects")
+    .select(
+      "id, slug, tech_stack, live_demo_url, code_url, featured, order, status, published, project_translations(locale, title, category, summary, description)",
+    )
+    .order("featured", { ascending: false })
+    .order("order")
+    .order("id");
+
+  if (error || !data) return [];
+
+  return data.map(mapProjectRow);
+}
+
+export async function getProject(id: string): Promise<AdminProjectRow | null> {
+  const rows = await listProjects();
+  return rows.find((row) => row.id === id) ?? null;
+}
+
+function mapProjectRow(
+  data: ProjectRowWithTranslations,
+): AdminProjectRow {
+  const en = data.project_translations.find((t) => t.locale === "en");
+  const vi = data.project_translations.find((t) => t.locale === "vi");
+
+  return {
+    id: data.id,
+    slug: data.slug,
+    techStack: parseTechStack(data.tech_stack),
+    liveDemoUrl: data.live_demo_url,
+    codeUrl: data.code_url,
+    featured: data.featured,
+    order: data.order,
+    status: data.status,
+    published: data.published,
+    titleEn: en?.title ?? "",
+    titleVi: vi?.title ?? "",
+    categoryEn: en?.category ?? "",
+    categoryVi: vi?.category ?? "",
+    summaryEn: en?.summary ?? "",
+    summaryVi: vi?.summary ?? "",
+    descriptionEn: en?.description ?? null,
+    descriptionVi: vi?.description ?? null,
+  };
+}
+
+function parseTechStack(value: string[] | string | null | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string" && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}

--- a/src/app/admin/(dashboard)/projects/data.ts
+++ b/src/app/admin/(dashboard)/projects/data.ts
@@ -50,7 +50,7 @@ export async function listProjects(): Promise<AdminProjectRow[]> {
   const { data, error } = await client
     .from("projects")
     .select(
-      "id, slug, tech_stack, live_demo_url, code_url, featured, order, status, published, project_translations(locale, title, category, summary, description)",
+      "id, slug, tech_stack, live_demo_url, code_url, featured, order, status, published, project_translations(locale, title, category, summary, description, highlights)",
     )
     .order("featured", { ascending: false })
     .order("order")

--- a/src/app/admin/(dashboard)/projects/data.ts
+++ b/src/app/admin/(dashboard)/projects/data.ts
@@ -18,6 +18,8 @@ export interface AdminProjectRow {
   summaryVi: string;
   descriptionEn: string | null;
   descriptionVi: string | null;
+  highlightsEn: string[];
+  highlightsVi: string[];
 }
 
 interface ProjectTranslation {
@@ -26,6 +28,7 @@ interface ProjectTranslation {
   category: string;
   summary: string;
   description: string | null;
+  highlights?: string[] | string;
 }
 
 interface ProjectRowWithTranslations {
@@ -87,7 +90,24 @@ function mapProjectRow(
     summaryVi: vi?.summary ?? "",
     descriptionEn: en?.description ?? null,
     descriptionVi: vi?.description ?? null,
+    highlightsEn: parseStringArray(en?.highlights),
+    highlightsVi: parseStringArray(vi?.highlights),
   };
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item));
+  }
+  if (typeof value === "string" && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed.map((item) => String(item)) : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
 }
 
 function parseTechStack(value: string[] | string | null | undefined): string[] {

--- a/src/app/admin/(dashboard)/projects/delete-project.tsx
+++ b/src/app/admin/(dashboard)/projects/delete-project.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteProject } from "./actions";
+
+interface DeleteProjectButtonProps {
+  id: string;
+  title: string;
+}
+
+export function DeleteProjectButton({ id, title }: DeleteProjectButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm(`Delete project "${title}"?`)) return;
+
+    startTransition(async () => {
+      const result = await deleteProject(id);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to delete.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        className="admin-link-button admin-link-button--danger"
+        disabled={isPending}
+        onClick={handleDelete}
+        type="button"
+      >
+        {isPending ? "…" : "Delete"}
+      </button>
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/projects/new/page.tsx
+++ b/src/app/admin/(dashboard)/projects/new/page.tsx
@@ -1,0 +1,14 @@
+import { ProjectForm } from "../project-form";
+
+export const metadata = {
+  title: "New project",
+};
+
+export default function AdminNewProjectPage() {
+  return (
+    <main className="admin-dashboard">
+      <h1>New project</h1>
+      <ProjectForm />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/projects/page.tsx
+++ b/src/app/admin/(dashboard)/projects/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+import { listProjects } from "./data";
+import { DeleteProjectButton } from "./delete-project";
+
+export const metadata = {
+  title: "Admin projects",
+};
+
+export default async function AdminProjectsPage() {
+  const projects = await listProjects();
+
+  return (
+    <main className="admin-dashboard">
+      <div className="admin-page-head">
+        <h1>Projects</h1>
+        <Link className="admin-button" href="/admin/projects/new">
+          New project
+        </Link>
+      </div>
+
+      <table className="admin-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Featured</th>
+            <th>Status</th>
+            <th>Order</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {projects.map((project) => (
+            <tr key={project.id}>
+              <td>{project.id}</td>
+              <td>{project.titleEn}</td>
+              <td>{project.featured ? "✓" : ""}</td>
+              <td>{project.status}</td>
+              <td>{project.order}</td>
+              <td className="admin-row-actions">
+                <Link href={`/admin/projects/${project.id}`}>Edit</Link>
+                <DeleteProjectButton id={project.id} title={project.titleEn} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/projects/project-form.tsx
+++ b/src/app/admin/(dashboard)/projects/project-form.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AdminProjectRow } from "./data";
+import {
+  createProject,
+  updateProject,
+  type ProjectActionResult,
+} from "./actions";
+
+interface ProjectFormProps {
+  existing?: AdminProjectRow;
+}
+
+export function ProjectForm({ existing }: ProjectFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+
+    const data = {
+      id: existing?.id ?? String(fd.get("id") ?? ""),
+      slug: String(fd.get("slug") ?? ""),
+      techStack: String(fd.get("techStack") ?? ""),
+      liveDemoUrl: String(fd.get("liveDemoUrl") ?? ""),
+      codeUrl: String(fd.get("codeUrl") ?? ""),
+      featured: fd.get("featured") === "on",
+      order: Number(fd.get("order") ?? 0),
+      status: String(fd.get("status") ?? "active"),
+      published: fd.get("published") === "on",
+      titleEn: String(fd.get("titleEn") ?? ""),
+      titleVi: String(fd.get("titleVi") ?? ""),
+      categoryEn: String(fd.get("categoryEn") ?? ""),
+      categoryVi: String(fd.get("categoryVi") ?? ""),
+      summaryEn: String(fd.get("summaryEn") ?? ""),
+      summaryVi: String(fd.get("summaryVi") ?? ""),
+      descriptionEn: String(fd.get("descriptionEn") ?? ""),
+      descriptionVi: String(fd.get("descriptionVi") ?? ""),
+    };
+
+    startTransition(async () => {
+      const result: ProjectActionResult = existing
+        ? await updateProject(data)
+        : await createProject(data);
+      if (result.ok) {
+        router.push("/admin/projects");
+        router.refresh();
+      } else {
+        setError(
+          result.fieldErrors
+            ? Object.values(result.fieldErrors).join(" ")
+            : result.error ?? "Failed.",
+        );
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      {!existing ? (
+        <label className="admin-field">
+          <span>ID (slug, optional)</span>
+          <input name="id" defaultValue="" />
+        </label>
+      ) : null}
+
+      <label className="admin-field">
+        <span>Slug</span>
+        <input name="slug" required defaultValue={existing?.slug ?? ""} />
+      </label>
+
+      <h3>Title</h3>
+      <label className="admin-field">
+        <span>Title (EN)</span>
+        <input name="titleEn" required defaultValue={existing?.titleEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Title (VI)</span>
+        <input name="titleVi" required defaultValue={existing?.titleVi ?? ""} />
+      </label>
+
+      <h3>Category</h3>
+      <label className="admin-field">
+        <span>Category (EN)</span>
+        <input name="categoryEn" required defaultValue={existing?.categoryEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Category (VI)</span>
+        <input name="categoryVi" required defaultValue={existing?.categoryVi ?? ""} />
+      </label>
+
+      <h3>Summary</h3>
+      <label className="admin-field">
+        <span>Summary (EN)</span>
+        <textarea name="summaryEn" required rows={3} defaultValue={existing?.summaryEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Summary (VI)</span>
+        <textarea name="summaryVi" required rows={3} defaultValue={existing?.summaryVi ?? ""} />
+      </label>
+
+      <h3>Description (optional)</h3>
+      <label className="admin-field">
+        <span>Description (EN)</span>
+        <textarea name="descriptionEn" rows={4} defaultValue={existing?.descriptionEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Description (VI)</span>
+        <textarea name="descriptionVi" rows={4} defaultValue={existing?.descriptionVi ?? ""} />
+      </label>
+
+      <h3>Details</h3>
+      <label className="admin-field">
+        <span>Tech stack (comma-separated)</span>
+        <input name="techStack" defaultValue={existing?.techStack.join(", ") ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Live Demo URL (http/https)</span>
+        <input name="liveDemoUrl" defaultValue={existing?.liveDemoUrl ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Code URL (http/https)</span>
+        <input name="codeUrl" defaultValue={existing?.codeUrl ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Order</span>
+        <input name="order" type="number" defaultValue={existing?.order ?? 0} />
+      </label>
+      <label className="admin-field">
+        <span>Status</span>
+        <select name="status" defaultValue={existing?.status ?? "active"}>
+          <option value="active">Active</option>
+          <option value="archived">Archived</option>
+          <option value="private">Private</option>
+        </select>
+      </label>
+
+      <label className="admin-check">
+        <input name="featured" type="checkbox" defaultChecked={existing?.featured} />
+        <span>Featured</span>
+      </label>
+      <label className="admin-check">
+        <input name="published" type="checkbox" defaultChecked={existing?.published} />
+        <span>Published</span>
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <button disabled={isPending} type="submit">
+        {isPending ? "Saving…" : existing ? "Update project" : "Create project"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/projects/project-form.tsx
+++ b/src/app/admin/(dashboard)/projects/project-form.tsx
@@ -41,6 +41,8 @@ export function ProjectForm({ existing }: ProjectFormProps) {
       summaryVi: String(fd.get("summaryVi") ?? ""),
       descriptionEn: String(fd.get("descriptionEn") ?? ""),
       descriptionVi: String(fd.get("descriptionVi") ?? ""),
+      highlightsEn: String(fd.get("highlightsEn") ?? ""),
+      highlightsVi: String(fd.get("highlightsVi") ?? ""),
     };
 
     startTransition(async () => {
@@ -112,6 +114,16 @@ export function ProjectForm({ existing }: ProjectFormProps) {
       <label className="admin-field">
         <span>Description (VI)</span>
         <textarea name="descriptionVi" rows={4} defaultValue={existing?.descriptionVi ?? ""} />
+      </label>
+
+      <h3>Highlights (one per line)</h3>
+      <label className="admin-field">
+        <span>Highlights (EN)</span>
+        <textarea name="highlightsEn" rows={4} defaultValue={existing?.highlightsEn.join("\n") ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Highlights (VI)</span>
+        <textarea name="highlightsVi" rows={4} defaultValue={existing?.highlightsVi.join("\n") ?? ""} />
       </label>
 
       <h3>Details</h3>

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -27,7 +27,7 @@ const FIXTURES = {
 
 async function insertProject(
   id: string,
-  opts: { status?: string; published?: boolean; withMedia?: boolean },
+  opts: { status?: string; published?: boolean; withMedia?: boolean; order?: number },
 ) {
   const { error } = await client.from("projects").upsert(
     {
@@ -35,7 +35,7 @@ async function insertProject(
       slug: id,
       tech_stack: ["TS"],
       featured: true,
-      order: 1,
+      order: opts.order ?? 1,
       status: opts.status ?? "active",
       published: opts.published ?? true,
     },
@@ -64,7 +64,7 @@ async function insertProject(
     ],
     { onConflict: "project_id,locale" },
   );
-  assert.equal(error, null, `translations ${id}: ${trErr?.message}`);
+  assert.equal(trErr, null, `translations ${id}: ${trErr?.message}`);
 
   if (opts.withMedia) {
     const { error: mediaErr } = await client.from("project_media").upsert(
@@ -79,22 +79,24 @@ async function insertProject(
       },
       { onConflict: "id" },
     );
-    assert.equal(error, null, `media ${id}: ${mediaErr?.message}`);
+    assert.equal(mediaErr, null, `media ${id}: ${mediaErr?.message}`);
   }
 }
 
 async function cleanup() {
-  for (const id of Object.values(FIXTURES)) {
-    await client.from("projects").delete().eq("id", id);
-  }
+  // Isolate from any pre-existing projects so fixture ordering is deterministic.
+  const { error } = await client.from("projects").delete().neq("id", "__none__");
+  assert.equal(error, null, `cleanup projects: ${error?.message}`);
 }
 
 test("public repository only returns featured+published+active projects with media", async () => {
   await cleanup();
-  await insertProject(FIXTURES.valid, { withMedia: true });
+  // zero-media project sorts before the valid one by order, so it must be
+  // dropped BEFORE index assignment to keep the visible index contiguous.
+  await insertProject(FIXTURES.zeroMedia, { withMedia: false, order: 0 });
   await insertProject(FIXTURES.private, { status: "private" });
   await insertProject(FIXTURES.unpublished, { published: false });
-  await insertProject(FIXTURES.zeroMedia, { withMedia: false });
+  await insertProject(FIXTURES.valid, { withMedia: true, order: 1 });
 
   const view = await getFeaturedProjects("en");
   const ids = view.projects.map((p) => p.id);
@@ -118,6 +120,11 @@ test("public repository only returns featured+published+active projects with med
 
   const valid = view.projects.find((p) => p.id === FIXTURES.valid);
   assert.ok(valid, "valid project present");
+  assert.equal(
+    valid?.index,
+    "01",
+    "visible indexes are contiguous (zero-media project dropped before numbering)",
+  );
   assert.deepEqual(
     valid?.highlights,
     ["H1", "H2"],

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRole) {
+  console.error(
+    "Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (local/cloud Supabase).",
+  );
+  process.exit(1);
+}
+
+import { createClient } from "@supabase/supabase-js";
+import { getFeaturedProjects } from "@/features/cms/repository";
+
+const client = createClient(url, serviceRole, {
+  auth: { persistSession: false },
+});
+
+const FIXTURES = {
+  valid: "repo-valid",
+  private: "repo-private",
+  unpublished: "repo-unpublished",
+  zeroMedia: "repo-zero-media",
+};
+
+async function insertProject(
+  id: string,
+  opts: { status?: string; published?: boolean; withMedia?: boolean },
+) {
+  const { error } = await client.from("projects").upsert(
+    {
+      id,
+      slug: id,
+      tech_stack: ["TS"],
+      featured: true,
+      order: 1,
+      status: opts.status ?? "active",
+      published: opts.published ?? true,
+    },
+    { onConflict: "id" },
+  );
+  assert.equal(error, null, `insert ${id}: ${error?.message}`);
+
+  const { error: trErr } = await client.from("project_translations").upsert(
+    [
+      {
+        project_id: id,
+        locale: "en",
+        title: id,
+        category: "Web",
+        summary: "Summary",
+        highlights: ["H1", "H2"],
+      },
+      {
+        project_id: id,
+        locale: "vi",
+        title: id,
+        category: "Web",
+        summary: "Tóm tắt",
+        highlights: ["H1", "H2"],
+      },
+    ],
+    { onConflict: "project_id,locale" },
+  );
+  assert.equal(error, null, `translations ${id}: ${trErr?.message}`);
+
+  if (opts.withMedia) {
+    const { error: mediaErr } = await client.from("project_media").upsert(
+      {
+        id: `${id}-main`,
+        project_id: id,
+        src: "/images/projects/test.jpg",
+        width: 800,
+        height: 600,
+        order: 1,
+        focal_point: "40% 60%",
+      },
+      { onConflict: "id" },
+    );
+    assert.equal(error, null, `media ${id}: ${mediaErr?.message}`);
+  }
+}
+
+async function cleanup() {
+  for (const id of Object.values(FIXTURES)) {
+    await client.from("projects").delete().eq("id", id);
+  }
+}
+
+test("public repository only returns featured+published+active projects with media", async () => {
+  await cleanup();
+  await insertProject(FIXTURES.valid, { withMedia: true });
+  await insertProject(FIXTURES.private, { status: "private" });
+  await insertProject(FIXTURES.unpublished, { published: false });
+  await insertProject(FIXTURES.zeroMedia, { withMedia: false });
+
+  const view = await getFeaturedProjects("en");
+  const ids = view.projects.map((p) => p.id);
+
+  assert.ok(
+    ids.includes(FIXTURES.valid),
+    "valid featured+published+active project with media is included",
+  );
+  assert.ok(
+    !ids.includes(FIXTURES.private),
+    "private project is excluded at the query boundary",
+  );
+  assert.ok(
+    !ids.includes(FIXTURES.unpublished),
+    "unpublished project is excluded at the query boundary",
+  );
+  assert.ok(
+    !ids.includes(FIXTURES.zeroMedia),
+    "featured+published+active project with zero media is filtered out",
+  );
+
+  const valid = view.projects.find((p) => p.id === FIXTURES.valid);
+  assert.ok(valid, "valid project present");
+  assert.deepEqual(
+    valid?.highlights,
+    ["H1", "H2"],
+    "highlights are preserved",
+  );
+  assert.equal(
+    valid?.media[0]?.focalPoint,
+    "40% 60%",
+    "media focalPoint is preserved",
+  );
+
+  await cleanup();
+});

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -4,9 +4,21 @@ import { test } from "node:test";
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
+// Hard local-only guard: this test mutates CMS data and MUST never run against a
+// cloud/production project. It only ever touches a handful of fixture rows, but
+// we refuse to run unless the URL is the known local Supabase endpoint.
 if (!url || !serviceRole) {
   console.error(
-    "Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (local/cloud Supabase).",
+    "Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (local Supabase).",
+  );
+  process.exit(1);
+}
+
+const LOCAL_HOST = /^http:\/\/127\.0\.0\.1(?::\d+)?$/;
+if (!LOCAL_HOST.test(url)) {
+  console.error(
+    `Refusing to run repository test against non-local Supabase: ${url}\n` +
+      "This test mutates CMS fixtures and must only target local Supabase.",
   );
   process.exit(1);
 }
@@ -83,10 +95,11 @@ async function insertProject(
   }
 }
 
+// Cleanup deletes ONLY the fixture ids this test created. Never a mass delete.
 async function cleanup() {
-  // Isolate from any pre-existing projects so fixture ordering is deterministic.
-  const { error } = await client.from("projects").delete().neq("id", "__none__");
-  assert.equal(error, null, `cleanup projects: ${error?.message}`);
+  for (const id of Object.values(FIXTURES)) {
+    await client.from("projects").delete().eq("id", id);
+  }
 }
 
 test("public repository only returns featured+published+active projects with media", async () => {
@@ -98,43 +111,51 @@ test("public repository only returns featured+published+active projects with med
   await insertProject(FIXTURES.unpublished, { published: false });
   await insertProject(FIXTURES.valid, { withMedia: true, order: 1 });
 
-  const view = await getFeaturedProjects("en");
-  const ids = view.projects.map((p) => p.id);
+  try {
+    const view = await getFeaturedProjects("en");
+    const ids = view.projects.map((p) => p.id);
 
-  assert.ok(
-    ids.includes(FIXTURES.valid),
-    "valid featured+published+active project with media is included",
-  );
-  assert.ok(
-    !ids.includes(FIXTURES.private),
-    "private project is excluded at the query boundary",
-  );
-  assert.ok(
-    !ids.includes(FIXTURES.unpublished),
-    "unpublished project is excluded at the query boundary",
-  );
-  assert.ok(
-    !ids.includes(FIXTURES.zeroMedia),
-    "featured+published+active project with zero media is filtered out",
-  );
+    assert.ok(
+      ids.includes(FIXTURES.valid),
+      "valid featured+published+active project with media is included",
+    );
+    assert.ok(
+      !ids.includes(FIXTURES.private),
+      "private project is excluded at the query boundary",
+    );
+    assert.ok(
+      !ids.includes(FIXTURES.unpublished),
+      "unpublished project is excluded at the query boundary",
+    );
+    assert.ok(
+      !ids.includes(FIXTURES.zeroMedia),
+      "featured+published+active project with zero media is filtered out",
+    );
 
-  const valid = view.projects.find((p) => p.id === FIXTURES.valid);
-  assert.ok(valid, "valid project present");
-  assert.equal(
-    valid?.index,
-    "01",
-    "visible indexes are contiguous (zero-media project dropped before numbering)",
-  );
-  assert.deepEqual(
-    valid?.highlights,
-    ["H1", "H2"],
-    "highlights are preserved",
-  );
-  assert.equal(
-    valid?.media[0]?.focalPoint,
-    "40% 60%",
-    "media focalPoint is preserved",
-  );
+    const valid = view.projects.find((p) => p.id === FIXTURES.valid);
+    assert.ok(valid, "valid project present");
+    assert.deepEqual(
+      valid?.highlights,
+      ["H1", "H2"],
+      "highlights are preserved",
+    );
+    assert.equal(
+      valid?.media[0]?.focalPoint,
+      "40% 60%",
+      "media focalPoint is preserved",
+    );
 
-  await cleanup();
+    // Visible indexes must be contiguous (01, 02, ...) with no gaps, regardless
+    // of how many pre-existing renderable projects the DB holds.
+    const expectedIndexes = view.projects.map((_, i) =>
+      String(i + 1).padStart(2, "0"),
+    );
+    assert.deepEqual(
+      view.projects.map((p) => p.index),
+      expectedIndexes,
+      "visible indexes are contiguous after zero-media filtering",
+    );
+  } finally {
+    await cleanup();
+  }
 });

--- a/src/features/cms/repository.ts
+++ b/src/features/cms/repository.ts
@@ -13,6 +13,10 @@ import {
   getContactContent as getLocalContact,
   type ContactContentView,
 } from "@/content/contact";
+import {
+  getFeaturedProjects as getLocalFeaturedProjects,
+  type FeaturedProjectsView,
+} from "@/content/projects";
 import { getServiceClient } from "./server";
 import { hasCmsConfig } from "./config";
 
@@ -218,6 +222,118 @@ export async function getContactContent(
         value: row.label,
         href: row.url,
       })),
+    };
+  } catch {
+    return base;
+  }
+}
+
+interface ProjectMediaRow {
+  id: string;
+  src: string;
+  width: number | null;
+  height: number | null;
+  order: number;
+  project_media_translations: Array<{ locale: string; alt: string }>;
+}
+
+interface ProjectRow {
+  id: string;
+  slug: string;
+  tech_stack: string[] | string;
+  live_demo_url: string | null;
+  code_url: string | null;
+  featured: boolean;
+  order: number;
+  status: string;
+  published: boolean;
+  project_translations: Array<{
+    locale: string;
+    title: string;
+    category: string;
+    summary: string;
+    description: string | null;
+  }>;
+  project_media: ProjectMediaRow[];
+}
+
+function parseTechStack(value: string[] | string | null | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string" && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export async function getFeaturedProjects(
+  locale: Locale,
+): Promise<FeaturedProjectsView> {
+  const base = getLocalFeaturedProjects(locale);
+
+  if (!hasCmsConfig()) {
+    return base;
+  }
+
+  const client = getServiceClient();
+  if (!client) return base;
+
+  try {
+    const { data, error } = await client
+      .from("projects")
+      .select(
+        "id, slug, tech_stack, live_demo_url, code_url, featured, order, status, published, project_translations(locale, title, category, summary, description), project_media(id, src, width, height, order, project_media_translations(locale, alt))",
+      )
+      .order("order")
+      .order("id");
+
+    if (error || !data) return base;
+
+    const rows = (data as ProjectRow[]).filter(
+      (row) => row.featured && row.published && row.status === "active",
+    );
+    rows.sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+
+    const projects = rows.map((row, index) => {
+      const en = row.project_translations.find((t) => t.locale === "en");
+      const active = row.project_translations.find((t) => t.locale === locale);
+      const media = [...(row.project_media ?? [])]
+        .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+        .map((m) => {
+          const alt =
+            m.project_media_translations.find((t) => t.locale === locale)?.alt ??
+            m.project_media_translations.find((t) => t.locale === "en")?.alt ??
+            "";
+          return {
+            id: m.id,
+            src: m.src,
+            alt,
+            width: m.width ?? 800,
+            height: m.height ?? 600,
+            focalPoint: "50% 50%",
+          };
+        });
+
+      return {
+        id: row.id,
+        index: String(index + 1).padStart(2, "0"),
+        title: active?.title ?? en?.title ?? "",
+        category: active?.category ?? en?.category ?? "",
+        summary: active?.summary ?? en?.summary ?? "",
+        techStack: parseTechStack(row.tech_stack),
+        media,
+        liveDemoUrl: row.live_demo_url ?? undefined,
+        codeUrl: row.code_url ?? undefined,
+      };
+    });
+
+    return {
+      ...base,
+      projects,
     };
   } catch {
     return base;

--- a/src/features/cms/repository.ts
+++ b/src/features/cms/repository.ts
@@ -316,11 +316,13 @@ export async function getFeaturedProjects(
     const rows = data as ProjectRow[];
     rows.sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
 
-    const projects = rows
-      .map((row, index) => {
-        const en = row.project_translations.find((t) => t.locale === "en");
-        const active = row.project_translations.find((t) => t.locale === locale);
-        const media = [...(row.project_media ?? [])]
+    // A featured+published project with zero media is non-renderable (the
+    // carousel has no zero-media state). Drop such rows BEFORE assigning the
+    // visible index so numbering stays contiguous (01/…, 02/…).
+    const renderable = rows
+      .map((row) => ({
+        row,
+        media: [...(row.project_media ?? [])]
           .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
           .map((m) => {
             const alt =
@@ -335,32 +337,32 @@ export async function getFeaturedProjects(
               height: m.height ?? 600,
               focalPoint: m.focal_point ?? "50% 50%",
             };
-          });
+          }),
+      }))
+      .filter((entry) => entry.media.length > 0);
 
-        // A featured+published project with zero media is non-renderable (the
-        // carousel has no zero-media state). Filter it out of the public result
-        // (media editing is #21).
-        if (media.length === 0) return null;
+    const projects = renderable.map(({ row, media }, index) => {
+      const en = row.project_translations.find((t) => t.locale === "en");
+      const active = row.project_translations.find((t) => t.locale === locale);
 
-        const highlights =
-          parseStringArray(active?.highlights).length > 0
-            ? parseStringArray(active?.highlights)
-            : parseStringArray(en?.highlights);
+      const highlights =
+        parseStringArray(active?.highlights).length > 0
+          ? parseStringArray(active?.highlights)
+          : parseStringArray(en?.highlights);
 
-        return {
-          id: row.id,
-          index: String(index + 1).padStart(2, "0"),
-          title: active?.title ?? en?.title ?? "",
-          category: active?.category ?? en?.category ?? "",
-          summary: active?.summary ?? en?.summary ?? "",
-          techStack: parseTechStack(row.tech_stack),
-          media,
-          liveDemoUrl: row.live_demo_url ?? undefined,
-          codeUrl: row.code_url ?? undefined,
-          ...(highlights.length > 0 ? { highlights } : {}),
-        };
-      })
-      .filter((project): project is NonNullable<typeof project> => project !== null);
+      return {
+        id: row.id,
+        index: String(index + 1).padStart(2, "0"),
+        title: active?.title ?? en?.title ?? "",
+        category: active?.category ?? en?.category ?? "",
+        summary: active?.summary ?? en?.summary ?? "",
+        techStack: parseTechStack(row.tech_stack),
+        media,
+        liveDemoUrl: row.live_demo_url ?? undefined,
+        codeUrl: row.code_url ?? undefined,
+        ...(highlights.length > 0 ? { highlights } : {}),
+      };
+    });
 
     return {
       ...base,

--- a/src/features/cms/repository.ts
+++ b/src/features/cms/repository.ts
@@ -233,6 +233,7 @@ interface ProjectMediaRow {
   src: string;
   width: number | null;
   height: number | null;
+  focal_point: string | null;
   order: number;
   project_media_translations: Array<{ locale: string; alt: string }>;
 }
@@ -253,6 +254,7 @@ interface ProjectRow {
     category: string;
     summary: string;
     description: string | null;
+    highlights?: string[] | string;
   }>;
   project_media: ProjectMediaRow[];
 }
@@ -263,6 +265,21 @@ function parseTechStack(value: string[] | string | null | undefined): string[] {
     try {
       const parsed = JSON.parse(value);
       return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item));
+  }
+  if (typeof value === "string" && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed.map((item) => String(item)) : [];
     } catch {
       return [];
     }
@@ -286,50 +303,64 @@ export async function getFeaturedProjects(
     const { data, error } = await client
       .from("projects")
       .select(
-        "id, slug, tech_stack, live_demo_url, code_url, featured, order, status, published, project_translations(locale, title, category, summary, description), project_media(id, src, width, height, order, project_media_translations(locale, alt))",
+        "id, slug, tech_stack, live_demo_url, code_url, featured, order, status, published, project_translations(locale, title, category, summary, description, highlights), project_media(id, src, width, height, focal_point, order, project_media_translations(locale, alt))",
       )
+      .eq("featured", true)
+      .eq("published", true)
+      .eq("status", "active")
       .order("order")
       .order("id");
 
     if (error || !data) return base;
 
-    const rows = (data as ProjectRow[]).filter(
-      (row) => row.featured && row.published && row.status === "active",
-    );
+    const rows = data as ProjectRow[];
     rows.sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
 
-    const projects = rows.map((row, index) => {
-      const en = row.project_translations.find((t) => t.locale === "en");
-      const active = row.project_translations.find((t) => t.locale === locale);
-      const media = [...(row.project_media ?? [])]
-        .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
-        .map((m) => {
-          const alt =
-            m.project_media_translations.find((t) => t.locale === locale)?.alt ??
-            m.project_media_translations.find((t) => t.locale === "en")?.alt ??
-            "";
-          return {
-            id: m.id,
-            src: m.src,
-            alt,
-            width: m.width ?? 800,
-            height: m.height ?? 600,
-            focalPoint: "50% 50%",
-          };
-        });
+    const projects = rows
+      .map((row, index) => {
+        const en = row.project_translations.find((t) => t.locale === "en");
+        const active = row.project_translations.find((t) => t.locale === locale);
+        const media = [...(row.project_media ?? [])]
+          .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+          .map((m) => {
+            const alt =
+              m.project_media_translations.find((t) => t.locale === locale)?.alt ??
+              m.project_media_translations.find((t) => t.locale === "en")?.alt ??
+              "";
+            return {
+              id: m.id,
+              src: m.src,
+              alt,
+              width: m.width ?? 800,
+              height: m.height ?? 600,
+              focalPoint: m.focal_point ?? "50% 50%",
+            };
+          });
 
-      return {
-        id: row.id,
-        index: String(index + 1).padStart(2, "0"),
-        title: active?.title ?? en?.title ?? "",
-        category: active?.category ?? en?.category ?? "",
-        summary: active?.summary ?? en?.summary ?? "",
-        techStack: parseTechStack(row.tech_stack),
-        media,
-        liveDemoUrl: row.live_demo_url ?? undefined,
-        codeUrl: row.code_url ?? undefined,
-      };
-    });
+        // A featured+published project with zero media is non-renderable (the
+        // carousel has no zero-media state). Filter it out of the public result
+        // (media editing is #21).
+        if (media.length === 0) return null;
+
+        const highlights =
+          parseStringArray(active?.highlights).length > 0
+            ? parseStringArray(active?.highlights)
+            : parseStringArray(en?.highlights);
+
+        return {
+          id: row.id,
+          index: String(index + 1).padStart(2, "0"),
+          title: active?.title ?? en?.title ?? "",
+          category: active?.category ?? en?.category ?? "",
+          summary: active?.summary ?? en?.summary ?? "",
+          techStack: parseTechStack(row.tech_stack),
+          media,
+          liveDemoUrl: row.live_demo_url ?? undefined,
+          codeUrl: row.code_url ?? undefined,
+          ...(highlights.length > 0 ? { highlights } : {}),
+        };
+      })
+      .filter((project): project is NonNullable<typeof project> => project !== null);
 
     return {
       ...base,

--- a/supabase/migrations/20260820160000_cms_projects_crud.sql
+++ b/supabase/migrations/20260820160000_cms_projects_crud.sql
@@ -1,0 +1,105 @@
+-- Issue #51: CMS CRUD for Projects (second CRUD slice).
+--
+-- 1. Convert projects (and its media/translation children) to stable text ids,
+--    matching the local content's stable string ids (e.g. 'atm-seeking'). This
+--    preserves stable IDs across the CMS and makes backfill/repository mapping
+--    direct, following the same pattern used for skills and social_links.
+-- 2. Add SECURITY INVOKER atomic RPCs (create/update + delete) granted to
+--    authenticated so admin CRUD runs through the owner RLS path. Each mutation
+--    writes the base row and both translation rows in a single transaction.
+--    Media editing is out of scope for #51 (Issue #21), so the RPCs leave media
+--    untouched; the public read path still maps existing media rows.
+-- 3. Deterministic ordering is handled in the admin query layer (order by
+--    order/id) and the public view derivation (filter featured, sort order/id).
+
+-- --- Convert projects to stable text ids -------------------------------------
+alter table project_media_translations drop constraint project_media_translations_project_media_id_fkey;
+alter table project_media drop constraint project_media_project_id_fkey;
+alter table project_translations drop constraint project_translations_project_id_fkey;
+
+alter table project_translations alter column project_id type text;
+alter table project_media alter column project_id type text;
+alter table project_media alter column id type text;
+alter table project_media drop constraint project_media_pkey;
+alter table project_media add primary key (id);
+alter table project_media_translations alter column project_media_id type text;
+
+alter table projects drop constraint projects_pkey;
+alter table projects alter column id type text;
+alter table projects add primary key (id);
+
+alter table project_translations
+  add constraint project_translations_project_id_fkey
+  foreign key (project_id) references projects(id) on delete cascade;
+alter table project_media
+  add constraint project_media_project_id_fkey
+  foreign key (project_id) references projects(id) on delete cascade;
+alter table project_media_translations
+  add constraint project_media_translations_project_media_id_fkey
+  foreign key (project_media_id) references project_media(id) on delete cascade;
+
+-- --- Atomic mutations (SECURITY INVOKER, owner RLS path) ----------------------
+create or replace function public.cms_upsert_project(
+  p_id text,
+  p_slug text,
+  p_tech_stack jsonb,
+  p_live_demo_url text,
+  p_code_url text,
+  p_featured boolean,
+  p_order integer,
+  p_status text,
+  p_published boolean,
+  p_title_en text,
+  p_title_vi text,
+  p_category_en text,
+  p_category_vi text,
+  p_summary_en text,
+  p_summary_vi text,
+  p_description_en text,
+  p_description_vi text
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  insert into public.projects (id, slug, tech_stack, live_demo_url, code_url, featured, "order", status, published, updated_at)
+  values (p_id, p_slug, p_tech_stack, p_live_demo_url, p_code_url, p_featured, p_order, p_status, p_published, now())
+  on conflict (id) do update set
+    slug = excluded.slug,
+    tech_stack = excluded.tech_stack,
+    live_demo_url = excluded.live_demo_url,
+    code_url = excluded.code_url,
+    featured = excluded.featured,
+    "order" = excluded."order",
+    status = excluded.status,
+    published = excluded.published,
+    updated_at = now();
+
+  insert into public.project_translations (project_id, locale, title, category, summary, description)
+  values
+    (p_id, 'en', p_title_en, p_category_en, p_summary_en, p_description_en),
+    (p_id, 'vi', p_title_vi, p_category_vi, p_summary_vi, p_description_vi)
+  on conflict (project_id, locale) do update set
+    title = excluded.title,
+    category = excluded.category,
+    summary = excluded.summary,
+    description = excluded.description;
+end;
+$$;
+
+create or replace function public.cms_delete_project(p_id text)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from public.projects where id = p_id;
+$$;
+
+revoke all on function public.cms_upsert_project(text, text, jsonb, text, text, boolean, integer, text, boolean, text, text, text, text, text, text, text, text) from public;
+revoke all on function public.cms_delete_project(text) from public;
+
+grant execute on function public.cms_upsert_project(text, text, jsonb, text, text, boolean, integer, text, boolean, text, text, text, text, text, text, text, text) to authenticated, service_role;
+grant execute on function public.cms_delete_project(text) to authenticated, service_role;

--- a/supabase/migrations/20260820170000_cms_projects_preserve_presentation.sql
+++ b/supabase/migrations/20260820170000_cms_projects_preserve_presentation.sql
@@ -74,3 +74,7 @@ $$;
 
 revoke all on function public.cms_upsert_project(text, text, jsonb, text, text, boolean, integer, text, boolean, text, text, text, text, text, text, text, text, jsonb, jsonb) from public;
 grant execute on function public.cms_upsert_project(text, text, jsonb, text, text, boolean, integer, text, boolean, text, text, text, text, text, text, text, text, jsonb, jsonb) to authenticated, service_role;
+
+-- Drop the obsolete 17-argument overload from the earlier migration (replaced by
+-- the 19-argument version above that carries highlights).
+drop function if exists public.cms_upsert_project(text, text, jsonb, text, text, boolean, integer, text, boolean, text, text, text, text, text, text, text, text);

--- a/supabase/migrations/20260820170000_cms_projects_preserve_presentation.sql
+++ b/supabase/migrations/20260820170000_cms_projects_preserve_presentation.sql
@@ -1,0 +1,76 @@
+-- Issue #51 review follow-up (request-changes):
+-- Preserve the public presentation fields that the local ProjectView carries but
+-- the initial projects CRUD schema omitted:
+--   1. project_media.focal_point (text) — local media carry meaningful focal points
+--      that the carousel renders via objectPosition; hard-coding "50% 50%" degrades
+--      cropping after CMS cutover.
+--   2. project_translations.highlights (jsonb) — the local ProjectView exposes
+--      optional highlight bullets; without a column they are dropped after cutover.
+--   3. Query-boundary publication filter: the public repository filters
+--      featured && published && status='active' in the PostgREST query (accepted
+--      #18 design), not only in application code.
+--   4. Zero-media safety: a featured+published project with no media is
+--      non-renderable (the carousel has no zero-media state). The repository
+--      adapter filters such projects out of the public result (media editing is #21).
+
+alter table project_media add column if not exists focal_point text;
+alter table project_translations add column if not exists highlights jsonb;
+
+-- Redefine the projects upsert to carry highlights (EN/VI) so admin edits do not
+-- wipe the preserved highlight bullets. Media (and focal_point) are left untouched
+-- by this slice; they are managed in #21.
+create or replace function public.cms_upsert_project(
+  p_id text,
+  p_slug text,
+  p_tech_stack jsonb,
+  p_live_demo_url text,
+  p_code_url text,
+  p_featured boolean,
+  p_order integer,
+  p_status text,
+  p_published boolean,
+  p_title_en text,
+  p_title_vi text,
+  p_category_en text,
+  p_category_vi text,
+  p_summary_en text,
+  p_summary_vi text,
+  p_description_en text,
+  p_description_vi text,
+  p_highlights_en jsonb,
+  p_highlights_vi jsonb
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  insert into public.projects (id, slug, tech_stack, live_demo_url, code_url, featured, "order", status, published, updated_at)
+  values (p_id, p_slug, p_tech_stack, p_live_demo_url, p_code_url, p_featured, p_order, p_status, p_published, now())
+  on conflict (id) do update set
+    slug = excluded.slug,
+    tech_stack = excluded.tech_stack,
+    live_demo_url = excluded.live_demo_url,
+    code_url = excluded.code_url,
+    featured = excluded.featured,
+    "order" = excluded."order",
+    status = excluded.status,
+    published = excluded.published,
+    updated_at = now();
+
+  insert into public.project_translations (project_id, locale, title, category, summary, description, highlights)
+  values
+    (p_id, 'en', p_title_en, p_category_en, p_summary_en, p_description_en, p_highlights_en),
+    (p_id, 'vi', p_title_vi, p_category_vi, p_summary_vi, p_description_vi, p_highlights_vi)
+  on conflict (project_id, locale) do update set
+    title = excluded.title,
+    category = excluded.category,
+    summary = excluded.summary,
+    description = excluded.description,
+    highlights = excluded.highlights;
+end;
+$$;
+
+revoke all on function public.cms_upsert_project(text, text, jsonb, text, text, boolean, integer, text, boolean, text, text, text, text, text, text, text, text, jsonb, jsonb) from public;
+grant execute on function public.cms_upsert_project(text, text, jsonb, text, text, boolean, integer, text, boolean, text, text, text, text, text, text, text, text, jsonb, jsonb) to authenticated, service_role;

--- a/supabase/tests/rls_crud_test.sql
+++ b/supabase/tests/rls_crud_test.sql
@@ -14,7 +14,7 @@
 -- to whichever auth user is the configured single owner.
 
 begin;
-select plan(9);
+select plan(11);
 
 -- Capture the owner uid while still superuser (admin_owner is RLS-filtered for
 -- other roles), then set claims session-wide so they survive the role switch.
@@ -40,6 +40,10 @@ insert into public.skills (id, group_key, "order")
   values ('rls-test', 'tech-stack', 1)
   on conflict (id) do nothing;
 
+insert into public.projects (id, slug, tech_stack, featured, "order", status, published)
+  values ('rls-test', 'rls-test', '[]', true, 1, 'active', true)
+  on conflict (id) do nothing;
+
 -- --- Owner: SELECT succeeds ------------------------------------------------
 set local role authenticated;
 
@@ -59,6 +63,12 @@ select is(
   (select count(*) from public.skills where id = 'rls-test'),
   1::bigint,
   'owner can SELECT skills'
+);
+
+select is(
+  (select count(*) from public.projects where id = 'rls-test'),
+  1::bigint,
+  'owner can SELECT projects'
 );
 
 -- --- Owner: INSERT succeeds -----------------------------------------------
@@ -118,10 +128,17 @@ select throws_ok(
   'non-owner cannot INSERT into skills (RLS with-check)'
 );
 
+select is(
+  (select count(*) from public.projects),
+  0::bigint,
+  'non-owner sees zero projects rows (RLS filters)'
+);
+
 -- --- Cleanup fixtures ------------------------------------------------
 reset role;
 delete from public.social_links where id = 'rls-test';
 delete from public.skills where id = 'rls-test';
+delete from public.projects where id = 'rls-test';
 delete from public.profile where id = '00000000-0000-0000-0000-000000000001';
 
 select * from finish();


### PR DESCRIPTION
Closes #51

## Summary
Second CMS CRUD slice: structured admin management for Projects, built on the
repository/view-model pattern established in #20. Admin CRUD routes through the
authenticated owner/RLS path, and the public site reads projects through the
repository adapter.

## What changed

### Schema / migrations
- Convert `projects` / `project_media` to stable text ids (matching local content
  slugs like `atm-seeking`), cascading FKs to translations.
- Add `cms_upsert_project` / `cms_delete_project` SECURITY INVOKER RPCs that run
  base-row + translation-row writes in a single transaction, granted to
  `authenticated` so RLS evaluates on every mutation.
- `scripts/backfill-content.mjs` now backfills projects (base + translations +
  media + media translations) idempotently and stores `tech_stack` as a proper
  jsonb array.

### Admin UI (authenticated owner/RLS path)
- Projects list / create / edit / delete with:
  - URL validation for Live Demo and Code URLs
  - deterministic featured + order controls
  - status (active/archived/private) and published toggle
  - EN/VI title/category/summary/description editing without duplicating entities
- All reads/writes use `getServerClient()` (authenticated) so owner RLS is
  authoritative.

### Public read path
- `getFeaturedProjects` added to `src/features/cms/repository.ts`: maps CMS project
  rows (base + translations + media) to the existing `FeaturedProjectsView`,
  filtering featured/published/active with stable ordering, with local-content
  fallback.
- The public locale page consumes the adapter so admin project edits change the
  site.

### Deterministic ordering
- Project list and featured derivation order by `order` then `id` as a stable
  secondary key.

## Verification
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` — 99 pass
- `npm run test:db` — 2 pass
- `supabase db test --local supabase/tests` — 11/11 RLS assertions pass (owner
  CRUD incl. projects; anonymous + non-owner denied)
- `npm run build` — pass
- Live owner-path check: project create/read/delete via RPC (204); non-owner and
  anonymous denied

## Known limitations
- Project media editing is out of scope (Issue #21); existing media rows are read
  for the public view but not editable from this slice.

## Docs affected
- `docs/superpowers/specs/2026-08-20-supabase-cms-schema-design.md` (projects
  stable-id conversion).