### PR TITLE
feat: admin sign-out with session revocation (Issue #70)

### DIFF
--- a/src/app/admin/(dashboard)/actions.ts
+++ b/src/app/admin/(dashboard)/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { endOwnerSession } from "@/features/cms/session";
+
+export async function signOut(): Promise<void> {
+  await endOwnerSession();
+  redirect("/admin/login");
+}

--- a/src/app/admin/(dashboard)/layout.tsx
+++ b/src/app/admin/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { isAdminUser } from "@/features/cms/session";
 import { ThemeToggle } from "@/features/theme/theme-toggle";
+import { signOut } from "./actions";
 import { AdminSidebar } from "./admin-sidebar";
 
 const adminThemeMessages = {
@@ -30,6 +31,11 @@ export default async function AdminDashboardLayout({
             <a className="admin-topbar__view" href="/" target="_blank" rel="noreferrer">
               View site <span aria-hidden="true">↗</span>
             </a>
+            <form action={signOut}>
+              <button type="submit" className="admin-topbar__signout">
+                Sign out
+              </button>
+            </form>
           </div>
         </header>
         <div className="admin-content">{children}</div>

--- a/src/features/cms/session.test.ts
+++ b/src/features/cms/session.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Hard local-only guard: this test exercises real auth against Supabase and
+// must never run against a cloud/production project.
+if (!url || !anonKey || !serviceRole) {
+  console.error(
+    "Requires NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY (local Supabase).",
+  );
+  process.exit(1);
+}
+
+const LOCAL_HOST = /^http:\/\/127\.0\.0\.1(?::\d+)?$/;
+if (!LOCAL_HOST.test(url)) {
+  console.error(
+    `Refusing to run session test against non-local Supabase: ${url}\n` +
+      "This test performs real sign-in/sign-out and must only target local Supabase.",
+  );
+  process.exit(1);
+}
+
+import { createClient } from "@supabase/supabase-js";
+import { endOwnerSession } from "@/features/cms/session";
+
+test("endOwnerSession revokes an authenticated session", async () => {
+  const admin = createClient(url, serviceRole, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const email = `session-test-${Date.now()}@local.test`;
+  const password = "session-test-password-1";
+  let userId: string | undefined;
+
+  try {
+    const { data: created, error: createError } =
+      await admin.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+      });
+    assert.equal(createError, null, `createUser: ${createError?.message}`);
+    userId = created.user?.id;
+
+    const anon = createClient(url, anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const { error: signInError } = await anon.auth.signInWithPassword({
+      email,
+      password,
+    });
+    assert.equal(signInError, null, `signInWithPassword: ${signInError?.message}`);
+
+    const {
+      data: { user: before },
+    } = await anon.auth.getUser();
+    assert.ok(before, "session should be valid right after sign-in");
+
+    await endOwnerSession(anon);
+
+    const {
+      data: { user: after },
+    } = await anon.auth.getUser();
+    assert.equal(after, null, "session must be revoked after endOwnerSession");
+  } finally {
+    if (userId) {
+      await admin.auth.admin.deleteUser(userId);
+    }
+  }
+});

--- a/src/features/cms/session.ts
+++ b/src/features/cms/session.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 
 import { cmsConfig, hasCmsConfig } from "./config";
@@ -46,4 +47,11 @@ export async function isAdminUser(): Promise<boolean> {
     .maybeSingle();
 
   return owner !== null;
+}
+
+export async function endOwnerSession(
+  client?: SupabaseClient,
+): Promise<void> {
+  const supabase = client ?? (await getServerClient());
+  await supabase.auth.signOut();
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2794,6 +2794,23 @@ video {
   text-decoration: underline;
 }
 
+.admin-topbar__signout {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.375rem 0.75rem;
+  cursor: pointer;
+}
+
+.admin-topbar__signout:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+
 .admin-content {
   padding: clamp(1.5rem, 4vw, 2.5rem);
 }
@@ -3330,6 +3347,7 @@ video {
 
 .admin-sidebar__link:focus-visible,
 .admin-topbar__view:focus-visible,
+.admin-topbar__signout:focus-visible,
 .admin-back-link:focus-visible,
 .admin-button:focus-visible,
 .admin-link-button:focus-visible,
@@ -3392,6 +3410,7 @@ video {
 @media (prefers-reduced-motion: no-preference) {
   .admin-sidebar__link,
   .admin-topbar__view,
+  .admin-topbar__signout,
   .admin-button,
   .admin-form button[type="submit"],
   .admin-form-actions a {


### PR DESCRIPTION
Closes #70

## Summary

Adds admin sign-out. A new `signOut` server action revokes the Supabase session (`endOwnerSession` in `src/features/cms/session.ts`) and redirects to `/admin/login`. The dashboard topbar gains a "Sign out" button (single placement per owner decision) styled with existing admin tokens.

Post-logout route protection requires no new code: `(dashboard)/layout.tsx` already validates the session server-side on every request (`isAdminUser()` → Supabase `getUser()`) and redirects unauthenticated visitors to `/admin/login`; `src/proxy.ts` intentionally excludes `/admin` from locale handling.

## Acceptance criteria

- [x] Signed-in owner can log out from the dashboard topbar
- [x] After logout, direct navigation to any `/admin/*` route redirects to `/admin/login` (existing server-side guard; verified below)
- [x] Logout revokes the Supabase session — covered by a real integration test (`session.test.ts`): sign-in → `getUser()` valid → `endOwnerSession()` → `getUser()` null
- [x] lint, typecheck, tests, build pass
- [ ] Visual/functional smoke verification on preview deployment

## Verification

- New integration test `src/features/cms/session.test.ts` written TDD-style (watched fail: `endOwnerSession is not a function`, then pass) against **local Supabase** with the same hard local-only guard as `repository.test.ts`; throwaway auth user created and cleaned up via service-role admin API. Run: `npx tsx --env-file=.env.local --test src/features/cms/session.test.ts` → 1/1 pass.
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` — 99/99 pass (the new test follows the `repository.test.ts` convention of local-Supabase-only manual runs, so it stays out of the default glob)
- `npm run build -- --webpack` — pass

## Screenshots

No headless browser in this sandbox; use the Vercel preview deployment: log in at `/en/admin/login`, confirm the "Sign out" button in the topbar (light/dark), sign out, then open `/admin/projects` directly and confirm redirect back to `/admin/login`.

## Risks / follow-ups

- Admin-only change; no public UI, data-model, RLS, or storage changes.
- Sign-out form posts to a server action; no client JS required.
