### PR TITLE
feat: stable skill taxonomy keys for CMS grouping

### DIFF
--- a/scripts/sync-skills-content.sql
+++ b/scripts/sync-skills-content.sql
@@ -251,4 +251,24 @@ insert into skill_translations (skill_id, locale, name, category) values
   ('repository-aware-development', 'en', 'Repository-aware Development', 'AI Development Capabilities'),
   ('repository-aware-development', 'vi', 'Phát triển gắn với repository', 'Năng lực phát triển AI');
 
+-- Stable taxonomy keys on the base rows (mirrors migration
+-- 20260823090000_skill_category_keys.sql; labels stay code-owned).
+update skills s
+set category_key = case t.category
+  when 'Architecture' then 'architecture'
+  when 'DevOps & Infrastructure' then 'devops-infrastructure'
+  when 'Frontend & UX' then 'frontend-ux'
+  when 'SEO & Growth' then 'seo-growth'
+  when 'Workflow & Collaboration' then 'workflow-collaboration'
+  when 'Product & Creative' then 'product-creative'
+  when 'AI Models & Assistants' then 'ai-models-assistants'
+  when 'Agentic Coding & Harness' then 'agentic-coding-harness'
+  when 'AI Development Capabilities' then 'ai-development-capabilities'
+  else null
+end
+from skill_translations t
+where t.skill_id = s.id
+  and t.locale = 'en'
+  and s.group_key = 'others';
+
 commit;

--- a/src/content/skills.test.ts
+++ b/src/content/skills.test.ts
@@ -4,7 +4,13 @@ import { test } from "node:test";
 import { skillIcons } from "@/components/sections/skills/skill-icons";
 import type { Locale } from "@/features/i18n/config";
 
-import { getSkillsContent } from "./skills";
+import {
+  foldOtherCategories,
+  getSkillsContent,
+  otherCategoryKeys,
+  otherGroupDefinitions,
+  otherTaxonomy,
+} from "./skills";
 
 const locales: Locale[] = ["en", "vi"];
 
@@ -221,6 +227,130 @@ test("agentic AI group is featured with three sub-sections and exact skills", ()
           approvedAgenticSections[index].skills,
         );
       });
+    }
+  }
+});
+
+test("fold matches by stable category_key first", () => {
+  const entries = [
+    {
+      id: "k8s",
+      name: "Kubernetes",
+      categoryKey: "devops-infrastructure",
+      categoryEn: null,
+    },
+    {
+      id: "n8n",
+      name: "n8n",
+      categoryKey: "agentic-coding-harness",
+      categoryEn: null,
+    },
+  ];
+
+  for (const locale of locales) {
+    const cards = foldOtherCategories(entries, locale);
+    const devops = cards.find((card) => card.id === "devops-infrastructure");
+    assert.ok(devops, "key-only entry lands in its group");
+    assert.ok(devops.skills.some((skill) => skill.id === "k8s"));
+
+    const agentic = cards.find((card) => card.id === "agentic-ai-development");
+    assert.ok(agentic, "agentic group renders when only sections match");
+    const harness = agentic.sections?.find(
+      (section) => section.id === "agentic-coding-harness",
+    );
+    assert.ok(harness);
+    assert.ok(harness.skills.some((skill) => skill.id === "n8n"));
+  }
+});
+
+test("fold keeps legacy English-title matching as a compatibility path", () => {
+  const entries = [
+    { id: "rest-api", name: "REST API", categoryEn: "Architecture" },
+    {
+      id: "chatgpt",
+      name: "ChatGPT",
+      categoryEn: "AI Models & Assistants",
+    },
+  ];
+
+  for (const locale of locales) {
+    const cards = foldOtherCategories(entries, locale);
+    const architecture = cards.find((card) => card.id === "architecture");
+    assert.ok(architecture?.skills.some((skill) => skill.id === "rest-api"));
+    const agentic = cards.find((card) => card.id === "agentic-ai-development");
+    const models = agentic?.sections?.find(
+      (section) => section.id === "ai-models-assistants",
+    );
+    assert.ok(models?.skills.some((skill) => skill.id === "chatgpt"));
+  }
+});
+
+test("unknown categories become distinct fallback cards; missing assignment is skipped", () => {
+  const entries = [
+    {
+      id: "mystery",
+      name: "Mystery Skill",
+      categoryKey: "not-a-real-key",
+      categoryEn: null,
+      categoryDisplay: "Mystery",
+    },
+    {
+      id: "legacy-typo",
+      name: "Legacy Typo",
+      categoryEn: "Architecure typo",
+    },
+    { id: "orphan", name: "Orphan", categoryEn: null },
+  ];
+
+  for (const locale of locales) {
+    const cards = foldOtherCategories(entries, locale);
+    const knownIds = new Set([
+      "architecture",
+      "devops-infrastructure",
+      "frontend-ux",
+      "seo-growth",
+      "workflow-collaboration",
+      "product-creative",
+      "agentic-ai-development",
+    ]);
+    for (const card of cards) {
+      if (knownIds.has(card.id)) continue;
+      assert.ok(
+        card.skills.some((skill) =>
+          ["mystery", "legacy-typo"].includes(skill.id),
+        ),
+        `unexpected card ${card.id}`,
+      );
+    }
+    const orphanStillRenders = cards.some((card) =>
+      card.skills.some((skill) => skill.id === "orphan"),
+    );
+    assert.equal(orphanStillRenders, false);
+  }
+});
+
+test("taxonomy keys stay in lockstep with group definitions", () => {
+  const definitionIds = new Set<string>();
+
+  for (const group of otherGroupDefinitions) {
+    definitionIds.add(group.id);
+    for (const section of group.sections ?? []) {
+      definitionIds.add(section.id);
+    }
+  }
+
+  assert.deepEqual(
+    [...definitionIds].sort(),
+    [...otherCategoryKeys].sort(),
+    "otherCategoryKeys and definitions must not drift",
+  );
+
+  const keys = new Set<string>();
+  for (const node of otherTaxonomy) {
+    assert.equal(keys.has(node.key), false, `duplicate key ${node.key}`);
+    keys.add(node.key);
+    if (node.kind === "section") {
+      assert.ok(node.parentKey, "sections must declare a parent group");
     }
   }
 });

--- a/src/content/skills.ts
+++ b/src/content/skills.ts
@@ -96,6 +96,35 @@ const skillCopy = {
   },
 } as const;
 
+/** Stable taxonomy keys for Others-tab top-level groups. */
+export const otherGroupKeys = [
+  "architecture",
+  "devops-infrastructure",
+  "frontend-ux",
+  "seo-growth",
+  "workflow-collaboration",
+  "product-creative",
+  "agentic-ai-development",
+] as const;
+
+export type OtherGroupKey = (typeof otherGroupKeys)[number];
+
+/** Stable taxonomy keys for sub-sections nested inside a group. */
+export const otherSectionKeys = [
+  "ai-models-assistants",
+  "agentic-coding-harness",
+  "ai-development-capabilities",
+] as const;
+
+export type OtherSectionKey = (typeof otherSectionKeys)[number];
+
+export type OtherCategoryKey = OtherGroupKey | OtherSectionKey;
+
+export const otherCategoryKeys: ReadonlyArray<OtherCategoryKey> = [
+  ...otherGroupKeys,
+  ...otherSectionKeys,
+];
+
 interface TechStackDefinition {
   readonly id: string;
   readonly name: string;
@@ -137,13 +166,13 @@ interface OtherSkillDefinition {
 }
 
 interface OtherSectionDefinition {
-  readonly id: string;
+  readonly id: OtherSectionKey;
   readonly name: LocalizedText;
   readonly skills: ReadonlyArray<OtherSkillDefinition>;
 }
 
 interface OtherGroupDefinition {
-  readonly id: string;
+  readonly id: OtherGroupKey;
   readonly name: LocalizedText;
   readonly subtitle: LocalizedText;
   readonly featured?: boolean;
@@ -152,7 +181,7 @@ interface OtherGroupDefinition {
 }
 
 /** Owner-approved Others tab groups and subtitles (2026-08). */
-const otherGroupDefinitions: ReadonlyArray<OtherGroupDefinition> = [
+export const otherGroupDefinitions: ReadonlyArray<OtherGroupDefinition> = [
   {
     id: "architecture",
     name: { en: "Architecture", vi: "Kiến trúc" },
@@ -413,9 +442,53 @@ const otherGroupDefinitions: ReadonlyArray<OtherGroupDefinition> = [
   },
 ];
 
+/** Stable taxonomy keys for Others-tab groups and their sub-sections. */
+export interface OtherTaxonomyNode {
+  readonly key: OtherCategoryKey;
+  readonly kind: "group" | "section";
+  /** Present when kind === "section". */
+  readonly parentKey?: OtherGroupKey;
+  readonly label: LocalizedText;
+}
+
+/**
+ * Single source of truth for Others-tab taxonomy membership: stable keys plus
+ * localized labels, derived from the owner-approved group definitions so the
+ * public render and admin selectors can never drift apart.
+ */
+export const otherTaxonomy: ReadonlyArray<OtherTaxonomyNode> =
+  otherGroupDefinitions.flatMap((group) => [
+    {
+      key: group.id,
+      kind: "group" as const,
+      label: group.name,
+    },
+    ...(group.sections?.map(
+      (section): OtherTaxonomyNode => ({
+        key: section.id,
+        kind: "section" as const,
+        parentKey: group.id,
+        label: section.name,
+      }),
+    ) ?? []),
+  ]);
+
+export function isOtherCategoryKey(
+  value: string | null | undefined,
+): value is OtherCategoryKey {
+  return (
+    typeof value === "string" &&
+    (otherCategoryKeys as ReadonlyArray<string>).includes(value)
+  );
+}
+
 export interface OtherCategoryEntry {
   id: string;
   name: string;
+  /** Stable taxonomy key (see otherTaxonomy); takes precedence over categoryEn. */
+  categoryKey?: string;
+  /** Legacy assignment: exact English group/section title. Kept as a
+   * compatibility path for rows not yet backfilled to category_key. */
   categoryEn: string | null;
   /** Locale-aware category label used when a category is unknown to code. */
   categoryDisplay?: string;
@@ -450,41 +523,48 @@ export function foldOtherCategories(
 
   const knownTitles = new Map<string, number>();
   const sectionIndexByTitle = new Map<string, { group: number; index: number }>();
+  const groupIndexByKey = new Map<string, number>();
+  const sectionIndexByKey = new Map<string, { group: number; index: number }>();
 
   localizedGroups.forEach((group, index) => {
     knownTitles.set(group.definition.name.en, index);
+    groupIndexByKey.set(group.definition.id, index);
 
     group.definition.sections?.forEach((section, sectionIdx) => {
       sectionIndexByTitle.set(section.name.en, { group: index, index: sectionIdx });
+      sectionIndexByKey.set(section.id, { group: index, index: sectionIdx });
     });
   });
 
   for (const entry of entries) {
-    if (!entry.categoryEn) {
-      continue;
-    }
+    if (entry.categoryKey || entry.categoryEn) {
+      const sectionTarget = entry.categoryKey
+        ? sectionIndexByKey.get(entry.categoryKey)
+        : sectionIndexByTitle.get(entry.categoryEn ?? "");
 
-    const sectionTarget = sectionIndexByTitle.get(entry.categoryEn);
+      if (sectionTarget) {
+        const target = localizedGroups[sectionTarget.group];
 
-    if (sectionTarget) {
-      const target = localizedGroups[sectionTarget.group];
+        target.card.sections?.[sectionTarget.index]?.skills.push({
+          id: entry.id,
+          name: entry.name,
+          iconKey: entry.iconKey,
+        });
+        continue;
+      }
 
-      target.card.sections?.[sectionTarget.index]?.skills.push({
-        id: entry.id,
-        name: entry.name,
-        iconKey: entry.iconKey,
-      });
-      continue;
-    }
+      const groupIndex = entry.categoryKey
+        ? groupIndexByKey.get(entry.categoryKey)
+        : knownTitles.get(entry.categoryEn ?? "");
 
-    const groupIndex = knownTitles.get(entry.categoryEn);
-
-    if (groupIndex !== undefined) {
-      localizedGroups[groupIndex].card.skills.push({
-        id: entry.id,
-        name: entry.name,
-        iconKey: entry.iconKey,
-      });
+      if (groupIndex !== undefined) {
+        localizedGroups[groupIndex].card.skills.push({
+          id: entry.id,
+          name: entry.name,
+          iconKey: entry.iconKey,
+        });
+        continue;
+      }
     }
   }
 
@@ -499,7 +579,7 @@ export function foldOtherCategories(
     })
     .map((group) => group.card);
 
-  const knownCardIds = new Set(cards.map((card) => card.id));
+  const knownCardIds = new Set<string>(cards.map((card) => card.id));
 
   const fallbackCards = buildFallbackCards(entries).filter(
     (card) => !knownCardIds.has(card.id),
@@ -514,11 +594,13 @@ function buildFallbackCards(
   const fallback = new Map<string, SkillCategoryView>();
 
   for (const entry of entries) {
-    if (!entry.categoryEn || isKnownCategoryTitle(entry.categoryEn)) {
+    const assignment = entry.categoryKey ?? entry.categoryEn;
+
+    if (!assignment || isKnownAssignment(assignment)) {
       continue;
     }
 
-    const existing = fallback.get(entry.categoryEn);
+    const existing = fallback.get(assignment);
     const skill: SkillView = {
       id: entry.id,
       name: entry.name,
@@ -528,9 +610,12 @@ function buildFallbackCards(
     if (existing) {
       existing.skills = [...existing.skills, skill];
     } else {
-      fallback.set(entry.categoryEn, {
-        id: entry.categoryEn.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-"),
-        name: entry.categoryDisplay ?? entry.categoryEn,
+      fallback.set(assignment, {
+        id: assignment.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-"),
+        name:
+          entry.categoryDisplay ??
+          entry.categoryEn ??
+          assignment,
         skills: [skill],
       });
     }
@@ -539,11 +624,15 @@ function buildFallbackCards(
   return [...fallback.values()];
 }
 
-function isKnownCategoryTitle(title: string): boolean {
-  return otherGroupDefinitions.some(
-    (group) =>
-      group.name.en === title ||
-      (group.sections?.some((section) => section.name.en === title) ?? false),
+function isKnownAssignment(assignment: string): boolean {
+  return (
+    isOtherCategoryKey(assignment) ||
+    otherGroupDefinitions.some(
+      (group) =>
+        group.name.en === assignment ||
+        (group.sections?.some((section) => section.name.en === assignment) ??
+          false),
+    )
   );
 }
 
@@ -563,6 +652,7 @@ export function getSkillsContent(locale: Locale): SkillsContentView {
       const flatSkills = (group.skills ?? []).map((skill) => ({
         id: skill.id,
         name: skill.name[locale],
+        categoryKey: group.id,
         categoryEn: group.name.en,
         categoryDisplay: group.name[locale],
       }));
@@ -571,6 +661,7 @@ export function getSkillsContent(locale: Locale): SkillsContentView {
         section.skills.map((skill) => ({
           id: skill.id,
           name: skill.name[locale],
+          categoryKey: section.id,
           categoryEn: section.name.en,
           categoryDisplay: section.name[locale],
         })),

--- a/src/features/cms/repository.ts
+++ b/src/features/cms/repository.ts
@@ -64,6 +64,7 @@ interface SkillRow {
   icon_key: SkillIconKey | null;
   url: string | null;
   order: number;
+  category_key?: string | null;
   skill_translations: SkillTranslation[];
 }
 
@@ -133,7 +134,7 @@ export async function getSkillsContent(
     const { data, error } = await client
       .from("skills")
       .select(
-        "id, group_key, icon_key, url, order, skill_translations(locale, name, category)",
+        "id, group_key, icon_key, url, order, category_key, skill_translations(locale, name, category)",
       )
       .order("group_key")
       .order("order")
@@ -165,6 +166,7 @@ export async function getSkillsContent(
       return {
         id: row.id,
         name: pickTranslation(row.skill_translations, "name", locale),
+        categoryKey: row.category_key ?? undefined,
         categoryEn,
         categoryDisplay:
           row.skill_translations.find((t) => t.locale === locale)?.category ??

--- a/supabase/migrations/20260823090000_skill_category_keys.sql
+++ b/supabase/migrations/20260823090000_skill_category_keys.sql
@@ -1,0 +1,71 @@
+-- Issue #81: stable skill taxonomy keys.
+--
+-- The 7 public "Others" groups (plus the 3 Agentic AI sub-sections) were only
+-- encoded as free-text `skill_translations.category` strings matched by exact
+-- English title. Structural group membership is not locale data, so it moves to
+-- a stable key on the base row; display labels stay code-owned
+-- (src/content/skills.ts otherTaxonomy). The legacy category strings remain as
+-- a temporary compatibility path for rows that are not backfilled.
+
+alter table public.skills add column if not exists category_key text;
+
+-- Backfill from the English translation's category title using the same
+-- mapping the read path used before keys existed.
+update public.skills s
+set category_key = case t.category
+  when 'Architecture' then 'architecture'
+  when 'DevOps & Infrastructure' then 'devops-infrastructure'
+  when 'Frontend & UX' then 'frontend-ux'
+  when 'SEO & Growth' then 'seo-growth'
+  when 'Workflow & Collaboration' then 'workflow-collaboration'
+  when 'Product & Creative' then 'product-creative'
+  when 'AI Models & Assistants' then 'ai-models-assistants'
+  when 'Agentic Coding & Harness' then 'agentic-coding-harness'
+  when 'AI Development Capabilities' then 'ai-development-capabilities'
+  else null
+end
+from public.skill_translations t
+where t.skill_id = s.id
+  and t.locale = 'en'
+  and s.group_key = 'others';
+
+-- Atomic mutation RPC: accept and persist the stable key (optional param keeps
+-- existing callers working until the admin UI passes it explicitly).
+create or replace function public.cms_upsert_skill(
+  p_id text,
+  p_group_key text,
+  p_icon_key text,
+  p_url text,
+  p_order integer,
+  p_featured boolean,
+  p_name_en text,
+  p_name_vi text,
+  p_category_en text,
+  p_category_vi text,
+  p_category_key text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into public.skills (id, group_key, icon_key, url, "order", featured, category_key)
+  values (p_id, p_group_key, p_icon_key, p_url, p_order, p_featured, p_category_key)
+  on conflict (id) do update set
+    group_key = excluded.group_key,
+    icon_key = excluded.icon_key,
+    url = excluded.url,
+    "order" = excluded."order",
+    featured = excluded.featured,
+    category_key = coalesce(excluded.category_key, public.skills.category_key);
+
+  insert into public.skill_translations (skill_id, locale, name, category)
+  values
+    (p_id, 'en', p_name_en, p_category_en),
+    (p_id, 'vi', p_name_vi, p_category_vi)
+  on conflict (skill_id, locale) do update set
+    name = excluded.name,
+    category = excluded.category;
+end;
+$$;


### PR DESCRIPTION
Closes #81

## Summary
First of three admin-organization PRs (ChatGPT-consensus plan, approve-with-changes). Makes Others-group membership a **stable structural key** instead of free-text English title matching:

- `src/content/skills.ts`: typed taxonomy as single source — `otherGroupKeys` / `otherSectionKeys` literal unions, `OtherCategoryKey`, derived `otherTaxonomy` nodes (key + kind + parentKey + localized label) exported alongside the (now exported) `otherGroupDefinitions`. Definition ids are now compile-checked against the key unions, so drift is impossible.
- `OtherCategoryEntry` gains `categoryKey`; `foldOtherCategories` matches **by key first**, keeps legacy EN-title matching as a tested temporary compat path for un-backfilled rows; unknown keys/titles still render as distinct fallback cards (fail-visible), missing assignment skipped.
- Migration `20260823090000_skill_category_keys.sql`: adds `skills.category_key`, backfills from EN category titles, extends `cms_upsert_skill` with optional `p_category_key` (`coalesce` on update so existing callers stay compatible).
- Repository selects and forwards `category_key`.
- `scripts/sync-skills-content.sql` mirrors the same backfill.

## Local-first verification (per AGENTS.md rule 10)
- `supabase db reset` replays all migrations incl. the new one ✓
- Restored prod content snapshot + ran `sync-skills-content.sql` locally: 78 skills, 58/58 others have `category_key` ✓
- Dev render verified from CMS path: all 7 groups correct in EN + VI (Kiến trúc / Quy trình & Hợp tác / Sản phẩm & Sáng tạo) ✓

## Tests run
- npm run lint ✓ · npm run typecheck ✓ · npm test 108/108 ✓ (4 new: key-first fold, legacy compat, unknown/missing semantics, taxonomy lockstep) · npm run build -- --webpack ✓

## Known limitations
- Cloud promotion of the migration happens after merge (human-approved step); until then cloud reads degrade gracefully to static content via the repository catch.
- Legacy title matching remains until a follow-up removes it after full backfill confidence.

## Docs affected
- None (issue #81 documents intent).