### PR TITLE
feat: header scroll glass and mdrakibali-style contact card

### DIFF
--- a/src/components/navigation/site-header.tsx
+++ b/src/components/navigation/site-header.tsx
@@ -37,6 +37,7 @@ export function SiteHeader({
   const [activeSection, setActiveSection] =
     useState<NavigationSectionId>("home");
   const [menuOpen, setMenuOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
   const headerRef = useRef<HTMLElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const navigationRef = useRef<HTMLDivElement>(null);
@@ -68,6 +69,17 @@ export function SiteHeader({
       window.removeEventListener("resize", updateActiveSection);
       window.removeEventListener("scroll", updateActiveSection);
     };
+  }, []);
+
+  useEffect(() => {
+    function updateScrolled() {
+      setScrolled(window.scrollY > 16);
+    }
+
+    updateScrolled();
+    window.addEventListener("scroll", updateScrolled, { passive: true });
+
+    return () => window.removeEventListener("scroll", updateScrolled);
   }, []);
 
   useEffect(() => {
@@ -238,7 +250,11 @@ export function SiteHeader({
   }
 
   return (
-    <header className="site-header" ref={headerRef}>
+    <header
+      className="site-header"
+      data-scrolled={scrolled ? "true" : "false"}
+      ref={headerRef}
+    >
       <div className="container-shell" data-size="wide">
         <div className="site-header__surface">
           <a

--- a/src/components/sections/contact/contact-form.tsx
+++ b/src/components/sections/contact/contact-form.tsx
@@ -16,6 +16,7 @@ const FIELD_ORDER: ContactFieldName[] = ["name", "email", "subject", "message"];
 
 interface ContactFormProps {
   content: ContactContentView;
+  labelledById?: string;
 }
 
 const initialState = { status: "idle" } as const;
@@ -34,7 +35,10 @@ function SubmitButton({ content }: Readonly<{ content: ContactContentView }>) {
   );
 }
 
-export function ContactForm({ content }: Readonly<ContactFormProps>) {
+export function ContactForm({
+  content,
+  labelledById,
+}: Readonly<ContactFormProps>) {
   const [state, formAction] = useActionState(
     submitContactForm,
     initialState,
@@ -105,7 +109,7 @@ export function ContactForm({ content }: Readonly<ContactFormProps>) {
   return (
     <form
       action={formAction}
-      aria-label={content.aria.formLabel}
+      aria-labelledby={labelledById}
       className="contact-form"
       noValidate
       onSubmit={handleSubmit}

--- a/src/components/sections/contact/contact-section.tsx
+++ b/src/components/sections/contact/contact-section.tsx
@@ -1,6 +1,9 @@
 import { Container } from "@/components/layout/container";
 import { SectionHeading } from "@/components/ui/section-heading";
-import type { ContactContentView } from "@/content/contact";
+import type {
+  ContactContentView,
+  SocialPlatform,
+} from "@/content/contact";
 
 import { ContactForm } from "./contact-form";
 import { SocialGlyphIcon } from "./social-glyph-icon";
@@ -9,7 +12,52 @@ interface ContactSectionProps {
   content: ContactContentView;
 }
 
+interface LinkGlyphProps {
+  className?: string;
+}
+
+function DetailLinkGlyph({ className }: Readonly<LinkGlyphProps>) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+const socialPlatformSet = new Set<string>([
+  "facebook",
+  "github",
+  "instagram",
+  "linkedin",
+  "x",
+]);
+
+function DetailIcon({
+  className,
+  id,
+}: Readonly<{ className?: string; id: string }>) {
+  return socialPlatformSet.has(id) ? (
+    <SocialGlyphIcon platform={id as SocialPlatform} />
+  ) : (
+    <DetailLinkGlyph className={className} />
+  );
+}
+
 export function ContactSection({ content }: Readonly<ContactSectionProps>) {
+  const nonSocialDetails = content.details.filter(
+    (detail) => !socialPlatformSet.has(detail.id),
+  );
+
   return (
     <section
       aria-labelledby="contact-title"
@@ -19,6 +67,7 @@ export function ContactSection({ content }: Readonly<ContactSectionProps>) {
       <Container>
         <div className="contact-section__intro">
           <SectionHeading
+            align="center"
             description={content.description}
             eyebrow={content.eyebrow}
             title={content.title}
@@ -28,66 +77,95 @@ export function ContactSection({ content }: Readonly<ContactSectionProps>) {
 
         <div className="contact-card">
           <div className="contact-layout">
-            <aside className="contact-info" aria-label={content.detailsLabel}>
-              <div className="contact-info__card">
-                <h3 className="contact-info__heading">
-                  {content.detailsLabel}
-                </h3>
-                <ul className="contact-info__list">
-                  {content.details.map((detail) => (
-                    <li key={detail.id}>
-                      <a
-                        className="contact-info__link"
-                        href={detail.href}
-                        rel="noopener noreferrer"
-                        target={detail.href ? "_blank" : undefined}
-                      >
-                        <span className="contact-info__label">
-                          {detail.label}
+            <div className="contact-info">
+              {nonSocialDetails.length > 0 ? (
+                <>
+                  <h3
+                    className="contact-heading"
+                    id="contact-details-title"
+                  >
+                    {content.detailsHeading}
+                  </h3>
+                  <ul
+                    className="contact-info__list"
+                    aria-labelledby="contact-details-title"
+                  >
+                    {nonSocialDetails.map((detail) => (
+                      <li className="contact-detail" key={detail.id}>
+                        <span className="contact-detail__chip">
+                          <DetailIcon
+                            className="contact-detail__icon"
+                            id={detail.id}
+                          />
                         </span>
-                        <span className="contact-info__value">
-                          {detail.value}
-                        </span>
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-
-                <ul aria-label={content.detailsLabel} className="contact-socials">
-                  {content.socials.map((social) => {
-                    const isConfigured = social.href.startsWith("https://");
-
-                    return (
-                      <li key={social.id}>
-                        {isConfigured ? (
-                          <a
-                            aria-label={social.label}
-                            className="contact-socials__link"
-                            href={social.href}
-                            rel="noopener noreferrer"
-                            target="_blank"
-                            title={social.label}
-                          >
-                            <SocialGlyphIcon platform={social.id} />
-                          </a>
-                        ) : (
-                          <span
-                            aria-disabled="true"
-                            className="contact-socials__link contact-socials__link--pending"
-                            title={social.label}
-                          >
-                            <SocialGlyphIcon platform={social.id} />
+                        <span className="contact-detail__text">
+                          <span className="contact-info__label">
+                            {detail.label}
                           </span>
-                        )}
+                          {detail.href ? (
+                            <a
+                              className="contact-detail__value"
+                              href={detail.href}
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              {detail.value}
+                            </a>
+                          ) : (
+                            <span className="contact-detail__value">
+                              {detail.value}
+                            </span>
+                          )}
+                        </span>
                       </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            </aside>
+                    ))}
+                  </ul>
+                </>
+              ) : null}
+
+              <h4 className="contact-heading" id="contact-socials-title">
+                {content.detailsLabel}
+              </h4>
+              <ul
+                aria-labelledby="contact-socials-title"
+                className="contact-socials"
+              >
+                {content.socials.map((social) => {
+                  const isConfigured = social.href.startsWith("https://");
+
+                  return (
+                    <li key={social.id}>
+                      {isConfigured ? (
+                        <a
+                          aria-label={social.label}
+                          className="contact-socials__link"
+                          href={social.href}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                          title={social.label}
+                        >
+                          <SocialGlyphIcon platform={social.id} />
+                        </a>
+                      ) : (
+                        <span
+                          aria-disabled="true"
+                          className="contact-socials__link contact-socials__link--pending"
+                          title={social.label}
+                        >
+                          <SocialGlyphIcon platform={social.id} />
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
 
             <div className="contact-panel">
-              <ContactForm content={content} />
+              <h3 className="contact-heading" id="contact-form-title">
+                {content.formHeading}
+              </h3>
+              <ContactForm content={content} labelledById="contact-form-title" />
             </div>
           </div>
         </div>

--- a/src/content/contact.ts
+++ b/src/content/contact.ts
@@ -29,6 +29,8 @@ export interface ContactContentView {
   title: string;
   description: string;
   detailsLabel: string;
+  detailsHeading: string;
+  formHeading: string;
   details: ReadonlyArray<ContactDetailView>;
   socials: ReadonlyArray<SocialLinkView>;
   form: {
@@ -116,6 +118,14 @@ const contactCopy = {
     en: "Find me on",
     vi: "Kết nối với mình",
   },
+  detailsHeading: {
+    en: "Contact details",
+    vi: "Thông tin liên hệ",
+  },
+  formHeading: {
+    en: "Send me a message",
+    vi: "Gửi tin nhắn cho mình",
+  },
   form: {
     name: { en: "Name", vi: "Họ tên" },
     namePlaceholder: { en: "Your name", vi: "Tên của bạn" },
@@ -189,6 +199,8 @@ export function getContactContent(locale: Locale): ContactContentView {
     title: localized(contactCopy.title),
     description: localized(contactCopy.description),
     detailsLabel: localized(contactCopy.detailsLabel),
+    detailsHeading: localized(contactCopy.detailsHeading),
+    formHeading: localized(contactCopy.formHeading),
     details: Object.values(contactDetails).map((detail) => ({
       id: detail.id,
       label: localized(detail.label),

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -51,6 +51,7 @@
   --color-accent: var(--palette-gold-600);
   --color-accent-hover: oklch(58% 0.14 78);
   --color-accent-soft: oklch(95% 0.055 85);
+  --color-on-accent: var(--palette-neutral-950);
   --color-success: var(--palette-green-600);
   --color-error: var(--palette-red-600);
   --color-focus: var(--palette-gold-500);
@@ -129,6 +130,7 @@
   --color-accent: var(--palette-gold-400);
   --color-accent-hover: oklch(88% 0.12 86);
   --color-accent-soft: oklch(28% 0.07 84);
+  --color-on-accent: var(--palette-neutral-950);
   --color-success: oklch(72% 0.14 155);
   --color-error: oklch(72% 0.17 25);
   --color-focus: var(--palette-gold-400);
@@ -289,9 +291,16 @@ video {
   position: sticky;
   z-index: 50;
   top: 0;
+  background: transparent;
   backdrop-filter: blur(0.5rem);
   -webkit-backdrop-filter: blur(0.5rem);
+  transition: background-color var(--motion-duration-slow, 0.3s)
+    var(--motion-ease-standard);
   pointer-events: none;
+}
+
+.site-header[data-scrolled="true"] {
+  background: color-mix(in oklch, var(--color-surface) 76%, transparent);
 }
 
 .site-header__surface {
@@ -1766,6 +1775,8 @@ video {
 }
 
 .contact-card {
+  max-width: 64rem;
+  margin-inline: auto;
   margin-block-start: var(--space-10);
   padding: var(--space-6);
   border: 1px solid var(--color-border);
@@ -1775,17 +1786,74 @@ video {
 
 .contact-layout {
   display: grid;
+  gap: var(--space-8);
+}
+
+.contact-info {
+  display: grid;
+  align-content: start;
+  gap: var(--space-5);
+}
+
+.contact-heading {
+  display: flex;
+  align-items: center;
+  margin: 0;
+  gap: var(--space-2);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.contact-heading::before {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 100%;
+  background: var(--color-accent);
+  content: "";
+}
+
+.contact-detail {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.contact-detail__chip {
+  display: grid;
+  flex: none;
+  place-items: center;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  color: var(--color-accent);
+}
+
+.contact-detail__icon,
+.contact-detail__chip svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.contact-detail__text {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-1);
+}
+
+.contact-detail__value {
+  color: var(--color-text);
+  font-weight: var(--font-weight-semibold);
+}
+
+
+.contact-layout {
+  display: grid;
   gap: var(--space-6);
 }
 
 .contact-info__card {
   display: grid;
   gap: var(--space-5);
-}
-
-.contact-info__heading {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
 }
 
 .contact-info__list {
@@ -1858,11 +1926,9 @@ video {
 }
 
 .contact-panel {
-  padding: var(--space-6);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-xl);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-md);
+  display: grid;
+  align-content: start;
+  gap: var(--space-5);
 }
 
 .contact-form {
@@ -1889,14 +1955,14 @@ video {
 .contact-form__field textarea {
   width: 100%;
   padding: var(--space-3) var(--space-4);
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface);
   color: var(--color-text);
   font: inherit;
   transition:
     border-color var(--motion-duration-fast) var(--motion-ease-standard),
-    background-color var(--motion-duration-fast) var(--motion-ease-standard);
+    box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .contact-form__field input:hover,
@@ -1906,7 +1972,9 @@ video {
 
 .contact-form__field input:focus-visible,
 .contact-form__field textarea:focus-visible {
-  border-color: var(--color-focus);
+  border-color: var(--color-accent-hover);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+  outline: none;
 }
 
 .contact-form__field input[aria-invalid="true"],
@@ -1945,28 +2013,27 @@ video {
 
 .contact-form__submit {
   display: inline-flex;
+  width: 100%;
   min-height: 3.25rem;
   align-items: center;
   justify-content: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-6);
-  border: 1px solid var(--color-accent);
-  border-radius: var(--radius-pill);
+  border: 0;
+  border-radius: var(--radius-lg);
   background: var(--color-accent);
-  color: var(--color-text-inverse);
+  color: var(--color-on-accent);
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-md);
   transition:
-    background-color var(--motion-duration-fast) var(--motion-ease-standard),
-    border-color var(--motion-duration-fast) var(--motion-ease-standard),
-    transform var(--motion-duration-fast) var(--motion-ease-standard);
+    opacity var(--motion-duration-fast) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
 }
 
 .contact-form__submit:hover:not(:disabled) {
-  border-color: var(--color-accent-hover);
-  background: var(--color-accent-hover);
-  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
+  opacity: 0.92;
 }
 
 .contact-form__submit:disabled {
@@ -1999,18 +2066,13 @@ video {
 
 @media (min-width: 64rem) {
   .contact-layout {
-    grid-template-columns: minmax(16rem, 22rem) minmax(0, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: start;
-    gap: var(--space-8);
-  }
-
-  .contact-info__card {
-    position: sticky;
-    top: calc(var(--header-scroll-offset) + var(--space-3));
+    gap: var(--space-10);
   }
 
   .contact-panel {
-    padding: var(--space-8);
+    padding-block-start: var(--space-2);
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1786,7 +1786,7 @@ video {
 
 .contact-layout {
   display: grid;
-  gap: var(--space-8);
+  gap: var(--space-6);
 }
 
 .contact-info {
@@ -1802,6 +1802,7 @@ video {
   gap: var(--space-2);
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-heading);
 }
 
 .contact-heading::before {
@@ -1848,12 +1849,7 @@ video {
 
 .contact-layout {
   display: grid;
-  gap: var(--space-6);
-}
-
-.contact-info__card {
-  display: grid;
-  gap: var(--space-5);
+  gap: var(--space-8);
 }
 
 .contact-info__list {
@@ -2068,7 +2064,7 @@ video {
   .contact-layout {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: start;
-    gap: var(--space-10);
+    gap: var(--space-12);
   }
 
   .contact-panel {


### PR DESCRIPTION
## Summary
Implements the ChatGPT-consulted design (proceed-with-changes consensus on this branch thread):

Header (A)
- data-scrolled attr toggled at scrollY>16 via passive listener; scrolled state adds 76% surface glass tint over the existing blur; no border (per review).

Contact rebuild (B) — faithful to mdrakibali.me/#contact spec
- Centered section heading (SectionHeading align=center).
- Single even card: max-width 64rem centered, radius-xl, 1px border, two equal columns ≥64rem with 3rem gap.
- Left column: accent-dot headings; contact-detail rows (icon chip + muted label + semibold value) rendered ONLY from real non-social CMS rows — GitHub duplication removed, empty heading hidden when no rows (per review); divider + visible 'Find me on' h4 + social row from PR #75.
- aria-labelledby to visible h3/h4 ids for aside regions and form (replaces duplicated aria-labels); DOM order left → socials → form.
- Right column: form kept (server action, honeypot, validation); inputs get reference styling (1px border, focus ring accent-soft + darker gold border); submit is full-width accent button using NEW --color-on-accent token (near-black text on gold ≈9.8:1, replacing white ≈2.15:1), radius-lg, shadow, hover opacity.
- New i18n copy keys: detailsHeading, formHeading (en/vi).

## Tests run
- npm run lint ✓ · npm run typecheck ✓ · npm test 99/99 ✓ · npm run build -- --webpack ✓

## Known limitations
- Contact-detail rows appear once owner adds real email/phone/location via CMS.

## Docs affected
- None.