### PR TITLE
feat: contact card with social icon row

### DIFF
--- a/src/components/sections/contact/contact-section.tsx
+++ b/src/components/sections/contact/contact-section.tsx
@@ -54,24 +54,34 @@ export function ContactSection({ content }: Readonly<ContactSectionProps>) {
                 </ul>
 
                 <ul aria-label={content.detailsLabel} className="contact-socials">
-                  {content.socials.map((social) => (
-                    <li key={social.id}>
-                      <a
-                        aria-label={social.label}
-                        className="contact-socials__link"
-                        href={social.href}
-                        rel="noopener noreferrer"
-                        target={
-                          social.href.startsWith("https://")
-                            ? "_blank"
-                            : undefined
-                        }
-                        title={social.label}
-                      >
-                        <SocialGlyphIcon platform={social.id} />
-                      </a>
-                    </li>
-                  ))}
+                  {content.socials.map((social) => {
+                    const isConfigured = social.href.startsWith("https://");
+
+                    return (
+                      <li key={social.id}>
+                        {isConfigured ? (
+                          <a
+                            aria-label={social.label}
+                            className="contact-socials__link"
+                            href={social.href}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            title={social.label}
+                          >
+                            <SocialGlyphIcon platform={social.id} />
+                          </a>
+                        ) : (
+                          <span
+                            aria-disabled="true"
+                            className="contact-socials__link contact-socials__link--pending"
+                            title={social.label}
+                          >
+                            <SocialGlyphIcon platform={social.id} />
+                          </span>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             </aside>

--- a/src/components/sections/contact/contact-section.tsx
+++ b/src/components/sections/contact/contact-section.tsx
@@ -3,6 +3,7 @@ import { SectionHeading } from "@/components/ui/section-heading";
 import type { ContactContentView } from "@/content/contact";
 
 import { ContactForm } from "./contact-form";
+import { SocialGlyphIcon } from "./social-glyph-icon";
 
 interface ContactSectionProps {
   content: ContactContentView;
@@ -25,34 +26,59 @@ export function ContactSection({ content }: Readonly<ContactSectionProps>) {
           />
         </div>
 
-        <div className="contact-layout">
-          <aside className="contact-info" aria-label={content.detailsLabel}>
-            <div className="contact-info__card">
-              <h3 className="contact-info__heading">{content.detailsLabel}</h3>
-              <ul className="contact-info__list">
-                {content.details.map((detail) => (
-                  <li key={detail.id}>
-                    <a
-                      className="contact-info__link"
-                      href={detail.href}
-                      rel="noopener noreferrer"
-                      target={detail.href ? "_blank" : undefined}
-                    >
-                      <span className="contact-info__label">
-                        {detail.label}
-                      </span>
-                      <span className="contact-info__value">
-                        {detail.value}
-                      </span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </aside>
+        <div className="contact-card">
+          <div className="contact-layout">
+            <aside className="contact-info" aria-label={content.detailsLabel}>
+              <div className="contact-info__card">
+                <h3 className="contact-info__heading">
+                  {content.detailsLabel}
+                </h3>
+                <ul className="contact-info__list">
+                  {content.details.map((detail) => (
+                    <li key={detail.id}>
+                      <a
+                        className="contact-info__link"
+                        href={detail.href}
+                        rel="noopener noreferrer"
+                        target={detail.href ? "_blank" : undefined}
+                      >
+                        <span className="contact-info__label">
+                          {detail.label}
+                        </span>
+                        <span className="contact-info__value">
+                          {detail.value}
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
 
-          <div className="contact-panel">
-            <ContactForm content={content} />
+                <ul aria-label={content.detailsLabel} className="contact-socials">
+                  {content.socials.map((social) => (
+                    <li key={social.id}>
+                      <a
+                        aria-label={social.label}
+                        className="contact-socials__link"
+                        href={social.href}
+                        rel="noopener noreferrer"
+                        target={
+                          social.href.startsWith("https://")
+                            ? "_blank"
+                            : undefined
+                        }
+                        title={social.label}
+                      >
+                        <SocialGlyphIcon platform={social.id} />
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </aside>
+
+            <div className="contact-panel">
+              <ContactForm content={content} />
+            </div>
           </div>
         </div>
       </Container>

--- a/src/components/sections/contact/social-glyph-icon.tsx
+++ b/src/components/sections/contact/social-glyph-icon.tsx
@@ -1,0 +1,43 @@
+import type { SocialPlatform } from "@/content/contact";
+
+import { socialGlyphs } from "./social-glyphs";
+
+interface SocialGlyphIconProps {
+  platform: SocialPlatform;
+}
+
+export function SocialGlyphIcon({ platform }: Readonly<SocialGlyphIconProps>) {
+  const glyph = socialGlyphs[platform];
+
+  if (glyph.kind === "fill") {
+    return (
+      <svg
+        aria-hidden="true"
+        className="contact-socials__icon"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path d={glyph.path} />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="contact-socials__icon"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      {glyph.shapes.map((shape, index) => {
+        const Tag = shape.tag;
+
+        return <Tag key={index} {...shape.attrs} />;
+      })}
+    </svg>
+  );
+}

--- a/src/components/sections/contact/social-glyphs.ts
+++ b/src/components/sections/contact/social-glyphs.ts
@@ -1,0 +1,74 @@
+import type { SocialPlatform } from "@/content/contact";
+
+interface StrokeShape {
+  readonly tag: "path" | "rect" | "circle" | "line";
+  readonly attrs: Readonly<Record<string, string>>;
+}
+
+type SocialGlyph =
+  | { readonly kind: "stroke"; readonly shapes: ReadonlyArray<StrokeShape> }
+  | { readonly kind: "fill"; readonly path: string };
+
+/**
+ * Lucide glyphs (ISC license) matching the mdrakibali.me reference, plus the
+ * official X mark (Simple Icons, CC0) rendered filled.
+ */
+export const socialGlyphs: Readonly<Record<SocialPlatform, SocialGlyph>> = {
+  facebook: {
+    kind: "stroke",
+    shapes: [
+      {
+        attrs: {
+          d: "M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z",
+        },
+        tag: "path",
+      },
+    ],
+  },
+  github: {
+    kind: "stroke",
+    shapes: [
+      {
+        attrs: {
+          d: "M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4",
+        },
+        tag: "path",
+      },
+      { attrs: { d: "M9 18c-4.51 2-5-2-7-2" }, tag: "path" },
+    ],
+  },
+  instagram: {
+    kind: "stroke",
+    shapes: [
+      {
+        attrs: { height: "20", rx: "5", ry: "5", width: "20", x: "2", y: "2" },
+        tag: "rect",
+      },
+      {
+        attrs: {
+          d: "M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z",
+        },
+        tag: "path",
+      },
+      { attrs: { x1: "17.5", x2: "17.51", y1: "6.5", y2: "6.5" }, tag: "line" },
+    ],
+  },
+  linkedin: {
+    kind: "stroke",
+    shapes: [
+      {
+        attrs: {
+          d: "M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z",
+        },
+        tag: "path",
+      },
+      { attrs: { height: "12", width: "4", x: "2", y: "9" }, tag: "rect" },
+      { attrs: { cx: "4", cy: "4", r: "2" }, tag: "circle" },
+    ],
+  },
+  x: {
+    kind: "fill",
+    path:
+      "M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z",
+  },
+};

--- a/src/content/contact.ts
+++ b/src/content/contact.ts
@@ -4,6 +4,19 @@ type LocalizedText = Readonly<Record<Locale, string>>;
 
 export type ContactFieldName = "name" | "email" | "subject" | "message";
 
+export type SocialPlatform =
+  | "facebook"
+  | "github"
+  | "instagram"
+  | "linkedin"
+  | "x";
+
+export interface SocialLinkView {
+  id: SocialPlatform;
+  label: string;
+  href: string;
+}
+
 export interface ContactDetailView {
   id: string;
   label: string;
@@ -17,6 +30,7 @@ export interface ContactContentView {
   description: string;
   detailsLabel: string;
   details: ReadonlyArray<ContactDetailView>;
+  socials: ReadonlyArray<SocialLinkView>;
   form: {
     name: string;
     namePlaceholder: string;
@@ -52,6 +66,38 @@ export const contactDetails = {
     href: "https://github.com/Akbi47",
   },
 } as const;
+
+const socialDefaults: ReadonlyArray<{
+  href: string;
+  id: SocialPlatform;
+  label: LocalizedText;
+}> = [
+  {
+    id: "linkedin",
+    label: { en: "LinkedIn", vi: "LinkedIn" },
+    href: "#",
+  },
+  {
+    id: "instagram",
+    label: { en: "Instagram", vi: "Instagram" },
+    href: "#",
+  },
+  {
+    id: "facebook",
+    label: { en: "Facebook", vi: "Facebook" },
+    href: "#",
+  },
+  {
+    id: "github",
+    label: { en: "GitHub", vi: "GitHub" },
+    href: contactDetails.github.href,
+  },
+  {
+    id: "x",
+    label: { en: "X", vi: "X" },
+    href: "#",
+  },
+];
 
 const contactCopy = {
   eyebrow: {
@@ -148,6 +194,11 @@ export function getContactContent(locale: Locale): ContactContentView {
       label: localized(detail.label),
       value: localized(detail.value),
       href: detail.href,
+    })),
+    socials: socialDefaults.map((social) => ({
+      id: social.id,
+      label: localized(social.label),
+      href: social.href,
     })),
     form: {
       name: localized(contactCopy.form.name),

--- a/src/features/cms/repository.ts
+++ b/src/features/cms/repository.ts
@@ -218,6 +218,13 @@ export async function getContactContent(
     if (error || !data) return base;
 
     const rows = data as SocialRow[];
+    const platformSet = new Set<string>([
+      "facebook",
+      "github",
+      "instagram",
+      "linkedin",
+      "x",
+    ]);
 
     return {
       ...base,
@@ -227,6 +234,16 @@ export async function getContactContent(
         value: row.label,
         href: row.url,
       })),
+      socials: rows
+        .filter(
+          (row) =>
+            row.icon_key !== null && platformSet.has(row.icon_key),
+        )
+        .map((row) => ({
+          id: row.icon_key as ContactContentView["socials"][number]["id"],
+          label: row.label,
+          href: row.url,
+        })),
     };
   } catch {
     return base;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1817,6 +1817,10 @@ video {
   color: var(--color-accent);
 }
 
+.contact-socials__link--pending {
+  opacity: 0.55;
+}
+
 .contact-socials__icon {
   width: 1.5rem;
   height: 1.5rem;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1765,20 +1765,22 @@ video {
   gap: var(--space-8);
 }
 
+.contact-card {
+  margin-block-start: var(--space-10);
+  padding: var(--space-6);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--color-surface);
+}
+
 .contact-layout {
   display: grid;
   gap: var(--space-6);
-  margin-block-start: var(--space-10);
 }
 
 .contact-info__card {
   display: grid;
   gap: var(--space-5);
-  padding: var(--space-6);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-xl);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-md);
 }
 
 .contact-info__heading {
@@ -1792,6 +1794,32 @@ video {
   padding: 0;
   gap: var(--space-3);
   list-style: none;
+}
+
+.contact-socials {
+  display: flex;
+  justify-content: center;
+  margin: 0;
+  padding: var(--space-4) 0 0;
+  border-block-start: 1px solid var(--color-border);
+  gap: var(--space-5);
+  list-style: none;
+}
+
+.contact-socials__link {
+  display: inline-flex;
+  color: var(--color-text-muted);
+  transition:
+    color var(--motion-duration-base) var(--motion-ease-standard);
+}
+
+.contact-socials__link:hover {
+  color: var(--color-accent);
+}
+
+.contact-socials__icon {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .contact-info__link {


### PR DESCRIPTION
## Summary
- Contact section now renders as one even, bordered card (mdrakibali.me/#contact pattern): outer .contact-card (1px border, radius-xl, surface bg) containing the two-column layout; inner info box de-duplicated (border/shadow removed) to avoid double-boxing.
- New social row under contact details: LinkedIn, Instagram, Facebook, GitHub, X — lucide-style stroke glyphs (ISC, fetched from lucide-static 0.525.0) matching the reference site, plus official X mark (Simple Icons CC0, filled); monochrome currentColor, muted → accent hover, 24px.
- Content layer: SocialPlatform/SocialLinkView types + socials view field; local fallback list (GitHub real, others "#" pending owner URLs); CMS adapter maps social_links rows with icon_key in {facebook,github,instagram,linkedin,x} into socials when configured.

## Tests run
- npm run lint ✓ · npm run typecheck ✓ · npm test 99/99 ✓ · npm run build -- --webpack ✓

## Visual verification
- Owner to smoke-check light/dark both locales; keyboard focus visible on social links.

## Known limitations
- Non-GitHub social hrefs are placeholders until owner supplies real profile URLs (editable via /admin/social or content fallback).

## Docs affected
- None.