### PR TITLE
feat: CMS CRUD for resume/CV (Issue #52)

### DIFF
--- a/scripts/backfill-content.mjs
+++ b/scripts/backfill-content.mjs
@@ -233,11 +233,112 @@ async function backfillProjects() {
   console.log("Projects backfilled.");
 }
 
+async function backfillResume() {
+  const { resumeEntries } = await import("../src/content/resume.ts");
+  const categoryNames = {
+    "career-journey": { en: "Career Journey", vi: "Hành trình sự nghiệp" },
+    "education-certifications": {
+      en: "Education & Certifications",
+      vi: "Học vấn & Chứng chỉ",
+    },
+  };
+
+  for (const [slug, names] of Object.entries(categoryNames)) {
+    await upsert(
+      "resume_categories",
+      [{ id: slug, slug, order: slug === "career-journey" ? 1 : 2 }],
+      "id",
+    );
+    await upsert(
+      "resume_category_translations",
+      [
+        { resume_category_id: slug, locale: "en", name: names.en },
+        { resume_category_id: slug, locale: "vi", name: names.vi },
+      ],
+      "resume_category_id,locale",
+    );
+  }
+
+  for (const entry of resumeEntries) {
+    await upsert(
+      "resume_entries",
+      [
+        {
+          id: entry.id,
+          category_id: entry.category,
+          start_date: null,
+          end_date: null,
+          order: entry.order,
+          draft: false,
+        },
+      ],
+      "id",
+    );
+
+    await upsert(
+      "resume_entry_translations",
+      [
+        {
+          resume_entry_id: entry.id,
+          locale: "en",
+          title: entry.title.en,
+          organization: entry.organization?.en ?? null,
+          location: entry.location?.en ?? null,
+          date_label: entry.dateLabel?.en ?? null,
+          summary: entry.summary?.en ?? null,
+          highlights: (entry.highlights ?? []).map((h) => h.en),
+          tags: (entry.tags ?? []).map((t) => t.en),
+        },
+        {
+          resume_entry_id: entry.id,
+          locale: "vi",
+          title: entry.title.vi,
+          organization: entry.organization?.vi ?? null,
+          location: entry.location?.vi ?? null,
+          date_label: entry.dateLabel?.vi ?? null,
+          summary: entry.summary?.vi ?? null,
+          highlights: (entry.highlights ?? []).map((h) => h.vi),
+          tags: (entry.tags ?? []).map((t) => t.vi),
+        },
+      ],
+      "resume_entry_id,locale",
+    );
+
+    for (const media of entry.media ?? []) {
+      await upsert(
+        "resume_media",
+        [
+          {
+            id: media.id,
+            resume_entry_id: entry.id,
+            thumbnail_src: media.thumbnailSrc,
+            full_src: media.fullSrc,
+            width: media.width ?? null,
+            height: media.height ?? null,
+            order: 1,
+          },
+        ],
+        "id",
+      );
+      await upsert(
+        "resume_media_translations",
+        [
+          { resume_media_id: media.id, locale: "en", alt: media.alt.en, caption: media.caption?.en ?? null },
+          { resume_media_id: media.id, locale: "vi", alt: media.alt.vi, caption: media.caption?.vi ?? null },
+        ],
+        "resume_media_id,locale",
+      );
+    }
+  }
+  console.log("Resume backfilled.");
+}
+
 async function main() {
   await backfillSkills();
   await backfillProfile();
   await backfillContact();
   await backfillProjects();
+  await backfillResume();
   console.log("Backfill complete.");
 }
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,12 +8,13 @@ import { ProjectsSection } from "@/components/sections/projects/projects-section
 import { ResumeSection } from "@/components/sections/resume/resume-section";
 import { ResumeSectionLock } from "@/components/sections/resume/resume-section-lock";
 import { SkillsSection } from "@/components/sections/skills/skills-section";
-import { getResumeContent, getResumeLockContent } from "@/content/resume";
+import { getResumeLockContent } from "@/content/resume";
 import { getResumePublicity } from "@/features/cms/resume-publicity";
 import {
   getContactContent as getCmsContact,
   getFeaturedProjects as getCmsFeaturedProjects,
   getPortfolioProfile as getCmsProfile,
+  getResumeContent as getCmsResume,
   getSkillsContent as getCmsSkills,
 } from "@/features/cms/repository";
 import { getMessages } from "@/features/i18n/messages";
@@ -58,7 +59,7 @@ export default async function LocalePage({
       {isResumePrivate ? (
         <ResumeSectionLock content={getResumeLockContent(locale)} />
       ) : (
-        <ResumeSection content={getResumeContent(locale)} />
+        <ResumeSection content={await getCmsResume(locale)} />
       )}
       <ContactSection content={contact} />
 

--- a/src/app/admin/(dashboard)/layout.tsx
+++ b/src/app/admin/(dashboard)/layout.tsx
@@ -9,6 +9,7 @@ const navLinks = [
   { href: "/admin/skills", label: "Skills" },
   { href: "/admin/social", label: "Social" },
   { href: "/admin/projects", label: "Projects" },
+  { href: "/admin/resume", label: "Resume" },
 ] as const;
 
 export default async function AdminDashboardLayout({

--- a/src/app/admin/(dashboard)/resume/actions.ts
+++ b/src/app/admin/(dashboard)/resume/actions.ts
@@ -1,0 +1,239 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServerClient, isAdminUser } from "@/features/cms/session";
+import { required } from "@/features/cms/validation";
+
+export interface ResumeActionResult {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Record<string, string>;
+}
+
+export interface ResumeCategoryFormData {
+  id?: string;
+  order: number;
+  nameEn: string;
+  nameVi: string;
+}
+
+export interface ResumeEntryFormData {
+  id?: string;
+  categoryId: string;
+  startDate: string;
+  endDate: string;
+  order: number;
+  draft: boolean;
+  titleEn: string;
+  titleVi: string;
+  organizationEn: string;
+  organizationVi: string;
+  locationEn: string;
+  locationVi: string;
+  dateLabelEn: string;
+  dateLabelVi: string;
+  summaryEn: string;
+  summaryVi: string;
+  highlightsEn: string;
+  highlightsVi: string;
+  tagsEn: string;
+  tagsVi: string;
+}
+
+function splitLines(value: string): string[] {
+  return value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function splitTags(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export async function createResumeCategory(
+  data: ResumeCategoryFormData,
+): Promise<ResumeActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  if (!required(data.nameEn) || !required(data.nameVi)) {
+    return { ok: false, error: "EN and VI names are required." };
+  }
+
+  const id = data.id && data.id.length > 0 ? data.id : slugify(data.nameEn);
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_upsert_resume_category", {
+    p_id: id,
+    p_order: data.order,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/admin/resume");
+  return { ok: true };
+}
+
+export async function updateResumeCategory(
+  data: ResumeCategoryFormData,
+): Promise<ResumeActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  if (!data.id) return { ok: false, error: "Missing id." };
+  if (!required(data.nameEn) || !required(data.nameVi)) {
+    return { ok: false, error: "EN and VI names are required." };
+  }
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_upsert_resume_category", {
+    p_id: data.id,
+    p_order: data.order,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/resume");
+  return { ok: true };
+}
+
+export async function deleteResumeCategory(
+  id: string,
+): Promise<ResumeActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_delete_resume_category", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/resume");
+  return { ok: true };
+}
+
+export async function createResumeEntry(
+  data: ResumeEntryFormData,
+): Promise<ResumeActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const invalid = validateEntry(data);
+  if (invalid) return invalid;
+
+  const id =
+    data.id && data.id.length > 0
+      ? data.id
+      : `${data.categoryId}-${slugify(data.titleEn)}`;
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_upsert_resume_entry", {
+    p_id: id,
+    p_category_id: data.categoryId,
+    p_start_date: data.startDate || null,
+    p_end_date: data.endDate || null,
+    p_order: data.order,
+    p_draft: data.draft,
+    p_title_en: data.titleEn.trim(),
+    p_title_vi: data.titleVi.trim(),
+    p_organization_en: data.organizationEn.trim() || null,
+    p_organization_vi: data.organizationVi.trim() || null,
+    p_location_en: data.locationEn.trim() || null,
+    p_location_vi: data.locationVi.trim() || null,
+    p_date_label_en: data.dateLabelEn.trim() || null,
+    p_date_label_vi: data.dateLabelVi.trim() || null,
+    p_summary_en: data.summaryEn.trim() || null,
+    p_summary_vi: data.summaryVi.trim() || null,
+    p_highlights_en: splitLines(data.highlightsEn),
+    p_highlights_vi: splitLines(data.highlightsVi),
+    p_tags_en: splitTags(data.tagsEn),
+    p_tags_vi: splitTags(data.tagsVi),
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/resume");
+  return { ok: true };
+}
+
+export async function updateResumeEntry(
+  data: ResumeEntryFormData,
+): Promise<ResumeActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  if (!data.id) return { ok: false, error: "Missing id." };
+  const invalid = validateEntry(data);
+  if (invalid) return invalid;
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_upsert_resume_entry", {
+    p_id: data.id,
+    p_category_id: data.categoryId,
+    p_start_date: data.startDate || null,
+    p_end_date: data.endDate || null,
+    p_order: data.order,
+    p_draft: data.draft,
+    p_title_en: data.titleEn.trim(),
+    p_title_vi: data.titleVi.trim(),
+    p_organization_en: data.organizationEn.trim() || null,
+    p_organization_vi: data.organizationVi.trim() || null,
+    p_location_en: data.locationEn.trim() || null,
+    p_location_vi: data.locationVi.trim() || null,
+    p_date_label_en: data.dateLabelEn.trim() || null,
+    p_date_label_vi: data.dateLabelVi.trim() || null,
+    p_summary_en: data.summaryEn.trim() || null,
+    p_summary_vi: data.summaryVi.trim() || null,
+    p_highlights_en: splitLines(data.highlightsEn),
+    p_highlights_vi: splitLines(data.highlightsVi),
+    p_tags_en: splitTags(data.tagsEn),
+    p_tags_vi: splitTags(data.tagsVi),
+  });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/resume");
+  return { ok: true };
+}
+
+export async function deleteResumeEntry(
+  id: string,
+): Promise<ResumeActionResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  const client = await getServerClient();
+
+  const { error } = await client.rpc("cms_delete_resume_entry", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/resume");
+  return { ok: true };
+}
+
+function validateEntry(data: ResumeEntryFormData): ResumeActionResult | null {
+  if (!required(data.categoryId)) {
+    return { ok: false, fieldErrors: { categoryId: "Category is required." } };
+  }
+  if (!required(data.titleEn)) {
+    return { ok: false, fieldErrors: { titleEn: "EN title is required." } };
+  }
+  if (!required(data.titleVi)) {
+    return { ok: false, fieldErrors: { titleVi: "VI title is required." } };
+  }
+  return null;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/app/admin/(dashboard)/resume/categories/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/resume/categories/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from "next/navigation";
+
+import { listResumeCategories } from "../../data";
+import { ResumeCategoryForm } from "../../resume-category-form";
+
+interface AdminEditResumeCategoryPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "Edit resume category",
+};
+
+export default async function AdminEditResumeCategoryPage({
+  params,
+}: AdminEditResumeCategoryPageProps) {
+  const { id } = await params;
+  const categories = await listResumeCategories();
+  const category = categories.find((item) => item.id === id);
+
+  if (!category) {
+    notFound();
+  }
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Edit resume category</h1>
+      <ResumeCategoryForm existing={category} />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/resume/categories/new/page.tsx
+++ b/src/app/admin/(dashboard)/resume/categories/new/page.tsx
@@ -1,0 +1,14 @@
+import { ResumeCategoryForm } from "../../resume-category-form";
+
+export const metadata = {
+  title: "New resume category",
+};
+
+export default function AdminNewResumeCategoryPage() {
+  return (
+    <main className="admin-dashboard">
+      <h1>New resume category</h1>
+      <ResumeCategoryForm />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/resume/data.ts
+++ b/src/app/admin/(dashboard)/resume/data.ts
@@ -1,0 +1,141 @@
+import { getServerClient } from "@/features/cms/session";
+
+export interface AdminResumeCategory {
+  id: string;
+  slug: string;
+  order: number;
+  nameEn: string;
+  nameVi: string;
+}
+
+export interface AdminResumeEntry {
+  id: string;
+  categoryId: string;
+  startDate: string | null;
+  endDate: string | null;
+  order: number;
+  draft: boolean;
+  titleEn: string;
+  titleVi: string;
+  organizationEn: string | null;
+  organizationVi: string | null;
+  locationEn: string | null;
+  locationVi: string | null;
+  dateLabelEn: string | null;
+  dateLabelVi: string | null;
+  summaryEn: string | null;
+  summaryVi: string | null;
+  highlightsEn: string[];
+  highlightsVi: string[];
+  tagsEn: string[];
+  tagsVi: string[];
+}
+
+interface CategoryRow {
+  id: string;
+  slug: string;
+  order: number;
+  resume_category_translations: Array<{ locale: string; name: string }>;
+}
+
+interface EntryRow {
+  id: string;
+  category_id: string;
+  start_date: string | null;
+  end_date: string | null;
+  order: number;
+  draft: boolean;
+  resume_entry_translations: Array<{
+    locale: string;
+    title: string;
+    organization: string | null;
+    location: string | null;
+    date_label: string | null;
+    summary: string | null;
+    highlights: string[] | string;
+    tags: string[] | string;
+  }>;
+}
+
+export async function listResumeCategories(): Promise<AdminResumeCategory[]> {
+  const client = await getServerClient();
+
+  const { data, error } = await client
+    .from("resume_categories")
+    .select("id, slug, order, resume_category_translations(locale, name)")
+    .order("order")
+    .order("id");
+
+  if (error || !data) return [];
+
+  return data.map((row: CategoryRow) => {
+    const en = row.resume_category_translations.find((t) => t.locale === "en");
+    const vi = row.resume_category_translations.find((t) => t.locale === "vi");
+    return {
+      id: row.id,
+      slug: row.slug,
+      order: row.order,
+      nameEn: en?.name ?? "",
+      nameVi: vi?.name ?? "",
+    };
+  });
+}
+
+export async function listResumeEntries(): Promise<AdminResumeEntry[]> {
+  const client = await getServerClient();
+
+  const { data, error } = await client
+    .from("resume_entries")
+    .select(
+      "id, category_id, start_date, end_date, order, draft, resume_entry_translations(locale, title, organization, location, date_label, summary, highlights, tags)",
+    )
+    .order("order")
+    .order("id");
+
+  if (error || !data) return [];
+
+  return data.map((row: EntryRow) => {
+    const en = row.resume_entry_translations.find((t) => t.locale === "en");
+    const vi = row.resume_entry_translations.find((t) => t.locale === "vi");
+    return {
+      id: row.id,
+      categoryId: row.category_id,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      order: row.order,
+      draft: row.draft,
+      titleEn: en?.title ?? "",
+      titleVi: vi?.title ?? "",
+      organizationEn: en?.organization ?? null,
+      organizationVi: vi?.organization ?? null,
+      locationEn: en?.location ?? null,
+      locationVi: vi?.location ?? null,
+      dateLabelEn: en?.date_label ?? null,
+      dateLabelVi: vi?.date_label ?? null,
+      summaryEn: en?.summary ?? null,
+      summaryVi: vi?.summary ?? null,
+      highlightsEn: parseStringArray(en?.highlights),
+      highlightsVi: parseStringArray(vi?.highlights),
+      tagsEn: parseStringArray(en?.tags),
+      tagsVi: parseStringArray(vi?.tags),
+    };
+  });
+}
+
+export async function getResumeEntry(id: string): Promise<AdminResumeEntry | null> {
+  const rows = await listResumeEntries();
+  return rows.find((row) => row.id === id) ?? null;
+}
+
+function parseStringArray(value: string[] | string | null | undefined): string[] {
+  if (Array.isArray(value)) return value.map((item) => String(item));
+  if (typeof value === "string" && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed.map((item) => String(item)) : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}

--- a/src/app/admin/(dashboard)/resume/entries/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/resume/entries/[id]/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+
+import { getResumeEntry, listResumeCategories } from "../../data";
+import { ResumeEntryForm } from "../../resume-entry-form";
+
+interface AdminEditResumeEntryPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "Edit resume entry",
+};
+
+export default async function AdminEditResumeEntryPage({
+  params,
+}: AdminEditResumeEntryPageProps) {
+  const { id } = await params;
+  const [entry, categories] = await Promise.all([
+    getResumeEntry(id),
+    listResumeCategories(),
+  ]);
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Edit resume entry</h1>
+      <ResumeEntryForm existing={entry} categories={categories} />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/resume/entries/new/page.tsx
+++ b/src/app/admin/(dashboard)/resume/entries/new/page.tsx
@@ -1,0 +1,17 @@
+import { listResumeCategories } from "../../data";
+import { ResumeEntryForm } from "../../resume-entry-form";
+
+export const metadata = {
+  title: "New resume entry",
+};
+
+export default async function AdminNewResumeEntryPage() {
+  const categories = await listResumeCategories();
+
+  return (
+    <main className="admin-dashboard">
+      <h1>New resume entry</h1>
+      <ResumeEntryForm categories={categories} />
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/resume/page.tsx
+++ b/src/app/admin/(dashboard)/resume/page.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+
+import { listResumeCategories, listResumeEntries } from "./data";
+import { ResumeDeleteButton } from "./resume-delete";
+
+export const metadata = {
+  title: "Admin resume",
+};
+
+export default async function AdminResumePage() {
+  const categories = await listResumeCategories();
+  const entries = await listResumeEntries();
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Resume / CV</h1>
+
+      <section className="admin-section">
+        <div className="admin-page-head">
+          <h2>Categories</h2>
+          <Link className="admin-button" href="/admin/resume/categories/new">
+            New category
+          </Link>
+        </div>
+        <table className="admin-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Order</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {categories.map((category) => (
+              <tr key={category.id}>
+                <td>{category.id}</td>
+                <td>{category.nameEn}</td>
+                <td>{category.order}</td>
+                <td className="admin-row-actions">
+                  <Link href={`/admin/resume/categories/${category.id}`}>Edit</Link>
+                  <ResumeDeleteButton id={category.id} label={category.nameEn} kind="category" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="admin-section">
+        <div className="admin-page-head">
+          <h2>Entries</h2>
+          <Link className="admin-button" href="/admin/resume/entries/new">
+            New entry
+          </Link>
+        </div>
+        <table className="admin-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Title</th>
+              <th>Category</th>
+              <th>Draft</th>
+              <th>Order</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => {
+              const category = categories.find((c) => c.id === entry.categoryId);
+              return (
+                <tr key={entry.id}>
+                  <td>{entry.id}</td>
+                  <td>{entry.titleEn}</td>
+                  <td>{category?.nameEn ?? entry.categoryId}</td>
+                  <td>{entry.draft ? "✓" : ""}</td>
+                  <td>{entry.order}</td>
+                  <td className="admin-row-actions">
+                    <Link href={`/admin/resume/entries/${entry.id}`}>Edit</Link>
+                    <ResumeDeleteButton id={entry.id} label={entry.titleEn} kind="entry" />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin/(dashboard)/resume/resume-category-form.tsx
+++ b/src/app/admin/(dashboard)/resume/resume-category-form.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AdminResumeCategory } from "./data";
+import {
+  createResumeCategory,
+  updateResumeCategory,
+  type ResumeActionResult,
+} from "./actions";
+
+interface ResumeCategoryFormProps {
+  existing?: AdminResumeCategory;
+}
+
+export function ResumeCategoryForm({ existing }: ResumeCategoryFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+
+    const data = {
+      id: existing?.id ?? String(fd.get("id") ?? ""),
+      order: Number(fd.get("order") ?? 0),
+      nameEn: String(fd.get("nameEn") ?? ""),
+      nameVi: String(fd.get("nameVi") ?? ""),
+    };
+
+    startTransition(async () => {
+      const result: ResumeActionResult = existing
+        ? await updateResumeCategory(data)
+        : await createResumeCategory(data);
+      if (result.ok) {
+        router.push("/admin/resume");
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed.");
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      {!existing ? (
+        <label className="admin-field">
+          <span>ID (slug, optional)</span>
+          <input name="id" defaultValue="" />
+        </label>
+      ) : null}
+
+      <label className="admin-field">
+        <span>Name (EN)</span>
+        <input name="nameEn" required defaultValue={existing?.nameEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Name (VI)</span>
+        <input name="nameVi" required defaultValue={existing?.nameVi ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Order</span>
+        <input name="order" type="number" defaultValue={existing?.order ?? 0} />
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <button disabled={isPending} type="submit">
+        {isPending ? "Saving…" : existing ? "Update category" : "Create category"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/resume/resume-delete.tsx
+++ b/src/app/admin/(dashboard)/resume/resume-delete.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteResumeCategory, deleteResumeEntry } from "./actions";
+
+interface ResumeDeleteButtonProps {
+  id: string;
+  label: string;
+  kind: "category" | "entry";
+}
+
+export function ResumeDeleteButton({
+  id,
+  label,
+  kind,
+}: ResumeDeleteButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm(`Delete ${kind} "${label}"?`)) return;
+
+    startTransition(async () => {
+      const result =
+        kind === "category" ? await deleteResumeCategory(id) : await deleteResumeEntry(id);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to delete.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        className="admin-link-button admin-link-button--danger"
+        disabled={isPending}
+        onClick={handleDelete}
+        type="button"
+      >
+        {isPending ? "…" : "Delete"}
+      </button>
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/resume/resume-entry-form.tsx
+++ b/src/app/admin/(dashboard)/resume/resume-entry-form.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AdminResumeCategory, AdminResumeEntry } from "./data";
+import {
+  createResumeEntry,
+  updateResumeEntry,
+  type ResumeActionResult,
+} from "./actions";
+
+interface ResumeEntryFormProps {
+  existing?: AdminResumeEntry;
+  categories: AdminResumeCategory[];
+}
+
+export function ResumeEntryForm({ existing, categories }: ResumeEntryFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+
+    const data = {
+      id: existing?.id ?? String(fd.get("id") ?? ""),
+      categoryId: String(fd.get("categoryId") ?? ""),
+      startDate: String(fd.get("startDate") ?? ""),
+      endDate: String(fd.get("endDate") ?? ""),
+      order: Number(fd.get("order") ?? 0),
+      draft: fd.get("draft") === "on",
+      titleEn: String(fd.get("titleEn") ?? ""),
+      titleVi: String(fd.get("titleVi") ?? ""),
+      organizationEn: String(fd.get("organizationEn") ?? ""),
+      organizationVi: String(fd.get("organizationVi") ?? ""),
+      locationEn: String(fd.get("locationEn") ?? ""),
+      locationVi: String(fd.get("locationVi") ?? ""),
+      dateLabelEn: String(fd.get("dateLabelEn") ?? ""),
+      dateLabelVi: String(fd.get("dateLabelVi") ?? ""),
+      summaryEn: String(fd.get("summaryEn") ?? ""),
+      summaryVi: String(fd.get("summaryVi") ?? ""),
+      highlightsEn: String(fd.get("highlightsEn") ?? ""),
+      highlightsVi: String(fd.get("highlightsVi") ?? ""),
+      tagsEn: String(fd.get("tagsEn") ?? ""),
+      tagsVi: String(fd.get("tagsVi") ?? ""),
+    };
+
+    startTransition(async () => {
+      const result: ResumeActionResult = existing
+        ? await updateResumeEntry(data)
+        : await createResumeEntry(data);
+      if (result.ok) {
+        router.push("/admin/resume");
+        router.refresh();
+      } else {
+        setError(
+          result.fieldErrors
+            ? Object.values(result.fieldErrors).join(" ")
+            : result.error ?? "Failed.",
+        );
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      {!existing ? (
+        <label className="admin-field">
+          <span>ID (slug, optional)</span>
+          <input name="id" defaultValue="" />
+        </label>
+      ) : null}
+
+      <label className="admin-field">
+        <span>Category</span>
+        <select name="categoryId" required defaultValue={existing?.categoryId ?? ""}>
+          <option value="">Select…</option>
+          {categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.nameEn}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <h3>Title</h3>
+      <label className="admin-field">
+        <span>Title (EN)</span>
+        <input name="titleEn" required defaultValue={existing?.titleEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Title (VI)</span>
+        <input name="titleVi" required defaultValue={existing?.titleVi ?? ""} />
+      </label>
+
+      <h3>Organization</h3>
+      <label className="admin-field">
+        <span>Organization (EN)</span>
+        <input name="organizationEn" defaultValue={existing?.organizationEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Organization (VI)</span>
+        <input name="organizationVi" defaultValue={existing?.organizationVi ?? ""} />
+      </label>
+
+      <h3>Location</h3>
+      <label className="admin-field">
+        <span>Location (EN)</span>
+        <input name="locationEn" defaultValue={existing?.locationEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Location (VI)</span>
+        <input name="locationVi" defaultValue={existing?.locationVi ?? ""} />
+      </label>
+
+      <h3>Date</h3>
+      <label className="admin-field">
+        <span>Start date</span>
+        <input name="startDate" type="date" defaultValue={existing?.startDate ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>End date</span>
+        <input name="endDate" type="date" defaultValue={existing?.endDate ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Date label (EN)</span>
+        <input name="dateLabelEn" defaultValue={existing?.dateLabelEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Date label (VI)</span>
+        <input name="dateLabelVi" defaultValue={existing?.dateLabelVi ?? ""} />
+      </label>
+
+      <h3>Summary</h3>
+      <label className="admin-field">
+        <span>Summary (EN)</span>
+        <textarea name="summaryEn" rows={3} defaultValue={existing?.summaryEn ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Summary (VI)</span>
+        <textarea name="summaryVi" rows={3} defaultValue={existing?.summaryVi ?? ""} />
+      </label>
+
+      <h3>Highlights (one per line)</h3>
+      <label className="admin-field">
+        <span>Highlights (EN)</span>
+        <textarea name="highlightsEn" rows={4} defaultValue={existing?.highlightsEn.join("\n") ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Highlights (VI)</span>
+        <textarea name="highlightsVi" rows={4} defaultValue={existing?.highlightsVi.join("\n") ?? ""} />
+      </label>
+
+      <h3>Tags (comma-separated)</h3>
+      <label className="admin-field">
+        <span>Tags (EN)</span>
+        <input name="tagsEn" defaultValue={existing?.tagsEn.join(", ") ?? ""} />
+      </label>
+      <label className="admin-field">
+        <span>Tags (VI)</span>
+        <input name="tagsVi" defaultValue={existing?.tagsVi.join(", ") ?? ""} />
+      </label>
+
+      <label className="admin-field">
+        <span>Order</span>
+        <input name="order" type="number" defaultValue={existing?.order ?? 0} />
+      </label>
+      <label className="admin-check">
+        <input name="draft" type="checkbox" defaultChecked={existing?.draft} />
+        <span>Draft (hidden from public)</span>
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <button disabled={isPending} type="submit">
+        {isPending ? "Saving…" : existing ? "Update entry" : "Create entry"}
+      </button>
+    </form>
+  );
+}

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -24,7 +24,10 @@ if (!LOCAL_HOST.test(url)) {
 }
 
 import { createClient } from "@supabase/supabase-js";
-import { getFeaturedProjects } from "@/features/cms/repository";
+import {
+  getFeaturedProjects,
+  getResumeContent,
+} from "@/features/cms/repository";
 
 const client = createClient(url, serviceRole, {
   auth: { persistSession: false },
@@ -157,5 +160,79 @@ test("public repository only returns featured+published+active projects with med
     );
   } finally {
     await cleanup();
+  }
+});
+
+const RESUME_FIXTURES = {
+  category: "repo-res-cat",
+  published: "repo-res-pub",
+  draft: "repo-res-draft",
+};
+
+async function insertResumeFixture() {
+  const { error: catErr } = await client.from("resume_categories").upsert(
+    { id: RESUME_FIXTURES.category, slug: RESUME_FIXTURES.category, order: 1 },
+    { onConflict: "id" },
+  );
+  assert.equal(catErr, null, `resume category: ${catErr?.message}`);
+
+  const { error: catTrErr } = await client
+    .from("resume_category_translations")
+    .upsert(
+      [
+        { resume_category_id: RESUME_FIXTURES.category, locale: "en", name: "Test Category" },
+        { resume_category_id: RESUME_FIXTURES.category, locale: "vi", name: "Danh mục" },
+      ],
+      { onConflict: "resume_category_id,locale" },
+    );
+  assert.equal(catTrErr, null, `resume category translations: ${catTrErr?.message}`);
+
+  for (const [id, draft] of [
+    [RESUME_FIXTURES.published, false],
+    [RESUME_FIXTURES.draft, true],
+  ] as const) {
+    const { error: entryErr } = await client.from("resume_entries").upsert(
+      { id, category_id: RESUME_FIXTURES.category, order: 1, draft },
+      { onConflict: "id" },
+    );
+    assert.equal(entryErr, null, `resume entry ${id}: ${entryErr?.message}`);
+
+    const { error: trErr } = await client.from("resume_entry_translations").upsert(
+      [
+        { resume_entry_id: id, locale: "en", title: id, highlights: ["H1"] },
+        { resume_entry_id: id, locale: "vi", title: id, highlights: ["H1"] },
+      ],
+      { onConflict: "resume_entry_id,locale" },
+    );
+    assert.equal(trErr, null, `resume entry translations ${id}: ${trErr?.message}`);
+  }
+}
+
+async function cleanupResume() {
+  for (const id of [RESUME_FIXTURES.published, RESUME_FIXTURES.draft]) {
+    await client.from("resume_entries").delete().eq("id", id);
+  }
+  await client.from("resume_categories").delete().eq("id", RESUME_FIXTURES.category);
+}
+
+test("public resume repository excludes draft entries and groups by category", async () => {
+  await cleanupResume();
+  await insertResumeFixture();
+
+  try {
+    const view = await getResumeContent("en");
+    const category = view.categories.find((c) => c.id === RESUME_FIXTURES.category);
+    assert.ok(category, "resume category is present");
+    const entryIds = category?.entries.map((e) => e.id) ?? [];
+    assert.ok(
+      entryIds.includes(RESUME_FIXTURES.published),
+      "published resume entry is included",
+    );
+    assert.ok(
+      !entryIds.includes(RESUME_FIXTURES.draft),
+      "draft resume entry is excluded at the query boundary",
+    );
+  } finally {
+    await cleanupResume();
   }
 });

--- a/src/features/cms/repository.ts
+++ b/src/features/cms/repository.ts
@@ -17,6 +17,11 @@ import {
   getFeaturedProjects as getLocalFeaturedProjects,
   type FeaturedProjectsView,
 } from "@/content/projects";
+import {
+  getResumeContent as getLocalResume,
+  type ResumeCategory,
+  type ResumeContentView,
+} from "@/content/resume";
 import { getServiceClient } from "./server";
 import { hasCmsConfig } from "./config";
 
@@ -287,6 +292,10 @@ function parseStringArray(value: unknown): string[] {
   return [];
 }
 
+function orUndefined(value: string | null | undefined): string | undefined {
+  return value == null ? undefined : value;
+}
+
 export async function getFeaturedProjects(
   locale: Locale,
 ): Promise<FeaturedProjectsView> {
@@ -381,4 +390,148 @@ function pickTranslation(
   const en = translations.find((t) => t.locale === "en");
   const active = translations.find((t) => t.locale === locale);
   return active?.[key] ?? en?.[key] ?? "";
+}
+
+interface ResumeCategoryRow {
+  id: string;
+  slug: string;
+  order: number;
+  resume_category_translations: Array<{ locale: string; name: string }>;
+}
+
+interface ResumeEntryRow {
+  id: string;
+  category_id: string;
+  order: number;
+  draft: boolean;
+  resume_entry_translations: Array<{
+    locale: string;
+    title: string;
+    organization: string | null;
+    location: string | null;
+    date_label: string | null;
+    summary: string | null;
+    highlights: string[] | string;
+    tags: string[] | string;
+  }>;
+  resume_media: Array<{
+    id: string;
+    thumbnail_src: string;
+    full_src: string;
+    width: number | null;
+    height: number | null;
+    resume_media_translations: Array<{
+      locale: string;
+      alt: string;
+      caption: string | null;
+    }>;
+  }>;
+}
+
+export async function getResumeContent(
+  locale: Locale,
+): Promise<ResumeContentView> {
+  const base = getLocalResume(locale);
+
+  if (!hasCmsConfig()) {
+    return base;
+  }
+
+  const client = getServiceClient();
+  if (!client) return base;
+
+  try {
+    const [categoriesRes, entriesRes] = await Promise.all([
+      client
+        .from("resume_categories")
+        .select("id, slug, order, resume_category_translations(locale, name)")
+        .order("order")
+        .order("id"),
+      client
+        .from("resume_entries")
+        .select(
+          "id, category_id, order, draft, resume_entry_translations(locale, title, organization, location, date_label, summary, highlights, tags), resume_media(id, thumbnail_src, full_src, width, height, resume_media_translations(locale, alt, caption))",
+        )
+        .eq("draft", false)
+        .order("order")
+        .order("id"),
+    ]);
+
+    if (categoriesRes.error || entriesRes.error) return base;
+
+    const categories = (categoriesRes.data ?? []) as ResumeCategoryRow[];
+    const entries = (entriesRes.data ?? []) as ResumeEntryRow[];
+
+    const categoriesView = categories.map((category) => {
+      const categoryEn = category.resume_category_translations.find(
+        (t) => t.locale === "en",
+      );
+      const categoryActive = category.resume_category_translations.find(
+        (t) => t.locale === locale,
+      );
+      const categoryEntries = entries
+        .filter((entry) => entry.category_id === category.id)
+        .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+
+      return {
+        id: category.id as ResumeCategory,
+        name: categoryActive?.name ?? categoryEn?.name ?? category.slug,
+        entries: categoryEntries.map((entry, index) => {
+          const en = entry.resume_entry_translations.find((t) => t.locale === "en");
+          const active = entry.resume_entry_translations.find(
+            (t) => t.locale === locale,
+          );
+          const media = (entry.resume_media ?? []).map((m) => {
+            const mActive = m.resume_media_translations.find(
+              (t) => t.locale === locale,
+            );
+            const mEn = m.resume_media_translations.find((t) => t.locale === "en");
+            return {
+              id: m.id,
+              thumbnailSrc: m.thumbnail_src,
+              fullSrc: m.full_src,
+              alt: mActive?.alt ?? mEn?.alt ?? "",
+              caption: mActive?.caption ?? mEn?.caption ?? undefined,
+              width: m.width ?? undefined,
+              height: m.height ?? undefined,
+            };
+          });
+          const highlights = parseStringArray(active?.highlights).length
+            ? parseStringArray(active?.highlights)
+            : parseStringArray(en?.highlights);
+          const tags = parseStringArray(active?.tags).length
+            ? parseStringArray(active?.tags)
+            : parseStringArray(en?.tags);
+
+          return {
+            id: entry.id,
+            index: String(index + 1).padStart(2, "0"),
+            title: active?.title ?? en?.title ?? "",
+            ...(orUndefined(active?.organization) ?? orUndefined(en?.organization)
+              ? { organization: orUndefined(active?.organization) ?? orUndefined(en?.organization) }
+              : {}),
+            ...(orUndefined(active?.location) ?? orUndefined(en?.location)
+              ? { location: orUndefined(active?.location) ?? orUndefined(en?.location) }
+              : {}),
+            ...(orUndefined(active?.date_label) ?? orUndefined(en?.date_label)
+              ? { dateLabel: orUndefined(active?.date_label) ?? orUndefined(en?.date_label) }
+              : {}),
+            ...(orUndefined(active?.summary) ?? orUndefined(en?.summary)
+              ? { summary: orUndefined(active?.summary) ?? orUndefined(en?.summary) }
+              : {}),
+            ...(highlights.length > 0 ? { highlights } : {}),
+            ...(tags.length > 0 ? { tags } : {}),
+            ...(media.length > 0 ? { media } : {}),
+          };
+        }),
+      };
+    });
+
+    return {
+      ...base,
+      categories: categoriesView,
+    };
+  } catch {
+    return base;
+  }
 }

--- a/supabase/migrations/20260820180000_cms_resume_crud.sql
+++ b/supabase/migrations/20260820180000_cms_resume_crud.sql
@@ -1,0 +1,170 @@
+-- Issue #52: CMS CRUD for Resume/CV (third and most security-sensitive CRUD slice).
+--
+-- 1. Convert resume tables to stable text ids (matching local content slugs/ids),
+--    following the same pattern as skills/social/projects.
+-- 2. Add SECURITY INVOKER atomic RPCs (upsert/delete) for categories and entries,
+--    granted to authenticated so admin CRUD runs through the owner RLS path. Each
+--    mutation writes the base row + both translation rows in a single transaction.
+--    Media editing is out of scope (#21); existing media rows are read for the view.
+-- 3. The public read path (repository adapter) filters draft=false entries and
+--    respects the global resume.publicity gate (already fail-closed in code).
+
+-- --- Convert resume tables to stable text ids --------------------------------
+alter table resume_media_translations drop constraint resume_media_translations_resume_media_id_fkey;
+alter table resume_media drop constraint resume_media_resume_entry_id_fkey;
+alter table resume_entry_translations drop constraint resume_entry_translations_resume_entry_id_fkey;
+alter table resume_entries drop constraint resume_entries_category_id_fkey;
+alter table resume_category_translations drop constraint resume_category_translations_resume_category_id_fkey;
+
+alter table resume_category_translations alter column resume_category_id type text;
+alter table resume_categories drop constraint resume_categories_pkey;
+alter table resume_categories alter column id type text;
+alter table resume_categories add primary key (id);
+
+alter table resume_category_translations
+  add constraint resume_category_translations_resume_category_id_fkey
+  foreign key (resume_category_id) references resume_categories(id) on delete cascade;
+
+alter table resume_entries drop constraint resume_entries_pkey;
+alter table resume_entries alter column id type text;
+alter table resume_entries alter column category_id type text;
+alter table resume_entries add primary key (id);
+
+alter table resume_entry_translations alter column resume_entry_id type text;
+alter table resume_media alter column resume_entry_id type text;
+alter table resume_media alter column id type text;
+alter table resume_media drop constraint resume_media_pkey;
+alter table resume_media add primary key (id);
+alter table resume_media_translations alter column resume_media_id type text;
+
+alter table resume_entries
+  add constraint resume_entries_category_id_fkey
+  foreign key (category_id) references resume_categories(id) on delete cascade;
+alter table resume_entry_translations
+  add constraint resume_entry_translations_resume_entry_id_fkey
+  foreign key (resume_entry_id) references resume_entries(id) on delete cascade;
+alter table resume_media
+  add constraint resume_media_resume_entry_id_fkey
+  foreign key (resume_entry_id) references resume_entries(id) on delete cascade;
+alter table resume_media_translations
+  add constraint resume_media_translations_resume_media_id_fkey
+  foreign key (resume_media_id) references resume_media(id) on delete cascade;
+
+-- --- Atomic mutations (SECURITY INVOKER, owner RLS path) ----------------------
+
+-- Categories: stable slug, order, EN/VI name.
+create or replace function public.cms_upsert_resume_category(
+  p_id text,
+  p_order integer,
+  p_name_en text,
+  p_name_vi text
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  insert into public.resume_categories (id, slug, "order")
+  values (p_id, p_id, p_order)
+  on conflict (id) do update set
+    slug = excluded.slug,
+    "order" = excluded."order";
+
+  insert into public.resume_category_translations (resume_category_id, locale, name)
+  values
+    (p_id, 'en', p_name_en),
+    (p_id, 'vi', p_name_vi)
+  on conflict (resume_category_id, locale) do update set
+    name = excluded.name;
+end;
+$$;
+
+create or replace function public.cms_delete_resume_category(p_id text)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from public.resume_categories where id = p_id;
+$$;
+
+-- Entries: base fields + draft + EN/VI translations.
+create or replace function public.cms_upsert_resume_entry(
+  p_id text,
+  p_category_id text,
+  p_start_date text,
+  p_end_date text,
+  p_order integer,
+  p_draft boolean,
+  p_title_en text,
+  p_title_vi text,
+  p_organization_en text,
+  p_organization_vi text,
+  p_location_en text,
+  p_location_vi text,
+  p_date_label_en text,
+  p_date_label_vi text,
+  p_summary_en text,
+  p_summary_vi text,
+  p_highlights_en jsonb,
+  p_highlights_vi jsonb,
+  p_tags_en jsonb,
+  p_tags_vi jsonb
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  insert into public.resume_entries (id, category_id, start_date, end_date, "order", draft, updated_at)
+  values (p_id, p_category_id, p_start_date, p_end_date, p_order, p_draft, now())
+  on conflict (id) do update set
+    category_id = excluded.category_id,
+    start_date = excluded.start_date,
+    end_date = excluded.end_date,
+    "order" = excluded."order",
+    draft = excluded.draft,
+    updated_at = now();
+
+  insert into public.resume_entry_translations (resume_entry_id, locale, title, organization, location, date_label, summary, highlights, tags)
+  values
+    (p_id, 'en', p_title_en, p_organization_en, p_location_en, p_date_label_en, p_summary_en, p_highlights_en, p_tags_en),
+    (p_id, 'vi', p_title_vi, p_organization_vi, p_location_vi, p_date_label_vi, p_summary_vi, p_highlights_vi, p_tags_vi)
+  on conflict (resume_entry_id, locale) do update set
+    title = excluded.title,
+    organization = excluded.organization,
+    location = excluded.location,
+    date_label = excluded.date_label,
+    summary = excluded.summary,
+    highlights = excluded.highlights,
+    tags = excluded.tags;
+end;
+$$;
+
+create or replace function public.cms_delete_resume_entry(p_id text)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from public.resume_entries where id = p_id;
+$$;
+
+revoke all on function public.cms_upsert_resume_category(text, integer, text, text) from public;
+revoke all on function public.cms_delete_resume_category(text) from public;
+revoke all on function public.cms_upsert_resume_entry(text, text, text, text, integer, boolean, text, text, text, text, text, text, text, text, text, text, jsonb, jsonb, jsonb, jsonb) from public;
+revoke all on function public.cms_delete_resume_entry(text) from public;
+
+grant execute on function public.cms_upsert_resume_category(text, integer, text, text) to authenticated, service_role;
+grant execute on function public.cms_delete_resume_category(text) to authenticated, service_role;
+grant execute on function public.cms_upsert_resume_entry(text, text, text, text, integer, boolean, text, text, text, text, text, text, text, text, text, text, jsonb, jsonb, jsonb, jsonb) to authenticated, service_role;
+grant execute on function public.cms_delete_resume_entry(text) to authenticated, service_role;
+
+-- Seed the two canonical resume categories (stable slugs) so the admin CRUD and
+-- the public view both have deterministic category ids.
+insert into public.resume_categories (id, slug, "order") values
+  ('career-journey', 'career-journey', 1),
+  ('education-certifications', 'education-certifications', 2)
+on conflict (id) do nothing;

--- a/supabase/tests/rls_crud_test.sql
+++ b/supabase/tests/rls_crud_test.sql
@@ -14,7 +14,7 @@
 -- to whichever auth user is the configured single owner.
 
 begin;
-select plan(11);
+select plan(13);
 
 -- Capture the owner uid while still superuser (admin_owner is RLS-filtered for
 -- other roles), then set claims session-wide so they survive the role switch.
@@ -44,6 +44,14 @@ insert into public.projects (id, slug, tech_stack, featured, "order", status, pu
   values ('rls-test', 'rls-test', '[]', true, 1, 'active', true)
   on conflict (id) do nothing;
 
+insert into public.resume_categories (id, slug, "order")
+  values ('rls-test', 'rls-test', 1)
+  on conflict (id) do nothing;
+
+insert into public.resume_entries (id, category_id, "order", draft)
+  values ('rls-test', 'rls-test', 1, false)
+  on conflict (id) do nothing;
+
 -- --- Owner: SELECT succeeds ------------------------------------------------
 set local role authenticated;
 
@@ -69,6 +77,12 @@ select is(
   (select count(*) from public.projects where id = 'rls-test'),
   1::bigint,
   'owner can SELECT projects'
+);
+
+select is(
+  (select count(*) from public.resume_entries where id = 'rls-test'),
+  1::bigint,
+  'owner can SELECT resume_entries'
 );
 
 -- --- Owner: INSERT succeeds -----------------------------------------------
@@ -134,11 +148,19 @@ select is(
   'non-owner sees zero projects rows (RLS filters)'
 );
 
+select is(
+  (select count(*) from public.resume_entries),
+  0::bigint,
+  'non-owner sees zero resume_entries rows (RLS filters)'
+);
+
 -- --- Cleanup fixtures ------------------------------------------------
 reset role;
 delete from public.social_links where id = 'rls-test';
 delete from public.skills where id = 'rls-test';
 delete from public.projects where id = 'rls-test';
+delete from public.resume_entries where id = 'rls-test';
+delete from public.resume_categories where id = 'rls-test';
 delete from public.profile where id = '00000000-0000-0000-0000-000000000001';
 
 select * from finish();


### PR DESCRIPTION
Closes #52

## Summary
Third and final CRUD slice: structured admin management for Resume/CV, built on
the repository/view-model pattern established in #20/#51. Admin CRUD routes
through the authenticated owner/RLS path, and the public site reads resume content
through the repository adapter with the two-gate (draft + global publicity) model.

## What changed

### Schema / migrations
- Convert resume tables to stable text ids (matching local content slugs/ids).
- Add `cms_upsert/delete_resume_category` and `cms_upsert/delete_resume_entry`
  SECURITY INVOKER RPCs (atomic base + translation writes) granted to
  `authenticated` so owner RLS is authoritative.
- Seed the two canonical resume categories (`career-journey`,
  `education-certifications`) with stable slugs.
- `scripts/backfill-content.mjs` backfills resume categories + entries + media
  idempotently (entries seeded as non-draft).

### Admin UI (authenticated owner/RLS path)
- Resume overview page listing categories and entries.
- Category CRUD (EN/VI name, order) and entry CRUD (title, organization, location,
  start/end dates, date label, summary, highlights, tags, category, order, draft).
- All reads/writes use `getServerClient()` (authenticated) + SECURITY INVOKER RPCs.

### Public read path
- `getResumeContent` added to the repository adapter: maps CMS resume categories +
  entries to the existing `ResumeContentView`, filtering `draft=false` at the query
  boundary (accepted #18 two-gate model), with local fallback.
- The public locale page consumes the adapter for the visible (non-lock) resume
  state; the private lock still uses public-safe local strings only. The global
  `resume.publicity` gate (already fail-closed) is unchanged.

### Verification
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` — 99 pass
- `npm run test:db` — 2 pass
- `npm run test:cms` — 2 pass (projects + resume draft-filter regression)
- `supabase db test --local supabase/tests` — 13/13 RLS assertions pass (owner CRUD
  incl. resume_entries; anonymous + non-owner denied)
- `npm run build` — pass
- Live owner-path check: resume entry create/read/delete via RPC (204)

## Known limitations
- Resume `links` (local-only field) has no DB column in the accepted schema, so it
  is not CMS-managed in this slice.
- Resume media management is out of scope (Issue #21); existing media rows are read
  for the public view but not editable here.

## Docs affected
- `docs/superpowers/specs/2026-08-20-supabase-cms-schema-design.md` (resume
  stable-id conversion).