### PR TITLE
fix: center find-me-on heading below socials divider

### DIFF
--- a/src/components/sections/contact/contact-section.tsx
+++ b/src/components/sections/contact/contact-section.tsx
@@ -72,7 +72,10 @@ export function ContactSection({ content }: Readonly<ContactSectionProps>) {
                 </>
               ) : null}
 
-              <h4 className="contact-heading" id="contact-socials-title">
+              <h4
+                className="contact-heading contact-heading--socials"
+                id="contact-socials-title"
+              >
                 {content.detailsLabel}
               </h4>
               <ul

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1853,6 +1853,18 @@ video {
   content: "";
 }
 
+.contact-heading--socials {
+  justify-content: center;
+  padding-top: var(--space-4);
+  border-block-start: 1px solid var(--color-border);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+}
+
+.contact-heading--socials::before {
+  content: none;
+}
+
 .contact-detail {
   display: flex;
   align-items: center;
@@ -1904,8 +1916,7 @@ video {
   display: flex;
   justify-content: center;
   margin: 0;
-  padding: var(--space-4) 0 0;
-  border-block-start: 1px solid var(--color-border);
+  padding: var(--space-3) 0 0;
   gap: var(--space-5);
   list-style: none;
 }


### PR DESCRIPTION
## Summary
Owner-requested contact polish (reference screenshot provided):
- "Find me on" heading (`h4#contact-socials-title`): accent-dot bullet removed, font reduced one step (`--font-size-lg` → `--font-size-base`, bold → semibold), centered like the icon row.
- Divider moved: `border-block-start` now sits **above** the heading instead of above the icons row — order is line → centered heading → centered socials, matching the reference.
- `.contact-socials` keeps its centered flex layout; top padding trimmed to `--space-3`.

No markup/semantics change beyond an added modifier class; `aria-labelledby` wiring untouched. Both themes use the same tokens.

## Tests run
- npm run lint ✓ · npm run typecheck ✓ · npm test 104/104 ✓ · npm run build -- --webpack ✓

## Visual verification
- Local browser unavailable in sandbox (missing system libs); owner to smoke-check the Vercel preview: light/dark, en/vi, mobile/desktop.

## Known limitations
- None.

## Docs affected
- None.