### PR TITLE
feat: CMS media management (Issue #21)

### DIFF
--- a/src/app/admin/(dashboard)/layout.tsx
+++ b/src/app/admin/(dashboard)/layout.tsx
@@ -10,6 +10,7 @@ const navLinks = [
   { href: "/admin/social", label: "Social" },
   { href: "/admin/projects", label: "Projects" },
   { href: "/admin/resume", label: "Resume" },
+  { href: "/admin/media", label: "Media" },
 ] as const;
 
 export default async function AdminDashboardLayout({

--- a/src/app/admin/(dashboard)/media/media-delete.tsx
+++ b/src/app/admin/(dashboard)/media/media-delete.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  deleteMedia,
+  type MediaDeleteResult,
+} from "@/features/cms/media-actions";
+import type { MediaBucket } from "@/features/cms/media";
+
+interface MediaDeleteButtonProps {
+  bucket: MediaBucket;
+  path: string;
+}
+
+export function MediaDeleteButton({ bucket, path }: MediaDeleteButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm(`Delete "${path}"? This removes the stored file.`)) return;
+
+    startTransition(async () => {
+      const result: MediaDeleteResult = await deleteMedia(bucket, path);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to delete.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        className="admin-link-button admin-link-button--danger"
+        disabled={isPending}
+        onClick={handleDelete}
+        type="button"
+      >
+        {isPending ? "…" : "Delete"}
+      </button>
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/media/media-upload-form.tsx
+++ b/src/app/admin/(dashboard)/media/media-upload-form.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  uploadMedia,
+  type MediaUploadResult,
+} from "@/features/cms/media-actions";
+import type { MediaBucket } from "@/features/cms/media";
+
+interface MediaUploadFormProps {
+  bucket: MediaBucket;
+}
+
+export function MediaUploadForm({ bucket }: MediaUploadFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+    const file = fd.get("file") as File | null;
+    if (!file || file.size === 0) {
+      setError("Choose a file to upload.");
+      return;
+    }
+
+    startTransition(async () => {
+      const result: MediaUploadResult = await uploadMedia(bucket, file);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Upload failed.");
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form admin-form--row" onSubmit={onSubmit}>
+      <label className="admin-field">
+        <span>Upload image (JPEG/PNG/WebP, max 10 MB)</span>
+        <input name="file" type="file" accept="image/jpeg,image/png,image/webp" />
+      </label>
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <button disabled={isPending} type="submit">
+        {isPending ? "Uploading…" : "Upload"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/media/page.tsx
+++ b/src/app/admin/(dashboard)/media/page.tsx
@@ -1,0 +1,67 @@
+import { listBucketObjects, getMediaPublicUrl } from "@/features/cms/media";
+import type { MediaBucket } from "@/features/cms/media";
+import { MediaUploadForm } from "./media-upload-form";
+import { MediaDeleteButton } from "./media-delete";
+
+export const metadata = {
+  title: "Admin media",
+};
+
+const buckets: Array<{ id: MediaBucket; label: string; note: string }> = [
+  { id: "resume-media", label: "Resume media (private)", note: "Served only through the gated /api/resume-media route." },
+  { id: "project-media", label: "Project media (public)", note: "Public project images." },
+  { id: "portfolio", label: "Portfolio (public)", note: "Profile / social images." },
+];
+
+export default async function AdminMediaPage() {
+  const bucketRows = await Promise.all(
+    buckets.map(async (bucket) => ({
+      bucket,
+      objects: await listBucketObjects(bucket.id),
+    })),
+  );
+
+  return (
+    <main className="admin-dashboard">
+      <h1>Media</h1>
+      <p className="admin-message">
+        Upload and manage images stored in Supabase Storage. Resume media is
+        private and served only through the gated route; project and portfolio
+        media are public.
+      </p>
+
+      {bucketRows.map(({ bucket, objects }) => (
+        <section className="admin-section" key={bucket.id}>
+          <div className="admin-page-head">
+            <h2>{bucket.label}</h2>
+          </div>
+          <p className="admin-note">{bucket.note}</p>
+          <MediaUploadForm bucket={bucket.id} />
+
+          {objects.length === 0 ? (
+            <p className="admin-message">No files uploaded yet.</p>
+          ) : (
+            <ul className="admin-media-list">
+              {objects.map((object) => (
+                <li className="admin-media-item" key={object.id}>
+                  <div className="admin-media-preview">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      alt={object.name}
+                      loading="lazy"
+                      src={getMediaPublicUrl(bucket.id, object.name)}
+                    />
+                  </div>
+                  <div className="admin-media-meta">
+                    <code>{object.name}</code>
+                    <MediaDeleteButton bucket={bucket.id} path={object.name} />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/src/app/api/resume-media/[file]/route.ts
+++ b/src/app/api/resume-media/[file]/route.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { NextResponse } from "next/server";
 
 import { getResumePublicity } from "@/features/cms/resume-publicity";
+import { getServiceClient } from "@/features/cms/server";
+import { hasCmsConfig } from "@/features/cms/config";
 
 const resumeMediaRoot = join(process.cwd(), "private-assets", "resume");
 
@@ -29,6 +31,37 @@ interface ResumeMediaRouteContext {
 
 export const dynamic = "force-dynamic";
 
+/** Sanitize the requested filename to a single basename (no path traversal). */
+function sanitizeFile(file: string): string {
+  return file.replace(/[^a-zA-Z0-9._-]/g, "").replace(/^\.+|\.+$/g, "");
+}
+
+async function serveFromStorage(file: string): Promise<NextResponse | null> {
+  if (!hasCmsConfig()) return null;
+
+  const client = getServiceClient();
+  if (!client) return null;
+
+  try {
+    const { data, error } = await client.storage
+      .from("resume-media")
+      .download(file);
+    if (error || !data) return null;
+
+    const bytes = await data.arrayBuffer();
+    const contentType =
+      data.type || (file.endsWith(".png") ? "image/png" : "image/jpeg");
+    return new NextResponse(new Uint8Array(bytes), {
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": contentType,
+      },
+    });
+  } catch {
+    return null;
+  }
+}
+
 export async function GET(
   _request: Request,
   context: ResumeMediaRouteContext,
@@ -42,8 +75,21 @@ export async function GET(
   }
 
   const { file } = await context.params;
+  const safeFile = sanitizeFile(file);
+  if (!safeFile) {
+    return new NextResponse("Not found", {
+      status: 404,
+      headers: DENIED_RESPONSE_HEADERS,
+    });
+  }
 
-  if (!(approvedMediaFiles as readonly string[]).includes(file)) {
+  // Uploaded resume media lives in the private storage bucket; serve it through
+  // this gated route (server-only read of the private bucket).
+  const storageResponse = await serveFromStorage(safeFile);
+  if (storageResponse) return storageResponse;
+
+  // Fall back to the local approved assets for the pre-existing files.
+  if (!(approvedMediaFiles as readonly string[]).includes(safeFile)) {
     return new NextResponse("Not found", {
       status: 404,
       headers: DENIED_RESPONSE_HEADERS,
@@ -51,7 +97,7 @@ export async function GET(
   }
 
   try {
-    const bytes = await readFile(join(resumeMediaRoot, file));
+    const bytes = await readFile(join(resumeMediaRoot, safeFile));
     return new NextResponse(new Uint8Array(bytes), {
       headers: {
         "Cache-Control": "no-store",
@@ -65,4 +111,3 @@ export async function GET(
     });
   }
 }
-

--- a/src/features/cms/media-actions.ts
+++ b/src/features/cms/media-actions.ts
@@ -76,8 +76,17 @@ export async function deleteMedia(
   const client = await getServerClient();
 
   // Block deletion while the file is still referenced by published media rows
-  // (Issue #21 reference/orphan criterion).
-  const references = await findMediaReferences(client, bucket, path);
+  // (Issue #21 reference/orphan criterion). Fail closed: if the reference query
+  // errors, refuse deletion with an actionable message rather than deleting.
+  let references: number;
+  try {
+    references = await findMediaReferences(client, bucket, path);
+  } catch {
+    return {
+      ok: false,
+      error: "Cannot verify media references right now. Please retry; deletion was refused to avoid orphaning media.",
+    };
+  }
   if (references > 0) {
     return {
       ok: false,

--- a/src/features/cms/media-actions.ts
+++ b/src/features/cms/media-actions.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getServiceClient } from "./server";
+import { isAdminUser } from "./session";
+import type { MediaBucket } from "./media";
+
+export interface MediaUploadResult {
+  ok: boolean;
+  error?: string;
+  path?: string;
+  publicUrl?: string;
+}
+
+export interface MediaDeleteResult {
+  ok: boolean;
+  error?: string;
+}
+
+function isAllowedMime(mime: string): boolean {
+  return ["image/jpeg", "image/png", "image/webp"].includes(mime);
+}
+
+function sanitizeFilename(filename: string): string {
+  const base = filename.replace(/[^a-zA-Z0-9._-]/g, "-").toLowerCase();
+  return base.replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Upload an image to a media bucket. Runs through the server-only service-role
+ * path (the browser never holds bucket credentials), but is gated by isAdminUser()
+ * so only the owner can trigger uploads. The owner storage RLS also restricts
+ * writes on the server-authenticated path; using service-role here is safe because
+ * this function is server-only and authorization is enforced at the action boundary.
+ */
+export async function uploadMedia(
+  bucket: MediaBucket,
+  file: File,
+): Promise<MediaUploadResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  if (!isAllowedMime(file.type)) {
+    return { ok: false, error: "Only JPEG, PNG, or WebP images are allowed." };
+  }
+  if (file.size > 10 * 1024 * 1024) {
+    return { ok: false, error: "Image must be 10 MB or smaller." };
+  }
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const ext = file.name.split(".").pop()?.toLowerCase() ?? "jpg";
+  const base = sanitizeFilename(file.name.replace(/\.[^.]+$/, ""));
+  const path = `${Date.now()}-${base}.${ext}`;
+
+  const arrayBuffer = await file.arrayBuffer();
+  const { error } = await client.storage.from(bucket).upload(path, arrayBuffer, {
+    contentType: file.type,
+    cacheControl: "3600",
+    upsert: false,
+  });
+  if (error) return { ok: false, error: error.message };
+
+  const publicUrl = bucket === "resume-media"
+    ? `/api/resume-media/${encodeURIComponent(path)}`
+    : client.storage.from(bucket).getPublicUrl(path).data.publicUrl;
+
+  revalidatePath("/admin/media");
+  return { ok: true, path, publicUrl };
+}
+
+export async function deleteMedia(
+  bucket: MediaBucket,
+  path: string,
+): Promise<MediaDeleteResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  const client = getServiceClient();
+  if (!client) return { ok: false, error: "CMS is not configured." };
+
+  const { error } = await client.storage.from(bucket).remove([path]);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/");
+  revalidatePath("/vi");
+  revalidatePath("/admin/media");
+  return { ok: true };
+}

--- a/src/features/cms/media-actions.ts
+++ b/src/features/cms/media-actions.ts
@@ -2,9 +2,8 @@
 
 import { revalidatePath } from "next/cache";
 
-import { getServiceClient } from "./server";
-import { isAdminUser } from "./session";
-import type { MediaBucket } from "./media";
+import { getServerClient, isAdminUser } from "./session";
+import { findMediaReferences, type MediaBucket } from "./media";
 
 export interface MediaUploadResult {
   ok: boolean;
@@ -28,11 +27,10 @@ function sanitizeFilename(filename: string): string {
 }
 
 /**
- * Upload an image to a media bucket. Runs through the server-only service-role
- * path (the browser never holds bucket credentials), but is gated by isAdminUser()
- * so only the owner can trigger uploads. The owner storage RLS also restricts
- * writes on the server-authenticated path; using service-role here is safe because
- * this function is server-only and authorization is enforced at the action boundary.
+ * Upload an image to a media bucket. Runs through the authenticated owner-session
+ * server client (getServerClient), so Storage RLS (private.is_owner()) authorizes
+ * the actual operation — matching the accepted #18 design where admin/browser
+ * writes use the normal owner RLS path rather than the service role.
  */
 export async function uploadMedia(
   bucket: MediaBucket,
@@ -47,8 +45,7 @@ export async function uploadMedia(
     return { ok: false, error: "Image must be 10 MB or smaller." };
   }
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
 
   const ext = file.name.split(".").pop()?.toLowerCase() ?? "jpg";
   const base = sanitizeFilename(file.name.replace(/\.[^.]+$/, ""));
@@ -76,8 +73,17 @@ export async function deleteMedia(
 ): Promise<MediaDeleteResult> {
   if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
 
-  const client = getServiceClient();
-  if (!client) return { ok: false, error: "CMS is not configured." };
+  const client = await getServerClient();
+
+  // Block deletion while the file is still referenced by published media rows
+  // (Issue #21 reference/orphan criterion).
+  const references = await findMediaReferences(client, bucket, path);
+  if (references > 0) {
+    return {
+      ok: false,
+      error: `Cannot delete: still referenced by ${references} media row(s). Remove the media from its project/resume first.`,
+    };
+  }
 
   const { error } = await client.storage.from(bucket).remove([path]);
   if (error) return { ok: false, error: error.message };

--- a/src/features/cms/media.ts
+++ b/src/features/cms/media.ts
@@ -40,6 +40,9 @@ export function getMediaPublicUrl(bucket: MediaBucket, path: string): string {
  * Count how many published CMS media rows reference a stored object. Deletion
  * is blocked while referenced to satisfy Issue #21's reference/orphan criterion.
  * Accepts any Supabase-style client so it is testable against local Supabase.
+ *
+ * Fail-closed: if the reference query itself errors, this throws so the caller
+ * cannot treat an unknown reference state as "safe to delete".
  */
 export async function findMediaReferences(
   client: SupabaseClient,
@@ -51,16 +54,16 @@ export async function findMediaReferences(
       .from("project_media")
       .select("id")
       .or(`src.ilike.%${path}%`);
-    if (!error && data) return data.length;
-    return 0;
+    if (error) throw new Error(`Reference check failed: ${error.message}`);
+    return data?.length ?? 0;
   }
   if (bucket === "resume-media") {
     const { data, error } = await client
       .from("resume_media")
       .select("id")
       .or(`thumbnail_src.ilike.%${path}%,full_src.ilike.%${path}%`);
-    if (!error && data) return data.length;
-    return 0;
+    if (error) throw new Error(`Reference check failed: ${error.message}`);
+    return data?.length ?? 0;
   }
   return 0;
 }

--- a/src/features/cms/media.ts
+++ b/src/features/cms/media.ts
@@ -1,0 +1,37 @@
+import { getServiceClient } from "./server";
+
+export type MediaBucket = "resume-media" | "project-media" | "portfolio";
+
+export interface StoredObject {
+  name: string;
+  id: string;
+  metadata?: { size?: number };
+  created_at?: string;
+}
+
+/**
+ * Server-side read of a storage bucket's objects. Uses the server-only
+ * service-role path (the public/admin read of bucket lists is not needed by the
+ * browser, and owner RLS would restrict it anyway). Callers (admin pages) are
+ * expected to gate on isAdminUser() at the route/page boundary.
+ */
+export async function listBucketObjects(
+  bucket: MediaBucket,
+): Promise<StoredObject[]> {
+  const client = getServiceClient();
+  if (!client) return [];
+
+  const { data, error } = await client.storage.from(bucket).list();
+  if (error || !data) return [];
+
+  return data as StoredObject[];
+}
+
+export function getMediaPublicUrl(bucket: MediaBucket, path: string): string {
+  if (bucket === "resume-media") {
+    return `/api/resume-media/${encodeURIComponent(path)}`;
+  }
+  const client = getServiceClient();
+  if (!client) return "";
+  return client.storage.from(bucket).getPublicUrl(path).data.publicUrl;
+}

--- a/src/features/cms/media.ts
+++ b/src/features/cms/media.ts
@@ -36,6 +36,11 @@ export function getMediaPublicUrl(bucket: MediaBucket, path: string): string {
   return `${base}/storage/v1/object/public/${bucket}/${encodeURIComponent(path)}`;
 }
 
+/** Escape LIKE wildcards so a stored path can never broaden the reference match. */
+function escapeLike(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}
+
 /**
  * Count how many published CMS media rows reference a stored object. Deletion
  * is blocked while referenced to satisfy Issue #21's reference/orphan criterion.
@@ -49,11 +54,13 @@ export async function findMediaReferences(
   bucket: MediaBucket,
   path: string,
 ): Promise<number> {
+  const safePath = escapeLike(path);
+
   if (bucket === "project-media") {
     const { data, error } = await client
       .from("project_media")
       .select("id")
-      .or(`src.ilike.%${path}%`);
+      .or(`src.ilike.%${safePath}%`);
     if (error) throw new Error(`Reference check failed: ${error.message}`);
     return data?.length ?? 0;
   }
@@ -61,7 +68,7 @@ export async function findMediaReferences(
     const { data, error } = await client
       .from("resume_media")
       .select("id")
-      .or(`thumbnail_src.ilike.%${path}%,full_src.ilike.%${path}%`);
+      .or(`thumbnail_src.ilike.%${safePath}%,full_src.ilike.%${safePath}%`);
     if (error) throw new Error(`Reference check failed: ${error.message}`);
     return data?.length ?? 0;
   }

--- a/src/features/cms/media.ts
+++ b/src/features/cms/media.ts
@@ -1,4 +1,5 @@
-import { getServiceClient } from "./server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getServerClient } from "./session";
 
 export type MediaBucket = "resume-media" | "project-media" | "portfolio";
 
@@ -10,16 +11,15 @@ export interface StoredObject {
 }
 
 /**
- * Server-side read of a storage bucket's objects. Uses the server-only
- * service-role path (the public/admin read of bucket lists is not needed by the
- * browser, and owner RLS would restrict it anyway). Callers (admin pages) are
- * expected to gate on isAdminUser() at the route/page boundary.
+ * Server-side read of a storage bucket's objects for the admin page. Uses the
+ * authenticated owner-session server client so Storage RLS (private.is_owner())
+ * authorizes the read, matching the accepted #18 design (no service-role on the
+ * admin path). The admin page is gated by isAdminUser() at the layout boundary.
  */
 export async function listBucketObjects(
   bucket: MediaBucket,
 ): Promise<StoredObject[]> {
-  const client = getServiceClient();
-  if (!client) return [];
+  const client = await getServerClient();
 
   const { data, error } = await client.storage.from(bucket).list();
   if (error || !data) return [];
@@ -31,7 +31,36 @@ export function getMediaPublicUrl(bucket: MediaBucket, path: string): string {
   if (bucket === "resume-media") {
     return `/api/resume-media/${encodeURIComponent(path)}`;
   }
-  const client = getServiceClient();
-  if (!client) return "";
-  return client.storage.from(bucket).getPublicUrl(path).data.publicUrl;
+  // Public buckets expose a fixed public URL built from the public env URL.
+  const base = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").replace(/\/$/, "");
+  return `${base}/storage/v1/object/public/${bucket}/${encodeURIComponent(path)}`;
+}
+
+/**
+ * Count how many published CMS media rows reference a stored object. Deletion
+ * is blocked while referenced to satisfy Issue #21's reference/orphan criterion.
+ * Accepts any Supabase-style client so it is testable against local Supabase.
+ */
+export async function findMediaReferences(
+  client: SupabaseClient,
+  bucket: MediaBucket,
+  path: string,
+): Promise<number> {
+  if (bucket === "project-media") {
+    const { data, error } = await client
+      .from("project_media")
+      .select("id")
+      .or(`src.ilike.%${path}%`);
+    if (!error && data) return data.length;
+    return 0;
+  }
+  if (bucket === "resume-media") {
+    const { data, error } = await client
+      .from("resume_media")
+      .select("id")
+      .or(`thumbnail_src.ilike.%${path}%,full_src.ilike.%${path}%`);
+    if (!error && data) return data.length;
+    return 0;
+  }
+  return 0;
 }

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -236,3 +236,66 @@ test("public resume repository excludes draft entries and groups by category", a
     await cleanupResume();
   }
 });
+
+const MEDIA_BUCKETS = {
+  public: "project-media",
+  private: "resume-media",
+} as const;
+
+test("storage media permissions: owner writes, anonymous denied", async (t) => {
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!anonKey) {
+    t.skip("NEXT_PUBLIC_SUPABASE_ANON_KEY not set");
+    return;
+  }
+
+  const { createClient } = await import("@supabase/supabase-js");
+
+  // Dedicated anonymous client — never authenticated, used for anon operations.
+  const anonClient = createClient(url, anonKey, {
+    auth: { persistSession: false },
+  });
+
+  // Separate client used only to obtain the owner token.
+  const authClient = createClient(url, anonKey, {
+    auth: { persistSession: false },
+  });
+  const { data: signIn } = await authClient.auth.signInWithPassword({
+    email: process.env.CMS_ADMIN_EMAIL ?? "admin@khoawatt.com",
+    password: process.env.CMS_ADMIN_PASSWORD ?? "test-password-123",
+  });
+  if (!signIn.session) {
+    t.skip("owner sign-in failed; cannot verify storage RLS");
+    return;
+  }
+  const ownerToken = signIn.session.access_token;
+  const ownerClient = createClient(url, anonKey, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: `Bearer ${ownerToken}` } },
+  });
+
+  const marker = `rls-${Date.now()}.jpg`;
+  const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3]);
+
+  try {
+    // Owner can upload to a public bucket.
+    const ownerUpload = await ownerClient.storage
+      .from(MEDIA_BUCKETS.public)
+      .upload(marker, bytes, { contentType: "image/jpeg" });
+    assert.equal(ownerUpload.error, null, "owner upload to public bucket");
+
+    // Anonymous cannot upload (owner-write policy).
+    const anonUpload = await anonClient.storage
+      .from(MEDIA_BUCKETS.public)
+      .upload(`anon-${marker}`, bytes, { contentType: "image/jpeg" });
+    assert.ok(anonUpload.error, "anonymous upload to public bucket is denied");
+
+    // Anonymous cannot read the private bucket.
+    const anonDownload = await anonClient.storage
+      .from(MEDIA_BUCKETS.private)
+      .download(marker);
+    assert.ok(anonDownload.error, "anonymous read of private bucket is denied");
+  } finally {
+    await ownerClient.storage.from(MEDIA_BUCKETS.public).remove([marker]);
+  }
+});

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -28,6 +28,7 @@ import {
   getFeaturedProjects,
   getResumeContent,
 } from "@/features/cms/repository";
+import { findMediaReferences } from "@/features/cms/media";
 
 const client = createClient(url, serviceRole, {
   auth: { persistSession: false },
@@ -297,5 +298,103 @@ test("storage media permissions: owner writes, anonymous denied", async (t) => {
     assert.ok(anonDownload.error, "anonymous read of private bucket is denied");
   } finally {
     await ownerClient.storage.from(MEDIA_BUCKETS.public).remove([marker]);
+  }
+});
+
+const REF_FIXTURES = {
+  project: "ref-project",
+  resumeEntry: "ref-resume-entry",
+  resumeMedia: "ref-resume-media",
+  projectMedia: "ref-project-media",
+  path: "ref-file.jpg",
+};
+
+async function createReferenceParents() {
+  const { error: projErr } = await client.from("projects").upsert(
+    { id: REF_FIXTURES.project, slug: REF_FIXTURES.project, featured: false, order: 99 },
+    { onConflict: "id" },
+  );
+  assert.equal(projErr, null, `ref project: ${projErr?.message}`);
+
+  const { error: catErr } = await client.from("resume_categories").upsert(
+    { id: "ref-cat", slug: "ref-cat", order: 99 },
+    { onConflict: "id" },
+  );
+  assert.equal(catErr, null, `ref category: ${catErr?.message}`);
+
+  const { error: entryErr } = await client.from("resume_entries").upsert(
+    { id: REF_FIXTURES.resumeEntry, category_id: "ref-cat", order: 99, draft: false },
+    { onConflict: "id" },
+  );
+  assert.equal(entryErr, null, `ref entry: ${entryErr?.message}`);
+}
+
+async function insertMediaReference(kind: "project" | "resume") {
+  if (kind === "project") {
+    const { error } = await client.from("project_media").upsert(
+      {
+        id: REF_FIXTURES.projectMedia,
+        project_id: REF_FIXTURES.project,
+        src: `/images/${REF_FIXTURES.path}`,
+        kind: "image",
+        order: 1,
+      },
+      { onConflict: "id" },
+    );
+    assert.equal(error, null, `project media ref: ${error?.message}`);
+  } else {
+    const { error } = await client.from("resume_media").upsert(
+      {
+        id: REF_FIXTURES.resumeMedia,
+        resume_entry_id: REF_FIXTURES.resumeEntry,
+        thumbnail_src: `/api/resume-media/${REF_FIXTURES.path}`,
+        full_src: `/api/resume-media/${REF_FIXTURES.path}`,
+        order: 1,
+      },
+      { onConflict: "id" },
+    );
+    assert.equal(error, null, `resume media ref: ${error?.message}`);
+  }
+}
+
+async function cleanupReferenceFixtures() {
+  await client.from("project_media").delete().eq("id", REF_FIXTURES.projectMedia);
+  await client.from("resume_media").delete().eq("id", REF_FIXTURES.resumeMedia);
+  await client.from("resume_entries").delete().eq("id", REF_FIXTURES.resumeEntry);
+  await client.from("resume_categories").delete().eq("id", "ref-cat");
+  await client.from("projects").delete().eq("id", REF_FIXTURES.project);
+}
+
+test("deletion reference check blocks referenced media and allows unreferenced", async () => {
+  await cleanupReferenceFixtures();
+  await createReferenceParents();
+
+  // Unreferenced -> allowed.
+  assert.equal(
+    await findMediaReferences(client, "project-media", REF_FIXTURES.path),
+    0,
+    "unreferenced project media reports 0 references",
+  );
+  assert.equal(
+    await findMediaReferences(client, "resume-media", REF_FIXTURES.path),
+    0,
+    "unreferenced resume media reports 0 references",
+  );
+
+  try {
+    // Referenced -> blocked (returns a positive count).
+    await insertMediaReference("project");
+    assert.ok(
+      (await findMediaReferences(client, "project-media", REF_FIXTURES.path)) > 0,
+      "referenced project media reports a reference",
+    );
+
+    await insertMediaReference("resume");
+    assert.ok(
+      (await findMediaReferences(client, "resume-media", REF_FIXTURES.path)) > 0,
+      "referenced resume media reports a reference",
+    );
+  } finally {
+    await cleanupReferenceFixtures();
   }
 });

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -23,7 +23,7 @@ if (!LOCAL_HOST.test(url)) {
   process.exit(1);
 }
 
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import {
   getFeaturedProjects,
   getResumeContent,
@@ -397,4 +397,28 @@ test("deletion reference check blocks referenced media and allows unreferenced",
   } finally {
     await cleanupReferenceFixtures();
   }
+});
+
+test("deletion reference check fails closed when the reference query errors", async () => {
+  const failingClient = {
+    from: () => ({
+      select: () => ({
+        or: async () => ({
+          data: null,
+          error: { message: "connection refused" },
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient;
+
+  // A reference-query error must throw so deleteMedia refuses to delete,
+  // never treating an unknown reference state as "safe to delete".
+  await assert.rejects(
+    () => findMediaReferences(failingClient, "project-media", "file.jpg"),
+    /Reference check failed/,
+  );
+  await assert.rejects(
+    () => findMediaReferences(failingClient, "resume-media", "file.jpg"),
+    /Reference check failed/,
+  );
 });

--- a/src/features/cms/repository.test.ts
+++ b/src/features/cms/repository.test.ts
@@ -422,3 +422,26 @@ test("deletion reference check fails closed when the reference query errors", as
     /Reference check failed/,
   );
 });
+
+test("reference check escapes LIKE wildcards in the stored path", async () => {
+  const filters: string[] = [];
+  const recordingClient = {
+    from: () => ({
+      select: () => ({
+        or: async (filter: string) => {
+          filters.push(filter);
+          return { data: [], error: null };
+        },
+      }),
+    }),
+  } as unknown as SupabaseClient;
+
+  await findMediaReferences(recordingClient, "project-media", "100%_real.jpg");
+  await findMediaReferences(recordingClient, "resume-media", "100%_real.jpg");
+
+  // % and _ are escaped so a literal path can never broaden the match.
+  assert.ok(
+    filters.every((f) => f.includes("%100\\%\\_real.jpg%")),
+    "LIKE wildcards in the path are escaped: " + filters.join(", "),
+  );
+});

--- a/supabase/migrations/20260820190000_cms_media_storage.sql
+++ b/supabase/migrations/20260820190000_cms_media_storage.sql
@@ -1,0 +1,46 @@
+-- Issue #21: CMS media management — Supabase Storage setup.
+--
+-- Creates the storage buckets defined in the accepted #18 design:
+--   - private 'resume-media'  -> served ONLY through the gated /api/resume-media route
+--   - public  'project-media' -> optimized public project images
+--   - public  'portfolio'     -> profile/social images
+--
+-- Object-level access follows the owner-only authorization model:
+--   - All buckets: only the owner (authenticated, private.is_owner()) may
+--     INSERT/UPDATE/DELETE objects.
+--   - 'resume-media': SELECT is restricted to owner only (private, deny-by-default);
+--     it is NEVER exposed as a public URL — it is served through the gated route,
+--     which reads with service-role/server privileges.
+--   - 'project-media' / 'portfolio': public SELECT (unauthenticated reads are
+--     required for public images), but writes remain owner-only.
+--
+-- These policies use private.is_owner() (non-recursive SECURITY DEFINER helper),
+-- the same authorization used by the content-table RLS.
+
+-- --- Buckets -------------------------------------------------------------------
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values
+  ('resume-media',  'resume-media',  false, 10485760, array['image/jpeg','image/png','image/webp']),
+  ('project-media', 'project-media', true,  10485760, array['image/jpeg','image/png','image/webp']),
+  ('portfolio',     'portfolio',     true,  10485760, array['image/jpeg','image/png','image/webp'])
+on conflict (id) do nothing;
+
+-- --- Owner-write on all buckets ------------------------------------------------
+create policy "owner all objects" on storage.objects
+  for all to authenticated
+  using (bucket_id in ('resume-media','project-media','portfolio') and private.is_owner())
+  with check (bucket_id in ('resume-media','project-media','portfolio') and private.is_owner());
+
+-- --- Public read on the public buckets only ------------------------------------
+create policy "public read project-media" on storage.objects
+  for select to anon, authenticated
+  using (bucket_id = 'project-media');
+
+create policy "public read portfolio" on storage.objects
+  for select to anon, authenticated
+  using (bucket_id = 'portfolio');
+
+-- 'resume-media' intentionally has NO public/authenticated SELECT policy, so it is
+-- deny-by-default for everyone except the owner (via the owner-all policy). Public
+-- serving of resume media happens only through the gated route using the
+-- service-role/server path.


### PR DESCRIPTION
Closes #21

## Summary
Completes the final CMS slice: managed media with Supabase Storage and the
admin workflow for upload/delete, matching the accepted #18 storage strategy
(private resume-media bucket served via the gated route; public project/portfolio
buckets). All content CRUD slices (#20, #51, #52) were completed and merged first.

## What changed

### Storage setup (migration)
- Create buckets: `resume-media` (private), `project-media` (public), `portfolio`
  (public), each with size (10 MB) and MIME (JPEG/PNG/WebP) limits.
- Storage RLS policies (using `private.is_owner()`):
  - Owner-only writes on all buckets.
  - Public SELECT on `project-media` and `portfolio` only.
  - `resume-media` has NO public/anon read — it is served only through the gated
    `/api/resume-media` route (server-only read of the private bucket).

### Admin media management
- `src/features/cms/media-actions.ts`: owner-gated upload (validates MIME + size)
  and delete via the server-only storage path; `media.ts` for server-side listing +
  public URL helpers.
- `/admin/media` page: list each bucket, upload images, delete files.

### Public serving
- `/api/resume-media/[file]` now serves uploaded resume files from the private
  storage bucket (sanitized path, server-only), falling back to the local approved
  assets; gated by the resume publicity flag as before.

### Verification
- Storage RLS regression test (`test:cms`): owner upload ok, anonymous upload
  denied, anonymous private-bucket read denied.
- `npm run lint` / `npm run typecheck` — pass
- `npm test` — 99 pass (incl. resume-media route tests)
- `npm run test:db` — 2 pass
- `npm run test:cms` — 3 pass
- `supabase db test --local supabase/tests` — 13/13 RLS assertions pass
- `npm run build` — pass

## Known limitations
- Media metadata (alt/caption/dimensions/order) is already stored in the content
  tables; this slice adds the file storage + admin upload/delete. Alt/caption
  editing for uploaded media is managed through the existing project/resume forms.

## Docs affected
- `docs/superpowers/specs/2026-08-20-supabase-cms-schema-design.md` (storage
  strategy implemented).