### PR TITLE
feat: transparent sticky header bar

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -289,6 +289,8 @@ video {
   position: sticky;
   z-index: 50;
   top: 0;
+  backdrop-filter: blur(0.5rem);
+  -webkit-backdrop-filter: blur(0.5rem);
   pointer-events: none;
 }
 
@@ -301,7 +303,6 @@ video {
   gap: var(--space-4);
   padding-block: var(--space-2);
   background: transparent;
-  backdrop-filter: blur(0.5rem);
   pointer-events: auto;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -289,23 +289,19 @@ video {
   position: sticky;
   z-index: 50;
   top: 0;
-  padding-block: var(--space-3);
   pointer-events: none;
 }
 
 .site-header__surface {
   position: relative;
   display: flex;
-  min-height: 3.5rem;
+  min-height: 4rem;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-pill);
-  background: color-mix(in oklch, var(--color-surface) 92%, transparent);
-  box-shadow: var(--shadow-md);
-  backdrop-filter: blur(1rem);
+  padding-block: var(--space-2);
+  background: transparent;
+  backdrop-filter: blur(0.5rem);
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary
- Restyle site header from floating pill (border + 92% surface + shadow + 1rem blur) to a full-width transparent sticky bar: no border/background/shadow, min-height 4rem, backdrop-filter blur(0.5rem) — matching the mdrakibali.me reference pattern (sticky top-0, transparent, light blur).
- Mobile dropdown keeps its own elevated surface, so menu readability is unchanged.

## Tests run
- npm run lint ✓
- npm run typecheck ✓
- npm test — 99 pass / 0 fail ✓
- npm run build -- --webpack ✓

## Visual verification
- Owner to smoke-check over hero at top-of-page and after scroll, light+dark, mobile+desktop.

## Known limitations
- None known; active-section highlight and focus states untouched.

## Docs affected
- None.