### PR TITLE
feat: grouped skills admin - per-group CRUD, typed selects, validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/app/api/resume-media/route.test.ts",
+    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
     "preflight": "tsx scripts/preflight-cutover.ts",
     "seed:admin": "node scripts/seed-admin.mjs",
     "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",

--- a/src/app/admin/(dashboard)/skills/actions.ts
+++ b/src/app/admin/(dashboard)/skills/actions.ts
@@ -4,15 +4,19 @@ import { revalidatePath } from "next/cache";
 
 import { getServerClient, isAdminUser } from "@/features/cms/session";
 import { isHttpUrl, required } from "@/features/cms/validation";
-import type { SkillGroup } from "@/content/skills";
+import {
+  isOtherCategoryKey,
+  skillIconKeys,
+  type SkillGroup,
+} from "@/content/skills";
 
 export interface SkillFormData {
   id: string;
   nameEn: string;
   nameVi: string;
   group: SkillGroup;
-  categoryEn?: string;
-  categoryVi?: string;
+  /** Stable Others-tab category key; ignored (nulled) for tech-stack. */
+  categoryKey?: string;
   iconKey?: string;
   url?: string;
   order: number;
@@ -33,13 +37,25 @@ function validate(data: SkillFormData): SkillActionResult | null {
   if (!required(data.nameVi)) errors.nameVi = "VI name is required.";
   if (data.url && !isHttpUrl(data.url)) errors.url = "URL must be http(s).";
 
+  if (
+    data.group === "others" &&
+    data.categoryKey &&
+    !isOtherCategoryKey(data.categoryKey)
+  ) {
+    errors.categoryKey = "Unknown category key.";
+  }
+
+  if (data.iconKey && !(skillIconKeys as ReadonlyArray<string>).includes(data.iconKey)) {
+    errors.iconKey = "Unknown icon key.";
+  }
+
   if (Object.keys(errors).length > 0) {
     return { ok: false, fieldErrors: errors };
   }
   return null;
 }
 
-export async function createSkill(
+export async function upsertSkill(
   data: SkillFormData,
 ): Promise<SkillActionResult> {
   if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
@@ -49,7 +65,8 @@ export async function createSkill(
   const client = await getServerClient();
 
   // Single-transaction write: base row + both translation rows roll back together
-  // on any failure (see migration cms_atomic_mutations).
+  // on any failure (see migration cms_atomic_mutations). Display labels for the
+  // taxonomy live in code, so translation categories are no longer written.
   const { error } = await client.rpc("cms_upsert_skill", {
     p_id: data.id,
     p_group_key: data.group,
@@ -59,37 +76,10 @@ export async function createSkill(
     p_featured: data.featured,
     p_name_en: data.nameEn.trim(),
     p_name_vi: data.nameVi.trim(),
-    p_category_en: data.categoryEn?.trim() || null,
-    p_category_vi: data.categoryVi?.trim() || null,
-  });
-  if (error) return { ok: false, error: error.message };
-
-  revalidatePath("/");
-  revalidatePath("/vi");
-  revalidatePath("/admin/skills");
-  return { ok: true };
-}
-
-export async function updateSkill(
-  data: SkillFormData,
-): Promise<SkillActionResult> {
-  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
-  const invalid = validate(data);
-  if (invalid) return invalid;
-
-  const client = await getServerClient();
-
-  const { error } = await client.rpc("cms_upsert_skill", {
-    p_id: data.id,
-    p_group_key: data.group,
-    p_icon_key: data.iconKey ?? null,
-    p_url: data.url || null,
-    p_order: data.order,
-    p_featured: data.featured,
-    p_name_en: data.nameEn.trim(),
-    p_name_vi: data.nameVi.trim(),
-    p_category_en: data.categoryEn?.trim() || null,
-    p_category_vi: data.categoryVi?.trim() || null,
+    p_category_en: null,
+    p_category_vi: null,
+    p_category_key:
+      data.group === "others" ? (data.categoryKey ?? null) : null,
   });
   if (error) return { ok: false, error: error.message };
 

--- a/src/app/admin/(dashboard)/skills/data.ts
+++ b/src/app/admin/(dashboard)/skills/data.ts
@@ -1,56 +1,79 @@
 import { getServerClient } from "@/features/cms/session";
-import type { SkillGroup } from "@/content/skills";
+import { isOtherCategoryKey, type SkillGroup } from "@/content/skills";
 
-export interface AdminSkillRow {
-  id: string;
-  group: SkillGroup;
-  iconKey: string | null;
-  url: string | null;
-  order: number;
-  featured: boolean;
-  nameEn: string;
-  nameVi: string;
-  categoryEn: string | null;
-  categoryVi: string | null;
+import type { AdminSkillRow } from "./skill-buckets";
+
+export type { AdminSkillRow } from "./skill-buckets";
+
+export interface SkillListResult {
+  skills: AdminSkillRow[];
+  error?: string;
 }
 
-export async function listSkills(): Promise<AdminSkillRow[]> {
+function mapSkillRow(
+  skill: {
+    id: string;
+    group_key: string;
+    category_key: string | null;
+    icon_key: string | null;
+    url: string | null;
+    order: number;
+    featured: boolean;
+    skill_translations: Array<{ locale: string; name: string }> | null;
+  },
+): AdminSkillRow {
+  const translations = skill.skill_translations ?? [];
+  const en = translations.find((t) => t.locale === "en");
+  const vi = translations.find((t) => t.locale === "vi");
+  const categoryKey = skill.category_key;
+
+  return {
+    id: skill.id,
+    group: skill.group_key as SkillGroup,
+    categoryKey:
+      categoryKey && isOtherCategoryKey(categoryKey) ? categoryKey : null,
+    iconKey: skill.icon_key,
+    url: skill.url,
+    order: skill.order,
+    featured: skill.featured,
+    nameEn: en?.name ?? "",
+    nameVi: vi?.name ?? "",
+  };
+}
+
+export async function listSkills(): Promise<SkillListResult> {
   const client = await getServerClient();
 
   const { data, error } = await client
     .from("skills")
-    .select("id, group_key, icon_key, url, order, featured, skill_translations(locale, name, category)")
+    .select("id, group_key, category_key, icon_key, url, order, featured, skill_translations(locale, name)")
     .order("group_key")
     .order("order")
     .order("id");
 
-  if (error || !data) return [];
+  if (error || !data) {
+    return { skills: [], error: error?.message ?? "Failed to load skills." };
+  }
 
-  return data.map((skill) => {
-    const translations = (skill.skill_translations ?? []) as Array<{
-      locale: string;
-      name: string;
-      category: string | null;
-    }>;
-    const en = translations.find((t) => t.locale === "en");
-    const vi = translations.find((t) => t.locale === "vi");
-
-    return {
-      id: skill.id,
-      group: skill.group_key as SkillGroup,
-      iconKey: skill.icon_key,
-      url: skill.url,
-      order: skill.order,
-      featured: skill.featured,
-      nameEn: en?.name ?? "",
-      nameVi: vi?.name ?? "",
-      categoryEn: en?.category ?? null,
-      categoryVi: vi?.category ?? null,
-    };
-  });
+  return {
+    skills: data.map((skill) =>
+      mapSkillRow(
+        skill as unknown as Parameters<typeof mapSkillRow>[0],
+      ),
+    ),
+  };
 }
 
 export async function getSkill(id: string): Promise<AdminSkillRow | null> {
-  const rows = await listSkills();
-  return rows.find((row) => row.id === id) ?? null;
+  const client = await getServerClient();
+
+  const { data, error } = await client
+    .from("skills")
+    .select("id, group_key, category_key, icon_key, url, order, featured, skill_translations(locale, name)")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  return mapSkillRow(data as unknown as Parameters<typeof mapSkillRow>[0]);
 }

--- a/src/app/admin/(dashboard)/skills/new/page.tsx
+++ b/src/app/admin/(dashboard)/skills/new/page.tsx
@@ -1,3 +1,4 @@
+import { isOtherCategoryKey, type OtherCategoryKey, type SkillGroup } from "@/content/skills";
 import { SkillForm } from "../skill-form";
 import { AdminFormCard, AdminPage } from "../../admin-page";
 
@@ -5,12 +6,28 @@ export const metadata = {
   title: "New skill",
 };
 
-export default function AdminNewSkillPage() {
+interface AdminNewSkillPageProps {
+  searchParams: Promise<{ group?: string; categoryKey?: string }>;
+}
+
+export default async function AdminNewSkillPage({
+  searchParams,
+}: AdminNewSkillPageProps) {
+  const { group, categoryKey } = await searchParams;
+
+  const defaultGroup: SkillGroup =
+    group === "others" ? "others" : "tech-stack";
+  const defaultCategoryKey: OtherCategoryKey | undefined =
+    categoryKey && isOtherCategoryKey(categoryKey) ? categoryKey : undefined;
+
   return (
     <AdminPage backHref="/admin/skills" title="New skill">
       <AdminFormCard>
         <h2>Skill details</h2>
-        <SkillForm />
+        <SkillForm
+          defaultGroup={defaultGroup}
+          defaultCategoryKey={defaultCategoryKey}
+        />
       </AdminFormCard>
     </AdminPage>
   );

--- a/src/app/admin/(dashboard)/skills/page.tsx
+++ b/src/app/admin/(dashboard)/skills/page.tsx
@@ -1,51 +1,86 @@
 import Link from "next/link";
 
 import { listSkills } from "./data";
+import {
+  bucketizeSkills,
+  TECH_STACK_BUCKET_ID,
+  UNASSIGNED_BUCKET_ID,
+  type AdminSkillBucket,
+} from "./skill-buckets";
 import { DeleteSkillButton } from "./delete-skill";
 import { AdminPage, AdminTable } from "../admin-page";
+import { otherTaxonomy } from "@/content/skills";
 
 export const metadata = {
   title: "Admin skills",
 };
 
-export default async function AdminSkillsPage() {
-  const skills = await listSkills();
-
+function categoryLabel(id: string): string {
   return (
-    <AdminPage
-      action={
-        <Link className="admin-button" href="/admin/skills/new">
-          New skill
-        </Link>
-      }
-      title="Skills"
-    >
-      {skills.length === 0 ? (
-        <p className="admin-empty">No skills yet.</p>
-      ) : (
-      <AdminTable label="Skills">
+    otherTaxonomy.find((node) => node.key === id)?.label.en ?? id
+  );
+}
+
+function BucketTable({ bucket }: { bucket: AdminSkillBucket }) {
+  return (
+    <section aria-labelledby={`skills-bucket-${bucket.id}`}>
+      <div className="admin-bucket-head">
+        <h2 id={`skills-bucket-${bucket.id}`}>{bucket.title}</h2>
+        {bucket.id !== UNASSIGNED_BUCKET_ID ? (
+          <Link
+            className="admin-button"
+            href={
+              bucket.id === TECH_STACK_BUCKET_ID
+                ? "/admin/skills/new?group=tech-stack"
+                : `/admin/skills/new?group=others&categoryKey=${bucket.id}`
+            }
+          >
+            Add skill
+          </Link>
+        ) : null}
+      </div>
+      {bucket.hint ? <p className="admin-hint">{bucket.hint}</p> : null}
+      <AdminTable label={`${bucket.title} skills`}>
         <thead>
           <tr>
             <th scope="col">ID</th>
             <th scope="col">Name</th>
-            <th scope="col">Group</th>
+            <th scope="col">Category</th>
             <th scope="col">Order</th>
-            <th scope="col">Featured</th>
-            <th scope="col"><span className="sr-only">Actions</span></th>
+            <th scope="col">
+              <span className="sr-only">Actions</span>
+            </th>
           </tr>
         </thead>
         <tbody>
-          {skills.map((skill) => (
+          {bucket.skills.map((skill) => (
             <tr key={skill.id}>
               <td>{skill.id}</td>
-              <td>{skill.nameEn}</td>
-              <td>{skill.group}</td>
-              <td>{skill.order}</td>
               <td>
+                {skill.nameEn}
                 {skill.featured ? (
-                  <span className="admin-badge admin-badge--success">Featured</span>
+                  <>
+                    {" "}
+                    <span className="admin-badge admin-badge--success">
+                      Featured
+                    </span>
+                  </>
                 ) : null}
               </td>
+              <td>
+                {skill.group === "others" ? (
+                  skill.categoryKey ? (
+                    categoryLabel(skill.categoryKey)
+                  ) : (
+                    <span className="admin-badge admin-badge--warning">
+                      Unassigned
+                    </span>
+                  )
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td>{skill.order}</td>
               <td className="admin-row-actions">
                 <Link href={`/admin/skills/${skill.id}`}>Edit</Link>
                 <DeleteSkillButton id={skill.id} name={skill.nameEn} />
@@ -54,6 +89,35 @@ export default async function AdminSkillsPage() {
           ))}
         </tbody>
       </AdminTable>
+    </section>
+  );
+}
+
+export default async function AdminSkillsPage() {
+  const { skills, error } = await listSkills();
+
+  if (error) {
+    return (
+      <AdminPage title="Skills">
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      </AdminPage>
+    );
+  }
+
+  const buckets = bucketizeSkills(skills);
+
+  return (
+    <AdminPage title="Skills">
+      {skills.length === 0 ? (
+        <p className="admin-empty">No skills yet.</p>
+      ) : (
+        <div className="admin-buckets">
+          {buckets.map((bucket) => (
+            <BucketTable bucket={bucket} key={bucket.id} />
+          ))}
+        </div>
       )}
     </AdminPage>
   );

--- a/src/app/admin/(dashboard)/skills/skill-buckets.test.ts
+++ b/src/app/admin/(dashboard)/skills/skill-buckets.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { OtherCategoryKey } from "@/content/skills";
+
+import {
+  bucketIdForCategoryKey,
+  bucketizeSkills,
+  UNASSIGNED_BUCKET_ID,
+  type AdminSkillRow,
+} from "./skill-buckets";
+
+function row(overrides: Partial<AdminSkillRow>): AdminSkillRow {
+  return {
+    id: "skill-1",
+    group: "others",
+    categoryKey: null,
+    iconKey: null,
+    url: null,
+    order: 0,
+    featured: false,
+    nameEn: "Skill",
+    nameVi: "Skill",
+    ...overrides,
+  };
+}
+
+test("bucketIdForCategoryKey rolls section keys up to their parent group", () => {
+  assert.equal(bucketIdForCategoryKey("architecture"), "architecture");
+  assert.equal(
+    bucketIdForCategoryKey("ai-models-assistants"),
+    "agentic-ai-development",
+  );
+  assert.equal(
+    bucketIdForCategoryKey("agentic-coding-harness"),
+    "agentic-ai-development",
+  );
+  assert.equal(
+    bucketIdForCategoryKey("ai-development-capabilities"),
+    "agentic-ai-development",
+  );
+});
+
+interface BucketExpectation {
+  label: string;
+  rows: AdminSkillRow[];
+  want: Array<{ id: string; count: number }>;
+}
+
+const table: BucketExpectation[] = [
+  {
+    label: "places tech-stack skills in the Tech Stack bucket",
+    rows: [
+      row({ id: "ts", group: "tech-stack" }),
+      row({ id: "ts2", group: "tech-stack" }),
+    ],
+    want: [{ id: "tech-stack", count: 2 }],
+  },
+  {
+    label: "buckets others skills by their group key",
+    rows: [row({ id: "arch", categoryKey: "architecture" })],
+    want: [
+      { id: "tech-stack", count: 0 },
+      { id: "architecture", count: 1 },
+    ],
+  },
+  {
+    label: "rolls section-keyed skills into their parent Agentic AI bucket",
+    rows: [
+      row({ id: "models", categoryKey: "ai-models-assistants" }),
+      row({ id: "harness", categoryKey: "agentic-coding-harness" }),
+      row({ id: "caps", categoryKey: "ai-development-capabilities" }),
+    ],
+    want: [{ id: "agentic-ai-development", count: 3 }],
+  },
+  {
+    label: "collects unkeyed and unknown-keyed others skills under Unassigned",
+    rows: [
+      row({ id: "nokey" }),
+      row({ id: "badkey", categoryKey: "not-a-real-key" as OtherCategoryKey }),
+    ],
+    want: [{ id: UNASSIGNED_BUCKET_ID, count: 2 }],
+  },
+  {
+    label: "keeps empty group buckets but drops an empty Unassigned bucket",
+    rows: [row({ id: "seo", categoryKey: "seo-growth" })],
+    want: [
+      { id: "tech-stack", count: 0 },
+      { id: "seo-growth", count: 1 },
+    ],
+  },
+];
+
+for (const expectation of table) {
+  test(`bucketizeSkills: ${expectation.label}`, () => {
+    const buckets = bucketizeSkills(expectation.rows);
+
+    for (const expected of expectation.want) {
+      const bucket = buckets.find((candidate) => candidate.id === expected.id);
+
+      assert.ok(bucket, `expected a "${expected.id}" bucket`);
+      assert.equal(bucket.skills.length, expected.count);
+    }
+
+    const unassigned = buckets.find(
+      (candidate) => candidate.id === UNASSIGNED_BUCKET_ID,
+    );
+
+    if (
+      expectation.want.every((entry) => entry.id !== UNASSIGNED_BUCKET_ID)
+    ) {
+      assert.ok(!unassigned, "empty Unassigned bucket should be omitted");
+    }
+  });
+}
+
+test("bucketizeSkills keeps stable display order across buckets", () => {
+  const buckets = bucketizeSkills([
+    row({ id: "a", categoryKey: "workflow-collaboration" }),
+    row({ id: "b", group: "tech-stack" }),
+    row({ id: "c", categoryKey: "architecture" }),
+    row({ id: "d" }),
+  ]);
+
+  assert.equal(buckets[0]?.id, "tech-stack");
+  assert.equal(buckets[1]?.id, "architecture");
+  assert.deepEqual(
+    buckets
+      .filter((bucket) => bucket.skills.length > 0)
+      .map((bucket) => bucket.id),
+    [
+      "tech-stack",
+      "architecture",
+      "workflow-collaboration",
+      UNASSIGNED_BUCKET_ID,
+    ],
+  );
+});

--- a/src/app/admin/(dashboard)/skills/skill-buckets.ts
+++ b/src/app/admin/(dashboard)/skills/skill-buckets.ts
@@ -1,0 +1,78 @@
+import {
+  otherGroupKeys,
+  otherTaxonomy,
+  type OtherCategoryKey,
+  type SkillGroup,
+} from "@/content/skills";
+
+export interface AdminSkillRow {
+  id: string;
+  group: SkillGroup;
+  categoryKey: OtherCategoryKey | null;
+  iconKey: string | null;
+  url: string | null;
+  order: number;
+  featured: boolean;
+  nameEn: string;
+  nameVi: string;
+}
+
+/**
+ * Admin listing buckets, in stable display order: Tech Stack first, then the
+ * code-owned Others groups, then anything unassigned/unknown so misfiled rows
+ * are visible instead of silently hidden.
+ */
+export interface AdminSkillBucket {
+  id: string;
+  title: string;
+  hint?: string;
+  skills: AdminSkillRow[];
+}
+
+/** Display bucket id for a taxonomy key: sections roll up to their parent group. */
+export function bucketIdForCategoryKey(key: OtherCategoryKey): string {
+  const node = otherTaxonomy.find((candidate) => candidate.key === key);
+
+  if (!node) return "unassigned";
+  return node.kind === "section" && node.parentKey ? node.parentKey : node.key;
+}
+
+export const UNASSIGNED_BUCKET_ID = "unassigned";
+export const TECH_STACK_BUCKET_ID = "tech-stack";
+
+export function bucketizeSkills(skills: AdminSkillRow[]): AdminSkillBucket[] {
+  const buckets: AdminSkillBucket[] = [
+    { id: TECH_STACK_BUCKET_ID, title: "Tech Stack", skills: [] },
+    ...otherGroupKeys.map((key) => ({
+      id: key,
+      title:
+        otherTaxonomy.find((node) => node.kind === "group" && node.key === key)
+          ?.label.en ?? key,
+      skills: [],
+    })),
+    {
+      id: UNASSIGNED_BUCKET_ID,
+      title: "Unassigned",
+      hint: "Others skills without a recognized category key. Edit each one to pick its group.",
+      skills: [],
+    },
+  ];
+
+  const byId = new Map(buckets.map((bucket) => [bucket.id, bucket]));
+
+  for (const skill of skills) {
+    let target = byId.get(skill.group);
+
+    if (skill.group === "others") {
+      target =
+        (skill.categoryKey ? byId.get(bucketIdForCategoryKey(skill.categoryKey)) : undefined) ??
+        byId.get(UNASSIGNED_BUCKET_ID);
+    }
+
+    target?.skills.push(skill);
+  }
+
+  return buckets.filter(
+    (bucket) => bucket.skills.length > 0 || bucket.id !== UNASSIGNED_BUCKET_ID,
+  );
+}

--- a/src/app/admin/(dashboard)/skills/skill-form.tsx
+++ b/src/app/admin/(dashboard)/skills/skill-form.tsx
@@ -4,29 +4,41 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
-import type { SkillGroup } from "@/content/skills";
+import {
+  otherTaxonomy,
+  skillIconKeys,
+  type OtherCategoryKey,
+  type SkillGroup,
+} from "@/content/skills";
 import type { AdminSkillRow } from "./data";
-import { createSkill, updateSkill, type SkillActionResult } from "./actions";
+import { upsertSkill, type SkillActionResult } from "./actions";
 
-const iconOptions = [
-  "typescript",
-  "javascript",
-  "react",
-  "nextjs",
-  "nodejs",
-  "nestjs",
-  "postgresql",
-  "wordpress",
-] as const;
+const groupLabels: Readonly<Record<SkillGroup, string>> = {
+  "tech-stack": "Tech Stack",
+  others: "Others",
+};
 
 interface SkillFormProps {
   existing?: AdminSkillRow;
+  /** Prefill for the create form (from a per-group Add button). */
+  defaultGroup?: SkillGroup;
+  defaultCategoryKey?: OtherCategoryKey;
 }
 
-export function SkillForm({ existing }: SkillFormProps) {
+export function SkillForm({
+  existing,
+  defaultGroup = "tech-stack",
+  defaultCategoryKey,
+}: SkillFormProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [group, setGroup] = useState<SkillGroup>(
+    existing?.group ?? defaultGroup,
+  );
+
+  const taxonomyGroups = otherTaxonomy.filter((node) => node.kind === "group");
+  const taxonomySections = otherTaxonomy.filter((node) => node.kind === "section");
 
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -38,8 +50,7 @@ export function SkillForm({ existing }: SkillFormProps) {
       nameEn: String(fd.get("nameEn") ?? ""),
       nameVi: String(fd.get("nameVi") ?? ""),
       group: String(fd.get("group") ?? "tech-stack") as SkillGroup,
-      categoryEn: String(fd.get("categoryEn") ?? ""),
-      categoryVi: String(fd.get("categoryVi") ?? ""),
+      categoryKey: String(fd.get("categoryKey") ?? "") || undefined,
       iconKey: String(fd.get("iconKey") ?? "") || undefined,
       url: String(fd.get("url") ?? ""),
       order: Number(fd.get("order") ?? 0),
@@ -47,14 +58,16 @@ export function SkillForm({ existing }: SkillFormProps) {
     };
 
     startTransition(async () => {
-      const result: SkillActionResult = existing
-        ? await updateSkill(data)
-        : await createSkill(data);
+      const result: SkillActionResult = await upsertSkill(data);
       if (result.ok) {
         router.push("/admin/skills");
         router.refresh();
       } else {
-        setError(result.fieldErrors ? Object.values(result.fieldErrors).join(" ") : (result.error ?? "Failed."));
+        setError(
+          result.fieldErrors
+            ? Object.values(result.fieldErrors).join(" ")
+            : (result.error ?? "Failed."),
+        );
       }
     });
   }
@@ -79,26 +92,50 @@ export function SkillForm({ existing }: SkillFormProps) {
 
       <label className="admin-field">
         <span>Group</span>
-        <select name="group" defaultValue={existing?.group ?? "tech-stack"}>
-          <option value="tech-stack">Tech Stack</option>
-          <option value="others">Others</option>
+        <select
+          name="group"
+          value={group}
+          onChange={(event) => setGroup(event.target.value as SkillGroup)}
+        >
+          {(Object.keys(groupLabels) as SkillGroup[]).map((key) => (
+            <option key={key} value={key}>
+              {groupLabels[key]}
+            </option>
+          ))}
         </select>
       </label>
 
-      <label className="admin-field">
-        <span>Category (EN) — Others only</span>
-        <input name="categoryEn" defaultValue={existing?.categoryEn ?? ""} />
-      </label>
-      <label className="admin-field">
-        <span>Category (VI) — Others only</span>
-        <input name="categoryVi" defaultValue={existing?.categoryVi ?? ""} />
-      </label>
+      {group === "others" ? (
+        <label className="admin-field">
+          <span>Category</span>
+          <select
+            name="categoryKey"
+            defaultValue={existing?.categoryKey ?? defaultCategoryKey ?? ""}
+          >
+            <option value="">— Unassigned —</option>
+            <optgroup label="Groups">
+              {taxonomyGroups.map((node) => (
+                <option key={node.key} value={node.key}>
+                  {node.label.en}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Agentic AI sub-sections">
+              {taxonomySections.map((node) => (
+                <option key={node.key} value={node.key}>
+                  {node.label.en}
+                </option>
+              ))}
+            </optgroup>
+          </select>
+        </label>
+      ) : null}
 
       <label className="admin-field">
         <span>Icon key</span>
         <select name="iconKey" defaultValue={existing?.iconKey ?? ""}>
           <option value="">None</option>
-          {iconOptions.map((icon) => (
+          {skillIconKeys.map((icon) => (
             <option key={icon} value={icon}>
               {icon}
             </option>

--- a/src/content/skills.ts
+++ b/src/content/skills.ts
@@ -4,26 +4,30 @@ type LocalizedText = Readonly<Record<Locale, string>>;
 
 export type SkillGroup = "tech-stack" | "others";
 
-export type SkillIconKey =
-  | "typescript"
-  | "javascript"
-  | "react"
-  | "nextjs"
-  | "nodejs"
-  | "nestjs"
-  | "postgresql"
-  | "wordpress"
-  | "python"
-  | "mongodb"
-  | "mysql"
-  | "docker"
-  | "aws"
-  | "digitalocean"
-  | "firebase"
-  | "azuredevops"
-  | "tailwindcss"
-  | "scss"
-  | "linux";
+/** Runtime single source for valid icon keys (admin selectors, validation). */
+export const skillIconKeys = [
+  "typescript",
+  "javascript",
+  "react",
+  "nextjs",
+  "nodejs",
+  "nestjs",
+  "postgresql",
+  "wordpress",
+  "python",
+  "mongodb",
+  "mysql",
+  "docker",
+  "aws",
+  "digitalocean",
+  "firebase",
+  "azuredevops",
+  "tailwindcss",
+  "scss",
+  "linux",
+] as const;
+
+export type SkillIconKey = (typeof skillIconKeys)[number];
 
 export interface SkillView {
   id: string;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3400,6 +3400,36 @@ video {
   background: color-mix(in srgb, var(--color-ui-error) 12%, transparent);
 }
 
+.admin-badge--warning {
+  color: var(--color-ui-warning);
+  background: color-mix(in srgb, var(--color-ui-warning) 12%, transparent);
+}
+
+/* Grouped skill buckets */
+.admin-buckets {
+  display: grid;
+  gap: var(--space-7);
+}
+
+.admin-bucket-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-block-end: var(--space-3);
+}
+
+.admin-bucket-head h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.admin-hint {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
 /* Row actions */
 .admin-row-actions {
   gap: 0.75rem;

--- a/supabase/migrations/20260823100000_skill_category_key_overwrite.sql
+++ b/supabase/migrations/20260823100000_skill_category_key_overwrite.sql
@@ -1,0 +1,43 @@
+-- Issue #82 follow-up to #81: admin edits must be able to CLEAR a skill's
+-- category key (moving a skill out of a group). The #81 version used
+-- coalesce-on-update so legacy callers omitting p_category_key kept the old
+-- value; now the only writer (admin upsert) passes the parameter explicitly,
+-- so plain assignment is correct and clearing works.
+create or replace function public.cms_upsert_skill(
+  p_id text,
+  p_group_key text,
+  p_icon_key text,
+  p_url text,
+  p_order integer,
+  p_featured boolean,
+  p_name_en text,
+  p_name_vi text,
+  p_category_en text,
+  p_category_vi text,
+  p_category_key text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into public.skills (id, group_key, icon_key, url, "order", featured, category_key)
+  values (p_id, p_group_key, p_icon_key, p_url, p_order, p_featured, p_category_key)
+  on conflict (id) do update set
+    group_key = excluded.group_key,
+    icon_key = excluded.icon_key,
+    url = excluded.url,
+    "order" = excluded."order",
+    featured = excluded.featured,
+    category_key = excluded.category_key;
+
+  insert into public.skill_translations (skill_id, locale, name, category)
+  values
+    (p_id, 'en', p_name_en, p_category_en),
+    (p_id, 'vi', p_name_vi, p_category_vi)
+  on conflict (skill_id, locale) do update set
+    name = excluded.name,
+    category = excluded.category;
+end;
+$$;


### PR DESCRIPTION
### Summary

Implements #82 (depends on #81, merged in #84). The skills admin is no longer a flat table:

- **Grouped listing** (`skill-buckets.ts`, `page.tsx`): stable-ordered buckets — Tech Stack, the 7 Others groups (titles derived from the shared `otherTaxonomy` labels), and an Unassigned bucket (shown only when non-empty) so misfiled rows stay visible. Each bucket has its own scoped **Add skill** link that prefills the form via query params (`?group=…&categoryKey=…`).
- **Section-key roll-up fix**: skills whose `category_key` is an Agentic AI sub-section key (`ai-models-assistants`, `agentic-coding-harness`, `ai-development-capabilities`) now land under their parent group bucket instead of wrongly appearing Unassigned — this affected 17 real local rows.
- **Form** (`skill-form.tsx`): Group select toggles the Category select; Category options come entirely from `otherTaxonomy` optgroups (Groups + Agentic AI sub-sections) — no typing English titles; Icon key select lists all **19** keys from the new runtime `skillIconKeys` array.
- **Server actions** (`actions.ts`): `createSkill`/`updateSkill` deduped into a single `upsertSkill`; server-side validation rejects unknown `categoryKey`/`iconKey` values at the action boundary; translation category columns are written as null (labels live in code).
- **Data layer** (`data.ts`): `listSkills()` returns `{ skills, error }` instead of swallowing errors (page renders `role="alert"` error state); `getSkill(id)` fetches one row via `.eq().maybeSingle()` rather than refetching the whole table; shared `mapSkillRow`.
- **Migration** `20260823100000_skill_category_key_overwrite.sql`: replaces `cms_upsert_skill` with plain `category_key = excluded.category_key` assignment (#81 used coalesce-on-update) so admins can **clear** a category when moving a skill out of a group. Applied to the local stack only.

Closes #82

### Acceptance criteria

- [x] Owner can manage skills per group without typing English titles
- [x] All 19 icon keys selectable; invalid values rejected server-side
- [x] lint/typecheck/test/build green
- [ ] Manual smoke in local CMS (authenticated owner session) — see Risks

### Verification

- `npm run lint` — clean
- `npm run typecheck` (`next typegen && tsc --noEmit`) — clean
- `npm test` — 115 pass / 0 fail (7 new unit tests for `bucketizeSkills`: tech-stack placement, group-key bucketing, section→parent roll-up, unassigned collection incl. unknown keys, empty-Unassigned omission, stable display order)
- `npm run build -- --webpack` — green (all admin routes compiled)
- Dev smoke: `/` and `/vi` render grouped skills including the Agentic AI group/sections; `/admin/skills` 307-redirects unauthenticated visitors
- Migration applied locally: `supabase db query --local -f supabase/migrations/20260823100000_skill_category_key_overwrite.sql` → CREATE FUNCTION

Independent pre-PR review via ChatGPT bridge: **approve-with-changes**, no code changes requested.

### Screenshots

Pending — grouped-listing captures require an authenticated owner session (see Risks). Will be attached after the owner smoke run.

### Risks / follow-ups

- **Authenticated manual smoke outstanding**: add/edit per group, move Others→Tech Stack (verify `category_key` clears), move Tech Stack→Others (category persists), invalid category/icon rejection through the action boundary, no unexpected Unassigned rows. Requires owner login; must complete before merge.
- **Migration cloud promotion is human-gated**: after review approval run `supabase db query --linked -f …`, then mirror prod data back into local per AGENTS.md local-first workflow.
- Admin UI remains English-only by design (admin area is not localized in this repo).

### Docs affected

None — no canonical behavior/architecture changes beyond the issue scope.
