### PR TITLE
feat: professional admin CMS dashboard UI (Issue #68)

### DIFF
--- a/src/app/admin/(dashboard)/admin-page.tsx
+++ b/src/app/admin/(dashboard)/admin-page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+interface AdminPageProps {
+  title: string;
+  backHref?: string;
+  backLabel?: string;
+  /** Optional action rendered on the right of the title (e.g. a "New X" link). */
+  action?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Consistent wrapper for admin pages: optional back link, a title row (with an
+ * optional action), and the page body. Form pages pass their fields via
+ * AdminFormCard.
+ */
+export function AdminPage({
+  title,
+  backHref,
+  backLabel = "Back",
+  action,
+  children,
+}: AdminPageProps) {
+  return (
+    <main className="admin-dashboard">
+      {backHref ? (
+        <Link className="admin-back-link" href={backHref}>
+          ← {backLabel}
+        </Link>
+      ) : null}
+      <div className="admin-page-head">
+        <h1>{title}</h1>
+        {action ? <div className="admin-page-head__action">{action}</div> : null}
+      </div>
+      {children}
+    </main>
+  );
+}
+
+interface AdminFormCardProps {
+  children: ReactNode;
+}
+
+/** Card container for a form page's fields. */
+export function AdminFormCard({ children }: AdminFormCardProps) {
+  return <div className="admin-form-card">{children}</div>;
+}
+
+interface AdminTableProps {
+  label: string;
+  children: ReactNode;
+}
+
+/** Keeps semantic tables usable at narrow viewports without scrolling the page. */
+export function AdminTable({ label, children }: AdminTableProps) {
+  return (
+    <div className="admin-table-wrap" role="region" aria-label={label} tabIndex={0}>
+      <table className="admin-table">{children}</table>
+    </div>
+  );
+}

--- a/src/app/admin/(dashboard)/admin-sidebar.tsx
+++ b/src/app/admin/(dashboard)/admin-sidebar.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+function SettingsIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <path
+        d="M4 7h16M4 12h16M4 17h16"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function ProfileIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <circle cx="12" cy="8" r="4" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M4 20c1.5-3.5 4.5-5 8-5s6.5 1.5 8 5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function SkillsIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <path
+        d="M14.7 6.3a4 4 0 0 0-5.4 5.4L4 17l3 3 5.3-5.3a4 4 0 0 0 5.4-5.4l-2.6 2.6-2.4-2.4 2.6-2.6Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function SocialIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <path
+        d="M10 14a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1.5 1.5M14 10a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1.5-1.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function ProjectsIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <rect height="14" stroke="currentColor" strokeWidth="1.8" width="16" x="4" y="5" rx="2" />
+      <path d="M4 10h16M9 5v14" stroke="currentColor" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+function ResumeIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <path
+        d="M7 3h7l4 4v14H7V3Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+      <path d="M14 3v4h4M10 12h5M10 15h5" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+function MediaIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <rect height="14" stroke="currentColor" strokeWidth="1.8" width="18" x="3" y="5" rx="2" />
+      <circle cx="9" cy="10" r="1.5" stroke="currentColor" strokeWidth="1.8" />
+      <path d="m21 15-4-4-5 5-3-3-6 6" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+const navLinks: Array<{ href: string; label: string; icon: () => ReactNode }> = [
+  { href: "/admin/settings", label: "Settings", icon: SettingsIcon },
+  { href: "/admin/profile", label: "Profile", icon: ProfileIcon },
+  { href: "/admin/skills", label: "Skills", icon: SkillsIcon },
+  { href: "/admin/social", label: "Social", icon: SocialIcon },
+  { href: "/admin/projects", label: "Projects", icon: ProjectsIcon },
+  { href: "/admin/resume", label: "Resume", icon: ResumeIcon },
+  { href: "/admin/media", label: "Media", icon: MediaIcon },
+];
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/admin/settings") return pathname === href;
+  return pathname.startsWith(href);
+}
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="admin-sidebar" aria-label="Admin navigation">
+      <div className="admin-brand">
+        <span className="admin-brand__mark">Q</span>
+        <span className="admin-brand__name">Khoa Watt</span>
+      </div>
+      <nav className="admin-sidebar__nav">
+        {navLinks.map((link) => {
+          const Icon = link.icon;
+          return (
+            <Link
+              aria-current={isActive(pathname, link.href) ? "page" : undefined}
+              className="admin-sidebar__link"
+              href={link.href}
+              key={link.href}
+            >
+              <span className="admin-sidebar__icon">
+                <Icon />
+              </span>
+              {link.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/app/admin/(dashboard)/layout.tsx
+++ b/src/app/admin/(dashboard)/layout.tsx
@@ -1,17 +1,14 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { isAdminUser } from "@/features/cms/session";
+import { ThemeToggle } from "@/features/theme/theme-toggle";
+import { AdminSidebar } from "./admin-sidebar";
 
-const navLinks = [
-  { href: "/admin/settings", label: "Settings" },
-  { href: "/admin/profile", label: "Profile" },
-  { href: "/admin/skills", label: "Skills" },
-  { href: "/admin/social", label: "Social" },
-  { href: "/admin/projects", label: "Projects" },
-  { href: "/admin/resume", label: "Resume" },
-  { href: "/admin/media", label: "Media" },
-] as const;
+const adminThemeMessages = {
+  toggle: "Toggle color theme",
+  switchToDark: "Switch to dark theme",
+  switchToLight: "Switch to light theme",
+};
 
 export default async function AdminDashboardLayout({
   children,
@@ -23,15 +20,20 @@ export default async function AdminDashboardLayout({
   }
 
   return (
-    <>
-      <nav className="admin-nav" aria-label="Admin">
-        {navLinks.map((link) => (
-          <Link href={link.href} key={link.href}>
-            {link.label}
-          </Link>
-        ))}
-      </nav>
-      {children}
-    </>
+    <div className="admin-shell">
+      <AdminSidebar />
+      <div className="admin-main">
+        <header className="admin-topbar">
+          <span className="admin-topbar__title">Content management</span>
+          <div className="admin-topbar__actions">
+            <ThemeToggle messages={adminThemeMessages} />
+            <a className="admin-topbar__view" href="/" target="_blank" rel="noreferrer">
+              View site <span aria-hidden="true">↗</span>
+            </a>
+          </div>
+        </header>
+        <div className="admin-content">{children}</div>
+      </div>
+    </div>
   );
 }

--- a/src/app/admin/(dashboard)/media/page.tsx
+++ b/src/app/admin/(dashboard)/media/page.tsx
@@ -2,6 +2,7 @@ import { listBucketObjects, getMediaPublicUrl } from "@/features/cms/media";
 import type { MediaBucket } from "@/features/cms/media";
 import { MediaUploadForm } from "./media-upload-form";
 import { MediaDeleteButton } from "./media-delete";
+import { AdminPage } from "../admin-page";
 
 export const metadata = {
   title: "Admin media",
@@ -22,8 +23,7 @@ export default async function AdminMediaPage() {
   );
 
   return (
-    <main className="admin-dashboard">
-      <h1>Media</h1>
+    <AdminPage title="Media">
       <p className="admin-message">
         Upload and manage images stored in Supabase Storage. Resume media is
         private and served only through the gated route; project and portfolio
@@ -48,8 +48,10 @@ export default async function AdminMediaPage() {
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       alt={object.name}
+                      height={80}
                       loading="lazy"
                       src={getMediaPublicUrl(bucket.id, object.name)}
+                      width={80}
                     />
                   </div>
                   <div className="admin-media-meta">
@@ -62,6 +64,6 @@ export default async function AdminMediaPage() {
           )}
         </section>
       ))}
-    </main>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/profile/page.tsx
+++ b/src/app/admin/(dashboard)/profile/page.tsx
@@ -1,5 +1,6 @@
 import { emptyProfileView, getProfileView } from "./data";
 import { ProfileForm } from "./profile-form";
+import { AdminFormCard, AdminPage } from "../admin-page";
 
 export const metadata = {
   title: "Admin profile",
@@ -9,9 +10,11 @@ export default async function AdminProfilePage() {
   const profile = (await getProfileView()) ?? emptyProfileView();
 
   return (
-    <main className="admin-dashboard">
-      <h1>Profile</h1>
-      <ProfileForm initial={profile} />
-    </main>
+    <AdminPage title="Profile">
+      <AdminFormCard>
+        <h2>Profile details</h2>
+        <ProfileForm initial={profile} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/profile/profile-form.tsx
+++ b/src/app/admin/(dashboard)/profile/profile-form.tsx
@@ -142,6 +142,9 @@ export function ProfileForm({ initial }: ProfileFormProps) {
         <button disabled={isPending} type="submit">
           {isPending ? "Saving…" : "Save profile"}
         </button>
+        <button className="admin-button-secondary" disabled={isPending} type="reset">
+          Cancel changes
+        </button>
         {initial.id ? (
           <button
             className="admin-link-button admin-link-button--danger"

--- a/src/app/admin/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/projects/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { getProject } from "../data";
 import { ProjectForm } from "../project-form";
+import { AdminFormCard, AdminPage } from "../../admin-page";
 
 interface AdminEditProjectPageProps {
   params: Promise<{ id: string }>;
@@ -22,9 +23,11 @@ export default async function AdminEditProjectPage({
   }
 
   return (
-    <main className="admin-dashboard">
-      <h1>Edit project</h1>
-      <ProjectForm existing={project} />
-    </main>
+    <AdminPage backHref="/admin/projects" title="Edit project">
+      <AdminFormCard>
+        <h2>Project details</h2>
+        <ProjectForm existing={project} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/projects/new/page.tsx
+++ b/src/app/admin/(dashboard)/projects/new/page.tsx
@@ -1,4 +1,5 @@
 import { ProjectForm } from "../project-form";
+import { AdminFormCard, AdminPage } from "../../admin-page";
 
 export const metadata = {
   title: "New project",
@@ -6,9 +7,11 @@ export const metadata = {
 
 export default function AdminNewProjectPage() {
   return (
-    <main className="admin-dashboard">
-      <h1>New project</h1>
-      <ProjectForm />
-    </main>
+    <AdminPage backHref="/admin/projects" title="New project">
+      <AdminFormCard>
+        <h2>Project details</h2>
+        <ProjectForm />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/projects/page.tsx
+++ b/src/app/admin/(dashboard)/projects/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { listProjects } from "./data";
 import { DeleteProjectButton } from "./delete-project";
+import { AdminPage, AdminTable } from "../admin-page";
 
 export const metadata = {
   title: "Admin projects",
@@ -11,23 +12,27 @@ export default async function AdminProjectsPage() {
   const projects = await listProjects();
 
   return (
-    <main className="admin-dashboard">
-      <div className="admin-page-head">
-        <h1>Projects</h1>
+    <AdminPage
+      action={
         <Link className="admin-button" href="/admin/projects/new">
           New project
         </Link>
-      </div>
-
-      <table className="admin-table">
+      }
+      title="Projects"
+    >
+      {projects.length === 0 ? (
+        <p className="admin-empty">No projects yet.</p>
+      ) : (
+      <AdminTable label="Projects">
         <thead>
           <tr>
-            <th>ID</th>
-            <th>Title</th>
-            <th>Featured</th>
-            <th>Status</th>
-            <th>Order</th>
-            <th />
+            <th scope="col">ID</th>
+            <th scope="col">Title</th>
+            <th scope="col">Featured</th>
+            <th scope="col">Status</th>
+            <th scope="col">Published</th>
+            <th scope="col">Order</th>
+            <th scope="col"><span className="sr-only">Actions</span></th>
           </tr>
         </thead>
         <tbody>
@@ -35,8 +40,21 @@ export default async function AdminProjectsPage() {
             <tr key={project.id}>
               <td>{project.id}</td>
               <td>{project.titleEn}</td>
-              <td>{project.featured ? "✓" : ""}</td>
-              <td>{project.status}</td>
+              <td>
+                {project.featured ? (
+                  <span className="admin-badge admin-badge--success">Featured</span>
+                ) : null}
+              </td>
+              <td>
+                <span className={`admin-badge ${project.status === "active" ? "admin-badge--success" : "admin-badge--muted"}`}>
+                  {project.status}
+                </span>
+              </td>
+              <td>
+                <span className={`admin-badge ${project.published ? "admin-badge--success" : "admin-badge--muted"}`}>
+                  {project.published ? "Published" : "Draft"}
+                </span>
+              </td>
               <td>{project.order}</td>
               <td className="admin-row-actions">
                 <Link href={`/admin/projects/${project.id}`}>Edit</Link>
@@ -45,7 +63,8 @@ export default async function AdminProjectsPage() {
             </tr>
           ))}
         </tbody>
-      </table>
-    </main>
+      </AdminTable>
+      )}
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/projects/project-form.tsx
+++ b/src/app/admin/(dashboard)/projects/project-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import type { AdminProjectRow } from "./data";
@@ -167,9 +168,12 @@ export function ProjectForm({ existing }: ProjectFormProps) {
         </p>
       ) : null}
 
-      <button disabled={isPending} type="submit">
-        {isPending ? "Saving…" : existing ? "Update project" : "Create project"}
-      </button>
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update project" : "Create project"}
+        </button>
+        <Link href="/admin/projects">Cancel</Link>
+      </div>
     </form>
   );
 }

--- a/src/app/admin/(dashboard)/resume/categories/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/resume/categories/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { listResumeCategories } from "../../data";
 import { ResumeCategoryForm } from "../../resume-category-form";
+import { AdminFormCard, AdminPage } from "../../../admin-page";
 
 interface AdminEditResumeCategoryPageProps {
   params: Promise<{ id: string }>;
@@ -23,9 +24,11 @@ export default async function AdminEditResumeCategoryPage({
   }
 
   return (
-    <main className="admin-dashboard">
-      <h1>Edit resume category</h1>
-      <ResumeCategoryForm existing={category} />
-    </main>
+    <AdminPage backHref="/admin/resume" title="Edit resume category">
+      <AdminFormCard>
+        <h2>Category</h2>
+        <ResumeCategoryForm existing={category} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/resume/categories/new/page.tsx
+++ b/src/app/admin/(dashboard)/resume/categories/new/page.tsx
@@ -1,4 +1,5 @@
 import { ResumeCategoryForm } from "../../resume-category-form";
+import { AdminFormCard, AdminPage } from "../../../admin-page";
 
 export const metadata = {
   title: "New resume category",
@@ -6,9 +7,11 @@ export const metadata = {
 
 export default function AdminNewResumeCategoryPage() {
   return (
-    <main className="admin-dashboard">
-      <h1>New resume category</h1>
-      <ResumeCategoryForm />
-    </main>
+    <AdminPage backHref="/admin/resume" title="New resume category">
+      <AdminFormCard>
+        <h2>Category</h2>
+        <ResumeCategoryForm />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/resume/entries/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/resume/entries/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { getResumeEntry, listResumeCategories } from "../../data";
 import { ResumeEntryForm } from "../../resume-entry-form";
+import { AdminFormCard, AdminPage } from "../../../admin-page";
 
 interface AdminEditResumeEntryPageProps {
   params: Promise<{ id: string }>;
@@ -25,9 +26,11 @@ export default async function AdminEditResumeEntryPage({
   }
 
   return (
-    <main className="admin-dashboard">
-      <h1>Edit resume entry</h1>
-      <ResumeEntryForm existing={entry} categories={categories} />
-    </main>
+    <AdminPage backHref="/admin/resume" title="Edit resume entry">
+      <AdminFormCard>
+        <h2>Entry details</h2>
+        <ResumeEntryForm existing={entry} categories={categories} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/resume/entries/new/page.tsx
+++ b/src/app/admin/(dashboard)/resume/entries/new/page.tsx
@@ -1,5 +1,6 @@
 import { listResumeCategories } from "../../data";
 import { ResumeEntryForm } from "../../resume-entry-form";
+import { AdminFormCard, AdminPage } from "../../../admin-page";
 
 export const metadata = {
   title: "New resume entry",
@@ -9,9 +10,11 @@ export default async function AdminNewResumeEntryPage() {
   const categories = await listResumeCategories();
 
   return (
-    <main className="admin-dashboard">
-      <h1>New resume entry</h1>
-      <ResumeEntryForm categories={categories} />
-    </main>
+    <AdminPage backHref="/admin/resume" title="New resume entry">
+      <AdminFormCard>
+        <h2>Entry details</h2>
+        <ResumeEntryForm categories={categories} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/resume/page.tsx
+++ b/src/app/admin/(dashboard)/resume/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { listResumeCategories, listResumeEntries } from "./data";
 import { ResumeDeleteButton } from "./resume-delete";
+import { AdminPage, AdminTable } from "../admin-page";
 
 export const metadata = {
   title: "Admin resume",
@@ -12,9 +13,7 @@ export default async function AdminResumePage() {
   const entries = await listResumeEntries();
 
   return (
-    <main className="admin-dashboard">
-      <h1>Resume / CV</h1>
-
+    <AdminPage title="Resume / CV">
       <section className="admin-section">
         <div className="admin-page-head">
           <h2>Categories</h2>
@@ -22,13 +21,16 @@ export default async function AdminResumePage() {
             New category
           </Link>
         </div>
-        <table className="admin-table">
+        {categories.length === 0 ? (
+          <p className="admin-empty">No resume categories yet.</p>
+        ) : (
+        <AdminTable label="Resume categories">
           <thead>
             <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>Order</th>
-              <th />
+              <th scope="col">ID</th>
+              <th scope="col">Name</th>
+              <th scope="col">Order</th>
+              <th scope="col"><span className="sr-only">Actions</span></th>
             </tr>
           </thead>
           <tbody>
@@ -44,7 +46,8 @@ export default async function AdminResumePage() {
               </tr>
             ))}
           </tbody>
-        </table>
+        </AdminTable>
+        )}
       </section>
 
       <section className="admin-section">
@@ -54,15 +57,18 @@ export default async function AdminResumePage() {
             New entry
           </Link>
         </div>
-        <table className="admin-table">
+        {entries.length === 0 ? (
+          <p className="admin-empty">No resume entries yet.</p>
+        ) : (
+        <AdminTable label="Resume entries">
           <thead>
             <tr>
-              <th>ID</th>
-              <th>Title</th>
-              <th>Category</th>
-              <th>Draft</th>
-              <th>Order</th>
-              <th />
+              <th scope="col">ID</th>
+              <th scope="col">Title</th>
+              <th scope="col">Category</th>
+              <th scope="col">Publication status</th>
+              <th scope="col">Order</th>
+              <th scope="col"><span className="sr-only">Actions</span></th>
             </tr>
           </thead>
           <tbody>
@@ -73,7 +79,13 @@ export default async function AdminResumePage() {
                   <td>{entry.id}</td>
                   <td>{entry.titleEn}</td>
                   <td>{category?.nameEn ?? entry.categoryId}</td>
-                  <td>{entry.draft ? "✓" : ""}</td>
+                  <td>
+                    {entry.draft ? (
+                      <span className="admin-badge admin-badge--muted">Draft</span>
+                    ) : (
+                      <span className="admin-badge admin-badge--success">Published</span>
+                    )}
+                  </td>
                   <td>{entry.order}</td>
                   <td className="admin-row-actions">
                     <Link href={`/admin/resume/entries/${entry.id}`}>Edit</Link>
@@ -83,8 +95,9 @@ export default async function AdminResumePage() {
               );
             })}
           </tbody>
-        </table>
+        </AdminTable>
+        )}
       </section>
-    </main>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/resume/resume-category-form.tsx
+++ b/src/app/admin/(dashboard)/resume/resume-category-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import type { AdminResumeCategory } from "./data";
@@ -71,9 +72,12 @@ export function ResumeCategoryForm({ existing }: ResumeCategoryFormProps) {
         </p>
       ) : null}
 
-      <button disabled={isPending} type="submit">
-        {isPending ? "Saving…" : existing ? "Update category" : "Create category"}
-      </button>
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update category" : "Create category"}
+        </button>
+        <Link href="/admin/resume">Cancel</Link>
+      </div>
     </form>
   );
 }

--- a/src/app/admin/(dashboard)/resume/resume-entry-form.tsx
+++ b/src/app/admin/(dashboard)/resume/resume-entry-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import type { AdminResumeCategory, AdminResumeEntry } from "./data";
@@ -178,9 +179,12 @@ export function ResumeEntryForm({ existing, categories }: ResumeEntryFormProps) 
         </p>
       ) : null}
 
-      <button disabled={isPending} type="submit">
-        {isPending ? "Saving…" : existing ? "Update entry" : "Create entry"}
-      </button>
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update entry" : "Create entry"}
+        </button>
+        <Link href="/admin/resume">Cancel</Link>
+      </div>
     </form>
   );
 }

--- a/src/app/admin/(dashboard)/settings/page.tsx
+++ b/src/app/admin/(dashboard)/settings/page.tsx
@@ -1,5 +1,6 @@
 import { getSettingsView } from "./data";
 import { SettingsForm } from "./settings-form";
+import { AdminFormCard, AdminPage } from "../admin-page";
 
 export const metadata = {
   title: "Admin settings",
@@ -9,9 +10,11 @@ export default async function AdminSettingsPage() {
   const view = await getSettingsView();
 
   return (
-    <main className="admin-dashboard">
-      <h1>Settings</h1>
-      <SettingsForm initial={view} />
-    </main>
+    <AdminPage title="Settings">
+      <AdminFormCard>
+        <h2>Site settings</h2>
+        <SettingsForm initial={view} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/skills/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/skills/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { getSkill } from "../data";
 import { SkillForm } from "../skill-form";
+import { AdminFormCard, AdminPage } from "../../admin-page";
 
 interface AdminEditSkillPageProps {
   params: Promise<{ id: string }>;
@@ -22,9 +23,11 @@ export default async function AdminEditSkillPage({
   }
 
   return (
-    <main className="admin-dashboard">
-      <h1>Edit skill</h1>
-      <SkillForm existing={skill} />
-    </main>
+    <AdminPage backHref="/admin/skills" title="Edit skill">
+      <AdminFormCard>
+        <h2>Skill details</h2>
+        <SkillForm existing={skill} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/skills/new/page.tsx
+++ b/src/app/admin/(dashboard)/skills/new/page.tsx
@@ -1,4 +1,5 @@
 import { SkillForm } from "../skill-form";
+import { AdminFormCard, AdminPage } from "../../admin-page";
 
 export const metadata = {
   title: "New skill",
@@ -6,9 +7,11 @@ export const metadata = {
 
 export default function AdminNewSkillPage() {
   return (
-    <main className="admin-dashboard">
-      <h1>New skill</h1>
-      <SkillForm />
-    </main>
+    <AdminPage backHref="/admin/skills" title="New skill">
+      <AdminFormCard>
+        <h2>Skill details</h2>
+        <SkillForm />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/skills/page.tsx
+++ b/src/app/admin/(dashboard)/skills/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { listSkills } from "./data";
 import { DeleteSkillButton } from "./delete-skill";
+import { AdminPage, AdminTable } from "../admin-page";
 
 export const metadata = {
   title: "Admin skills",
@@ -11,23 +12,26 @@ export default async function AdminSkillsPage() {
   const skills = await listSkills();
 
   return (
-    <main className="admin-dashboard">
-      <div className="admin-page-head">
-        <h1>Skills</h1>
+    <AdminPage
+      action={
         <Link className="admin-button" href="/admin/skills/new">
           New skill
         </Link>
-      </div>
-
-      <table className="admin-table">
+      }
+      title="Skills"
+    >
+      {skills.length === 0 ? (
+        <p className="admin-empty">No skills yet.</p>
+      ) : (
+      <AdminTable label="Skills">
         <thead>
           <tr>
-            <th>ID</th>
-            <th>Name</th>
-            <th>Group</th>
-            <th>Order</th>
-            <th>Featured</th>
-            <th />
+            <th scope="col">ID</th>
+            <th scope="col">Name</th>
+            <th scope="col">Group</th>
+            <th scope="col">Order</th>
+            <th scope="col">Featured</th>
+            <th scope="col"><span className="sr-only">Actions</span></th>
           </tr>
         </thead>
         <tbody>
@@ -37,7 +41,11 @@ export default async function AdminSkillsPage() {
               <td>{skill.nameEn}</td>
               <td>{skill.group}</td>
               <td>{skill.order}</td>
-              <td>{skill.featured ? "✓" : ""}</td>
+              <td>
+                {skill.featured ? (
+                  <span className="admin-badge admin-badge--success">Featured</span>
+                ) : null}
+              </td>
               <td className="admin-row-actions">
                 <Link href={`/admin/skills/${skill.id}`}>Edit</Link>
                 <DeleteSkillButton id={skill.id} name={skill.nameEn} />
@@ -45,7 +53,8 @@ export default async function AdminSkillsPage() {
             </tr>
           ))}
         </tbody>
-      </table>
-    </main>
+      </AdminTable>
+      )}
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/skills/skill-form.tsx
+++ b/src/app/admin/(dashboard)/skills/skill-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import type { SkillGroup } from "@/content/skills";
@@ -126,9 +127,12 @@ export function SkillForm({ existing }: SkillFormProps) {
         </p>
       ) : null}
 
-      <button disabled={isPending} type="submit">
-        {isPending ? "Saving…" : existing ? "Update skill" : "Create skill"}
-      </button>
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update skill" : "Create skill"}
+        </button>
+        <Link href="/admin/skills">Cancel</Link>
+      </div>
     </form>
   );
 }

--- a/src/app/admin/(dashboard)/social/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/social/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { listSocialLinks } from "../data";
 import { SocialLinkForm } from "../social-form";
+import { AdminFormCard, AdminPage } from "../../admin-page";
 
 interface AdminEditSocialPageProps {
   params: Promise<{ id: string }>;
@@ -23,9 +24,11 @@ export default async function AdminEditSocialPage({
   }
 
   return (
-    <main className="admin-dashboard">
-      <h1>Edit social link</h1>
-      <SocialLinkForm existing={link} />
-    </main>
+    <AdminPage backHref="/admin/social" title="Edit social link">
+      <AdminFormCard>
+        <h2>Social link</h2>
+        <SocialLinkForm existing={link} />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/social/new/page.tsx
+++ b/src/app/admin/(dashboard)/social/new/page.tsx
@@ -1,4 +1,5 @@
 import { SocialLinkForm } from "../social-form";
+import { AdminFormCard, AdminPage } from "../../admin-page";
 
 export const metadata = {
   title: "New social link",
@@ -6,9 +7,11 @@ export const metadata = {
 
 export default function AdminNewSocialPage() {
   return (
-    <main className="admin-dashboard">
-      <h1>New social link</h1>
-      <SocialLinkForm />
-    </main>
+    <AdminPage backHref="/admin/social" title="New social link">
+      <AdminFormCard>
+        <h2>Social link</h2>
+        <SocialLinkForm />
+      </AdminFormCard>
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/social/page.tsx
+++ b/src/app/admin/(dashboard)/social/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { listSocialLinks } from "./data";
 import { DeleteSocialButton } from "./delete-social";
+import { AdminPage, AdminTable } from "../admin-page";
 
 export const metadata = {
   title: "Admin social links",
@@ -11,21 +12,24 @@ export default async function AdminSocialPage() {
   const links = await listSocialLinks();
 
   return (
-    <main className="admin-dashboard">
-      <div className="admin-page-head">
-        <h1>Social links</h1>
+    <AdminPage
+      action={
         <Link className="admin-button" href="/admin/social/new">
           New link
         </Link>
-      </div>
-
-      <table className="admin-table">
+      }
+      title="Social links"
+    >
+      {links.length === 0 ? (
+        <p className="admin-empty">No social links yet.</p>
+      ) : (
+      <AdminTable label="Social links">
         <thead>
           <tr>
-            <th>Label</th>
-            <th>URL</th>
-            <th>Order</th>
-            <th />
+            <th scope="col">Label</th>
+            <th scope="col">URL</th>
+            <th scope="col">Order</th>
+            <th scope="col"><span className="sr-only">Actions</span></th>
           </tr>
         </thead>
         <tbody>
@@ -41,7 +45,8 @@ export default async function AdminSocialPage() {
             </tr>
           ))}
         </tbody>
-      </table>
-    </main>
+      </AdminTable>
+      )}
+    </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/social/social-form.tsx
+++ b/src/app/admin/(dashboard)/social/social-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import type { AdminSocialLink } from "./data";
@@ -72,9 +73,12 @@ export function SocialLinkForm({ existing }: SocialLinkFormProps) {
         </p>
       ) : null}
 
-      <button disabled={isPending} type="submit">
-        {isPending ? "Saving…" : existing ? "Update link" : "Create link"}
-      </button>
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update link" : "Create link"}
+        </button>
+        <Link href="/admin/social">Cancel</Link>
+      </div>
     </form>
   );
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,19 @@
+import { ThemeProvider } from "@/features/theme/theme-provider";
+import { ThemeScript } from "@/features/theme/theme-script";
+
+import "@/styles/globals.css";
+
 export default function AdminLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  return <div className="admin-shell">{children}</div>;
+  return (
+    <html data-theme="light" lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
+      <body>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
+    </html>
+  );
 }

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,4 +1,11 @@
 import { LoginForm } from "./login-form";
+import { ThemeToggle } from "@/features/theme/theme-toggle";
+
+const adminThemeMessages = {
+  toggle: "Toggle color theme",
+  switchToDark: "Switch to dark theme",
+  switchToLight: "Switch to light theme",
+};
 
 export const metadata = {
   title: "Admin sign in",
@@ -6,10 +13,21 @@ export const metadata = {
 
 export default function AdminLoginPage() {
   return (
-    <main className="admin-login">
-      <h1>Portfolio admin</h1>
-      <p>Sign in to manage content.</p>
-      <LoginForm />
+    <main className="admin-login-shell">
+      <div className="admin-login-theme">
+        <ThemeToggle messages={adminThemeMessages} />
+      </div>
+      <section className="admin-login" aria-labelledby="admin-login-title">
+        <div className="admin-brand admin-login__brand">
+          <span className="admin-brand__mark" aria-hidden="true">Q</span>
+          <span className="admin-brand__name">Khoa Watt</span>
+        </div>
+        <div className="admin-login__heading">
+          <h1 id="admin-login-title">Portfolio admin</h1>
+          <p>Sign in to manage your portfolio content.</p>
+        </div>
+        <LoginForm />
+      </section>
     </main>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2674,14 +2674,165 @@ video {
   min-height: 100vh;
   background: var(--color-page);
   color: var(--color-text);
+  display: grid;
+  grid-template-columns: 15.5rem 1fr;
+}
+
+.admin-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.25rem 0.875rem;
+  background: var(--color-surface-subtle);
+  border-right: 1px solid var(--color-border);
+  overflow-y: auto;
+}
+
+.admin-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.admin-brand__mark {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+  font-weight: 700;
+}
+
+.admin-brand__name {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.admin-sidebar__nav {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.admin-sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.admin-sidebar__link:hover {
+  color: var(--color-text);
+  background: var(--color-surface-elevated);
+}
+
+.admin-sidebar__link[aria-current="page"] {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.admin-sidebar__icon {
+  display: grid;
+  place-items: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.admin-sidebar__link[aria-current="page"] .admin-sidebar__icon {
+  color: var(--color-accent);
+}
+
+.admin-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.875rem clamp(1.25rem, 3vw, 2.5rem);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-topbar__title {
+  font-weight: 600;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+.admin-topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.admin-topbar__view {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.admin-topbar__view:hover {
+  text-decoration: underline;
+}
+
+.admin-content {
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.admin-login-shell {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.25rem, 5vw, 3rem);
+  background:
+    radial-gradient(circle at top left, var(--color-accent-soft), transparent 38rem),
+    var(--color-page);
+}
+
+.admin-login-theme {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
 }
 
 .admin-login {
-  max-width: 24rem;
-  margin: 0 auto;
-  padding: clamp(2rem, 8vw, 4rem) 1.25rem;
+  width: min(100%, 26rem);
+  padding: clamp(1.5rem, 5vw, 2.25rem);
   display: grid;
-  gap: 1rem;
+  gap: 1.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.admin-login__brand {
+  padding: 0;
+}
+
+.admin-login__heading {
+  display: grid;
+  gap: 0.375rem;
 }
 
 .admin-login h1 {
@@ -2698,7 +2849,6 @@ video {
 .admin-login-form {
   display: grid;
   gap: 1rem;
-  margin-top: 1rem;
 }
 
 .admin-field {
@@ -2745,9 +2895,7 @@ video {
 }
 
 .admin-dashboard {
-  max-width: 44rem;
-  margin: 0 auto;
-  padding: clamp(1.5rem, 5vw, 3rem) 1.25rem;
+  width: min(100%, 72rem);
   display: grid;
   gap: 1.5rem;
 }
@@ -2846,6 +2994,14 @@ video {
   gap: 1rem;
 }
 
+.admin-page-head h1 {
+  margin: 0;
+}
+
+.admin-page-head__action {
+  flex-shrink: 0;
+}
+
 .admin-button {
   display: inline-flex;
   align-items: center;
@@ -2856,10 +3012,21 @@ video {
   color: var(--color-text);
   font-weight: 600;
   text-decoration: none;
+  min-height: 2.75rem;
+}
+
+.admin-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface);
+  overscroll-behavior-inline: contain;
 }
 
 .admin-table {
   width: 100%;
+  min-width: 42rem;
   border-collapse: collapse;
   font-size: 0.9rem;
 }
@@ -2869,6 +3036,7 @@ video {
   text-align: left;
   padding: 0.625rem 0.75rem;
   border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
 }
 
 .admin-table thead th {
@@ -2880,6 +3048,7 @@ video {
   display: flex;
   gap: 0.75rem;
   align-items: center;
+  white-space: nowrap;
 }
 
 .admin-row-actions a {
@@ -2907,6 +3076,10 @@ video {
 }
 
 .admin-form select,
+.admin-form textarea,
+.admin-form input[type="date"],
+.admin-form input[type="email"],
+.admin-form input[type="file"],
 .admin-form input[type="text"],
 .admin-form input[type="number"],
 .admin-form input:not([type]) {
@@ -2915,9 +3088,16 @@ video {
   border-radius: 0.5rem;
   background: var(--color-surface);
   color: var(--color-text);
+  width: 100%;
+  min-width: 0;
+}
+
+.admin-form textarea {
+  resize: vertical;
 }
 
 .admin-form select:focus-visible,
+.admin-form textarea:focus-visible,
 .admin-form input:focus-visible {
   outline: 2px solid var(--color-focus);
   outline-offset: 2px;
@@ -2945,19 +3125,276 @@ video {
   gap: 0.5rem;
 }
 
-.admin-nav {
-  display: flex;
-  gap: 1rem;
-  padding: 1rem clamp(1.25rem, 5vw, 3rem);
+/* Admin dashboard shell refinements */
+.admin-table {
+  border: 0;
+}
+
+.admin-table thead th {
+  background: var(--color-surface-subtle);
+}
+
+.admin-table tbody tr:hover {
+  background: var(--color-surface-subtle);
+}
+
+.admin-table th,
+.admin-table td {
   border-bottom: 1px solid var(--color-border);
 }
 
-.admin-nav a {
+.admin-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+/* Status / boolean badges */
+.admin-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.admin-badge--success {
+  color: var(--color-ui-success);
+  background: color-mix(in srgb, var(--color-ui-success) 12%, transparent);
+}
+
+.admin-badge--muted {
   color: var(--color-text-muted);
-  text-decoration: none;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+}
+
+.admin-badge--error {
+  color: var(--color-ui-error);
+  background: color-mix(in srgb, var(--color-ui-error) 12%, transparent);
+}
+
+/* Row actions */
+.admin-row-actions {
+  gap: 0.75rem;
+}
+
+.admin-row-actions a {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
   font-weight: 500;
 }
 
-.admin-nav a:hover {
+.admin-row-actions a:hover {
+  background: var(--color-accent-soft);
+}
+
+/* Empty state */
+.admin-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--color-text-muted);
+  border: 1px dashed var(--color-border-strong);
+  border-radius: 0.75rem;
+}
+
+/* Form sections in cards */
+.admin-section {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.875rem;
+  background: var(--color-surface);
+}
+
+.admin-section h2 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.admin-form-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding-top: 0.5rem;
+}
+
+.admin-button-secondary {
+  min-height: 2.75rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 0.5rem;
+  background: transparent;
   color: var(--color-text);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-form-actions a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 0.5rem;
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: 600;
+  min-height: 2.75rem;
+}
+
+.admin-form-actions a:hover {
+  background: var(--color-surface-subtle);
+}
+
+/* Media list */
+.admin-media-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.admin-media-item {
+  display: grid;
+  grid-template-columns: 5rem 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface);
+}
+
+.admin-media-preview {
+  width: 5rem;
+  height: 5rem;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  background: var(--color-surface-subtle);
+}
+
+.admin-media-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.admin-media-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.admin-media-meta code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+}
+
+.admin-note {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+/* Form page: back link + card container */
+.admin-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.admin-back-link:hover {
+  color: var(--color-accent);
+}
+
+.admin-form-card {
+  max-width: 36rem;
+  padding: 1.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface-elevated);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.admin-sidebar__link:focus-visible,
+.admin-topbar__view:focus-visible,
+.admin-back-link:focus-visible,
+.admin-button:focus-visible,
+.admin-link-button:focus-visible,
+.admin-form-actions a:focus-visible,
+.admin-button-secondary:focus-visible,
+.admin-table-wrap:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.admin-form-card h2 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.admin-form-card .admin-form {
+  max-width: none;
+}
+
+/* Responsive: collapse sidebar to top bar on small screens */
+@media (max-width: 768px) {
+  .admin-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-sidebar {
+    position: static;
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0.75rem;
+  }
+
+  .admin-sidebar__nav {
+    display: flex;
+    gap: 0.25rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    scrollbar-width: thin;
+  }
+
+  .admin-sidebar__link {
+    min-height: 2.75rem;
+    flex: 0 0 auto;
+  }
+
+  .admin-sidebar .admin-brand {
+    display: none;
+  }
+
+  .admin-content {
+    padding: 1.25rem 1rem;
+  }
+
+  .admin-page-head {
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .admin-sidebar__link,
+  .admin-topbar__view,
+  .admin-button,
+  .admin-form button[type="submit"],
+  .admin-form-actions a {
+    transition: background-color 120ms ease, color 120ms ease;
+  }
 }


### PR DESCRIPTION
Closes #68

## Summary

Presentation-layer upgrade of the admin CMS from minimal forms to a professional full-dashboard experience. No content-model, data/API, RLS, storage, or public-UI changes.

- Dashboard shell: fixed sidebar navigation (`admin-sidebar.tsx`, new) + header; `(dashboard)` layout reworked around it.
- List pages (Projects, Resume, Skills, Social) → consistent data tables with status/published badges and row actions.
- All create/edit form pages → consistent card layouts with labeled sections and save/cancel actions.
- Settings / Media / Profile → card-based layouts matching the new shell; Login page → polished centered card.
- `globals.css`: admin design styles on existing `--color-*` tokens; light/dark preserved.

Branch is 1 commit ahead of `main` (72c5e36); reviewed externally via ChatGPT pre-PR bridge (verdict: approve-with-changes, no code changes required).

## Acceptance criteria

- [x] All existing admin routes render in the new dashboard shell (sidebar + header)
- [x] List pages use consistent data-table layout with status/published indicators and row actions
- [x] Form pages use consistent card layout with clear labels and save/cancel actions
- [x] Login page is a polished centered card
- [x] Light/dark themes and `en`/`vi` locale labels preserved
- [x] Accessibility preserved in code (keyboard nav, focus-visible, semantic headings, reduced-motion)
- [ ] Visual verification screenshots attached (see Screenshots)
- [x] `lint`, `typecheck`, tests, and build pass

## Verification

- `npm run lint` — pass
- `npm run typecheck` (`next typegen && tsc --noEmit`) — pass
- `npm test` — 99/99 pass
- `npm run build -- --webpack` — production build passes (all admin routes compiled)

## Screenshots

No headless browser is available in this sandbox, so local captures were not possible. Use the Vercel preview deployment for this PR to verify visually at mobile/tablet/desktop breakpoints and both themes (admin login at `/en/admin/login`). Code-level responsive/a11y inspection was independently confirmed by the ChatGPT pre-PR review.

## Risks / follow-ups

- Visual confirmation against preview deployment pending before merge (human reviewer).
- Admin-only change; zero impact on public site or CMS backend behavior.
