### PR TITLE
feat: blog schema foundation - tables, RLS, atomic RPCs, publish gate, seed

### DIFF
--- a/docs/03-content-data-model.md
+++ b/docs/03-content-data-model.md
@@ -181,6 +181,48 @@ export interface NewsletterSignup {
 
 If persistence is deferred, keep the UI disabled/marked appropriately rather than simulating a successful subscription.
 
+## Blog
+
+Blog entities live in Supabase (`blog_*` tables) following the CMS conventions — stable text ids, `_translations` child tables keyed `(entity_id, locale)`, and a publish gate inside the atomic mutation RPC that requires complete `en` + `vi` translations before a post can go live.
+
+```ts
+export interface BlogCategory {
+  slug: string;
+  name: LocalizedText;
+}
+
+export interface BlogTag {
+  slug: string;
+  name: LocalizedText;
+}
+
+export interface BlogPost {
+  slug: string;                 // one stable slug shared by both locales
+  title: LocalizedText;
+  summary: LocalizedText;
+  contentMd: LocalizedText;     // Markdown source, rendered by the shared pipeline
+  category: BlogCategory;
+  tags: BlogTag[];
+  coverImage?: ManagedImage;    // bucket path in the public 'blog-media' bucket
+  publishedAt?: string;         // ISO, stamped once on first publish
+  updatedAt?: string;
+  readingTimeMinutes: number;   // computed at render, never stored
+}
+
+export type ManagedImage = {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+};
+```
+
+Rules:
+
+- A post is publicly visible only when `status='published'`; the repository adapter enforces the published-only filter (fail-closed, like resume publicity).
+- `published_at` is stamped on the first successful publish and preserved on later edits (including unpublish/republish).
+- Missing translations resolve to `notFound()`, never a partial render.
+
 ## Future CMS mapping
 
 Recommended entities:
@@ -197,5 +239,8 @@ Recommended entities:
 - `resume_entry_translations`
 - `resume_media`
 - `social_links`
+- `blog_categories` (+ `blog_category_translations`)
+- `blog_tags` (+ `blog_tag_translations`)
+- `blog_posts` (+ `blog_post_translations`, `blog_post_tags`)
 
 Stable IDs and translation tables make locale additions possible without duplicating entire documents.

--- a/supabase/migrations/20260825100000_blog_schema.sql
+++ b/supabase/migrations/20260825100000_blog_schema.sql
@@ -1,0 +1,422 @@
+-- Issue #89: Blog schema foundation.
+--
+-- Implements slice 1 of the blog design spec
+-- (docs/superpowers/specs/2026-08-25-blog-design.md, §3 Data model).
+--
+-- Conventions followed from the established CMS migrations:
+--   - Base rows use stable TEXT ids (projects/resume/skills/social pattern), not
+--     UUIDs. Categories/tags use id = slug (like resume_categories); posts keep a
+--     stable id independent of an editable slug (like projects), because a
+--     published post's slug is a URL migration (§6) and must not change the id.
+--   - `_translations` child tables keyed (entity_id, locale) with
+--     locale CHECK in ('en','vi').
+--   - SECURITY INVOKER atomic RPCs granted to authenticated + service_role, so
+--     admin CRUD runs through the owner RLS path (same as cms_upsert_project /
+--     cms_upsert_resume_entry). Each mutation writes base row + both translation
+--     rows + tag links in one transaction.
+--   - RLS: anon = zero privileges (hardening #66); authenticated owner is
+--     authorized via private.is_owner(); service_role is the server read/write
+--     path and bypasses RLS. The public repository adapter enforces
+--     status='published' filtering (fail-closed, same philosophy as resume
+--     publicity) — the anonymous read path is never exposed at the table level.
+--   - Publish gate + update invariants live inside the atomic RPC, never
+--     application-layer only.
+
+-- --- Content tables -----------------------------------------------------------
+
+create table blog_categories (
+  id text primary key,
+  slug text not null unique check (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create table blog_category_translations (
+  category_id text not null references blog_categories(id) on delete cascade,
+  locale text not null check (locale in ('en','vi')),
+  name text not null check (btrim(name) <> ''),
+  primary key (category_id, locale)
+);
+
+create table blog_tags (
+  id text primary key,
+  slug text not null unique check (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
+  created_at timestamptz not null default now()
+);
+
+create table blog_tag_translations (
+  tag_id text not null references blog_tags(id) on delete cascade,
+  locale text not null check (locale in ('en','vi')),
+  name text not null check (btrim(name) <> ''),
+  primary key (tag_id, locale)
+);
+
+create table blog_posts (
+  id text primary key,
+  slug text not null unique check (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
+  category_id text not null references blog_categories(id) on delete restrict,
+  cover_bucket_path text,
+  status text not null default 'draft' check (status in ('draft','published')),
+  published_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table blog_post_translations (
+  post_id text not null references blog_posts(id) on delete cascade,
+  locale text not null check (locale in ('en','vi')),
+  title text not null check (btrim(title) <> ''),
+  summary text not null check (btrim(summary) <> ''),
+  content_md text not null,
+  primary key (post_id, locale)
+);
+
+create table blog_post_tags (
+  post_id text not null references blog_posts(id) on delete cascade,
+  tag_id text not null references blog_tags(id) on delete cascade,
+  primary key (post_id, tag_id)
+);
+
+-- Supporting indexes for the high-frequency repository queries.
+create index blog_posts_status_published_at_idx on blog_posts (status, published_at desc);
+create index blog_posts_category_id_idx on blog_posts (category_id);
+create index blog_post_tags_tag_id_idx on blog_post_tags (tag_id);
+
+-- --- Grants -------------------------------------------------------------------
+-- anon gets zero privileges (deny-by-default, hardening #66).
+
+revoke all on blog_categories, blog_category_translations, blog_tags,
+  blog_tag_translations, blog_posts, blog_post_translations, blog_post_tags
+  from anon;
+
+grant select, insert, update, delete on blog_categories, blog_category_translations,
+  blog_tags, blog_tag_translations, blog_posts, blog_post_translations, blog_post_tags
+  to authenticated, service_role;
+
+-- --- RLS ----------------------------------------------------------------------
+
+alter table blog_categories enable row level security;
+alter table blog_category_translations enable row level security;
+alter table blog_tags enable row level security;
+alter table blog_tag_translations enable row level security;
+alter table blog_posts enable row level security;
+alter table blog_post_translations enable row level security;
+alter table blog_post_tags enable row level security;
+
+create policy "blog owner all" on blog_categories for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+create policy "blog owner all" on blog_category_translations for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+create policy "blog owner all" on blog_tags for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+create policy "blog owner all" on blog_tag_translations for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+create policy "blog owner all" on blog_posts for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+create policy "blog owner all" on blog_post_translations for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+create policy "blog owner all" on blog_post_tags for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+
+-- --- Atomic mutation RPCs (SECURITY INVOKER, owner RLS path) ------------------
+
+-- Categories: stable slug id, sort order, EN/VI name.
+create or replace function public.cms_upsert_blog_category(
+  p_id text,
+  p_sort_order integer,
+  p_name_en text,
+  p_name_vi text
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if p_id !~ '^[a-z0-9]+(-[a-z0-9]+)*$' then
+    raise exception 'Invalid category slug "%". Use lowercase letters, numbers, and hyphens.', p_id;
+  end if;
+  if btrim(p_name_en) = '' or btrim(p_name_vi) = '' then
+    raise exception 'Category name is required in both en and vi.';
+  end if;
+
+  insert into public.blog_categories (id, slug, sort_order)
+  values (p_id, p_id, p_sort_order)
+  on conflict (id) do update set
+    slug = excluded.slug,
+    sort_order = excluded.sort_order;
+
+  insert into public.blog_category_translations (category_id, locale, name)
+  values
+    (p_id, 'en', p_name_en),
+    (p_id, 'vi', p_name_vi)
+  on conflict (category_id, locale) do update set
+    name = excluded.name;
+end;
+$$;
+
+-- Category deletion is blocked while referenced by posts (DB restrict + friendly
+-- RPC guard so the owner gets a clear, non-generic error).
+create or replace function public.cms_delete_blog_category(p_id text)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if exists (select 1 from public.blog_posts where category_id = p_id) then
+    raise exception 'Category "%" cannot be deleted while posts reference it.', p_id;
+  end if;
+  delete from public.blog_categories where id = p_id;
+end;
+$$;
+
+-- Tags: stable slug id, EN/VI name.
+create or replace function public.cms_upsert_blog_tag(
+  p_id text,
+  p_name_en text,
+  p_name_vi text
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if p_id !~ '^[a-z0-9]+(-[a-z0-9]+)*$' then
+    raise exception 'Invalid tag slug "%". Use lowercase letters, numbers, and hyphens.', p_id;
+  end if;
+  if btrim(p_name_en) = '' or btrim(p_name_vi) = '' then
+    raise exception 'Tag name is required in both en and vi.';
+  end if;
+
+  insert into public.blog_tags (id, slug)
+  values (p_id, p_id)
+  on conflict (id) do update set
+    slug = excluded.slug;
+
+  insert into public.blog_tag_translations (tag_id, locale, name)
+  values
+    (p_id, 'en', p_name_en),
+    (p_id, 'vi', p_name_vi)
+  on conflict (tag_id, locale) do update set
+    name = excluded.name;
+end;
+$$;
+
+-- Tag deletion is blocked while referenced by posts (owner-operated CMS favors
+-- explicit blocking over silent association cleanup, for auditability).
+create or replace function public.cms_delete_blog_tag(p_id text)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if exists (select 1 from public.blog_post_tags where tag_id = p_id) then
+    raise exception 'Tag "%" cannot be deleted while posts reference it.', p_id;
+  end if;
+  delete from public.blog_tags where id = p_id;
+end;
+$$;
+
+-- Posts: base row + both translations + tag links in one transaction, with the
+-- publish gate and update invariants enforced atomically.
+--
+-- Publish gate: setting status='published' fails unless both en and vi
+-- translations exist with non-empty title, summary, content_md, and a valid
+-- category. The error enumerates exactly which locale/fields are missing so the
+-- admin can surface them field-by-field.
+--
+-- Update invariants:
+--   - status transitions are validated atomically (draft->published gated;
+--     published->draft always allowed);
+--   - a mutation that would empty a required translation of a published post is
+--     rejected (the gate runs whenever the resulting status is 'published'), so
+--     the owner must explicitly unpublish before stripping content;
+--   - slug collisions and category/tag references are validated in the same
+--     transaction.
+--
+-- published_at is stamped on the first successful publish and preserved on all
+-- subsequent edits (including unpublish/republish cycles); it never moves.
+create or replace function public.cms_upsert_blog_post(
+  p_id text,
+  p_slug text,
+  p_category_id text,
+  p_cover_bucket_path text,
+  p_status text,
+  p_tags text[],
+  p_title_en text,
+  p_summary_en text,
+  p_content_md_en text,
+  p_title_vi text,
+  p_summary_vi text,
+  p_content_md_vi text
+)
+returns void
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_published_at timestamptz;
+  v_missing text[] := '{}';
+begin
+  if p_status not in ('draft', 'published') then
+    raise exception 'Invalid status "%". Must be draft or published.', p_status;
+  end if;
+
+  if p_slug !~ '^[a-z0-9]+(-[a-z0-9]+)*$' then
+    raise exception 'Invalid slug "%". Use lowercase letters, numbers, and hyphens.', p_slug;
+  end if;
+
+  -- Existing row context for the update invariants.
+  select published_at into v_published_at
+  from public.blog_posts
+  where id = p_id;
+
+  -- Slug uniqueness across posts (the column is unique; give a clear error).
+  if exists (select 1 from public.blog_posts where slug = p_slug and id <> p_id) then
+    raise exception 'Slug "%" is already in use by another post.', p_slug;
+  end if;
+
+  -- Publish gate: the resulting status is 'published', so every required
+  -- translation field must be present and non-empty in both locales.
+  if p_status = 'published' then
+    if btrim(p_title_en) = '' then v_missing := array_append(v_missing, 'title (en)'); end if;
+    if btrim(p_summary_en) = '' then v_missing := array_append(v_missing, 'summary (en)'); end if;
+    if btrim(p_content_md_en) = '' then v_missing := array_append(v_missing, 'content (en)'); end if;
+    if btrim(p_title_vi) = '' then v_missing := array_append(v_missing, 'title (vi)'); end if;
+    if btrim(p_summary_vi) = '' then v_missing := array_append(v_missing, 'summary (vi)'); end if;
+    if btrim(p_content_md_vi) = '' then v_missing := array_append(v_missing, 'content (vi)'); end if;
+    if array_length(v_missing, 1) > 0 then
+      raise exception 'Cannot publish: missing required translation(s): %', array_to_string(v_missing, ', ');
+    end if;
+
+    if not exists (select 1 from public.blog_categories where id = p_category_id) then
+      raise exception 'Cannot publish: category "%" does not exist.', p_category_id;
+    end if;
+
+    -- First publish stamps published_at; subsequent edits never alter it.
+    v_published_at := coalesce(v_published_at, now());
+  end if;
+
+  -- Base row upsert.
+  insert into public.blog_posts (id, slug, category_id, cover_bucket_path, status, published_at, updated_at)
+  values (p_id, p_slug, p_category_id, p_cover_bucket_path, p_status, v_published_at, now())
+  on conflict (id) do update set
+    slug = excluded.slug,
+    category_id = excluded.category_id,
+    cover_bucket_path = excluded.cover_bucket_path,
+    status = excluded.status,
+    published_at = excluded.published_at,
+    updated_at = now();
+
+  -- Translation upsert (title/summary non-empty CHECKs apply for drafts too).
+  insert into public.blog_post_translations (post_id, locale, title, summary, content_md)
+  values
+    (p_id, 'en', p_title_en, p_summary_en, p_content_md_en),
+    (p_id, 'vi', p_title_vi, p_summary_vi, p_content_md_vi)
+  on conflict (post_id, locale) do update set
+    title = excluded.title,
+    summary = excluded.summary,
+    content_md = excluded.content_md;
+
+  -- Replace tag links atomically; every referenced tag must already exist.
+  if p_tags is not null and array_length(p_tags, 1) > 0
+     and exists (
+       select 1 from unnest(p_tags) t
+       where not exists (select 1 from public.blog_tags where id = t)
+     ) then
+    raise exception 'One or more tag ids do not exist.';
+  end if;
+
+  delete from public.blog_post_tags where post_id = p_id;
+  if p_tags is not null and array_length(p_tags, 1) > 0 then
+    insert into public.blog_post_tags (post_id, tag_id)
+    select p_id, t from unnest(p_tags) t;
+  end if;
+end;
+$$;
+
+create or replace function public.cms_delete_blog_post(p_id text)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from public.blog_posts where id = p_id;
+$$;
+
+revoke all on function public.cms_upsert_blog_category(text, integer, text, text) from public;
+revoke all on function public.cms_delete_blog_category(text) from public;
+revoke all on function public.cms_upsert_blog_tag(text, text, text) from public;
+revoke all on function public.cms_delete_blog_tag(text) from public;
+revoke all on function public.cms_upsert_blog_post(text, text, text, text, text, text[], text, text, text, text, text, text) from public;
+revoke all on function public.cms_delete_blog_post(text) from public;
+
+grant execute on function public.cms_upsert_blog_category(text, integer, text, text) to authenticated, service_role;
+grant execute on function public.cms_delete_blog_category(text) to authenticated, service_role;
+grant execute on function public.cms_upsert_blog_tag(text, text, text) to authenticated, service_role;
+grant execute on function public.cms_delete_blog_tag(text) to authenticated, service_role;
+grant execute on function public.cms_upsert_blog_post(text, text, text, text, text, text[], text, text, text, text, text, text) to authenticated, service_role;
+grant execute on function public.cms_delete_blog_post(text) to authenticated, service_role;
+
+-- --- blog-media Storage bucket -------------------------------------------------
+-- Public bucket for post covers (same convention as project-media/portfolio:
+-- public reads, owner-only writes via private.is_owner()).
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('blog-media', 'blog-media', true, 10485760, array['image/jpeg','image/png','image/webp'])
+on conflict (id) do nothing;
+
+create policy "owner all blog-media objects" on storage.objects
+  for all to authenticated
+  using (bucket_id = 'blog-media' and private.is_owner())
+  with check (bucket_id = 'blog-media' and private.is_owner());
+
+create policy "public read blog-media" on storage.objects
+  for select to anon, authenticated
+  using (bucket_id = 'blog-media');
+
+-- --- Seed ---------------------------------------------------------------------
+-- 3 starter categories (Knowledge, Techniques, Reviews) + demo tag set.
+
+insert into public.blog_categories (id, slug, sort_order) values
+  ('knowledge', 'knowledge', 1),
+  ('techniques', 'techniques', 2),
+  ('reviews', 'reviews', 3)
+on conflict (id) do nothing;
+
+insert into public.blog_category_translations (category_id, locale, name) values
+  ('knowledge', 'en', 'Knowledge'),
+  ('knowledge', 'vi', 'Kiến thức'),
+  ('techniques', 'en', 'Techniques'),
+  ('techniques', 'vi', 'Kỹ thuật'),
+  ('reviews', 'en', 'Reviews'),
+  ('reviews', 'vi', 'Đánh giá')
+on conflict (category_id, locale) do nothing;
+
+insert into public.blog_tags (id, slug) values
+  ('nextjs', 'nextjs'),
+  ('supabase', 'supabase'),
+  ('seo', 'seo'),
+  ('typescript', 'typescript'),
+  ('ai-agents', 'ai-agents'),
+  ('ux', 'ux')
+on conflict (id) do nothing;
+
+insert into public.blog_tag_translations (tag_id, locale, name) values
+  ('nextjs', 'en', 'Next.js'),
+  ('nextjs', 'vi', 'Next.js'),
+  ('supabase', 'en', 'Supabase'),
+  ('supabase', 'vi', 'Supabase'),
+  ('seo', 'en', 'SEO'),
+  ('seo', 'vi', 'SEO'),
+  ('typescript', 'en', 'TypeScript'),
+  ('typescript', 'vi', 'TypeScript'),
+  ('ai-agents', 'en', 'AI Agents'),
+  ('ai-agents', 'vi', 'AI Agent'),
+  ('ux', 'en', 'UX'),
+  ('ux', 'vi', 'UX')
+on conflict (tag_id, locale) do nothing;

--- a/supabase/tests/blog_schema_test.sql
+++ b/supabase/tests/blog_schema_test.sql
@@ -1,0 +1,260 @@
+-- Blog schema verification for Issue #89 (slice 1).
+--
+-- Exercises the atomic-mutation RPCs (publish gate, published_at stamping,
+-- update invariants, slug/tag validation, reference-blocked deletion) and RLS
+-- (owner / non-owner / anonymous), following the same role + JWT claims pattern
+-- as rls_crud_test.sql. The owner auth_uid is read from the seeded admin_owner
+-- row so the test adapts to whichever auth user is the configured single owner.
+
+begin;
+select plan(35);
+
+-- Capture the owner uid, then set claims as the owner.
+select set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', (select auth_uid from public.admin_owner limit 1)::text,
+    'role', 'authenticated'
+  )::text,
+  false
+);
+
+set local role authenticated;
+
+-- --- Seed sanity --------------------------------------------------------------
+select is(
+  (select count(*) from public.blog_categories),
+  3::bigint,
+  'seed: 3 starter categories'
+);
+
+select is(
+  (select count(*) from public.blog_tags),
+  6::bigint,
+  'seed: 6 demo tags'
+);
+
+-- --- Owner RPC creates (categories / tags) ------------------------------------
+select lives_ok(
+  $$ select public.cms_upsert_blog_category('test-cat', 99, 'Test Category', 'Danh mục kiểm thử') $$,
+  'owner can create a blog category via RPC'
+);
+
+select lives_ok(
+  $$ select public.cms_upsert_blog_tag('test-tag', 'Test Tag', 'Thẻ kiểm thử') $$,
+  'owner can create a blog tag via RPC'
+);
+
+-- --- Publish gate: draft path -------------------------------------------------
+select lives_ok(
+  $$ select public.cms_upsert_blog_post('post-a', 'post-a', 'test-cat', null, 'draft', array['test-tag'], 'Title A', 'Summary A', 'Content A', 'Tiêu đề A', 'Tóm tắt A', '') $$,
+  'draft post may keep content_md empty'
+);
+
+select is(
+  (select status from public.blog_posts where id = 'post-a'),
+  'draft',
+  'post-a is draft after create'
+);
+
+select is(
+  (select published_at from public.blog_posts where id = 'post-a'),
+  null,
+  'draft post has null published_at'
+);
+
+-- --- Publish gate: rejections -------------------------------------------------
+select throws_ok(
+  $$ select public.cms_upsert_blog_post('post-b', 'post-b', 'test-cat', null, 'published', null, 'Title B', 'Summary B', 'Content B', 'Tiêu đề B', 'Tóm tắt B', '') $$,
+  null,
+  'Cannot publish: missing required translation(s): content (vi)',
+  'publish gate rejects empty vi content'
+);
+
+select throws_ok(
+  $$ select public.cms_upsert_blog_post('post-c', 'post-c', 'test-cat', null, 'published', null, 'Title C', 'Summary C', 'Content C', '', 'Tóm tắt C', 'Nội dung C') $$,
+  null,
+  'Cannot publish: missing required translation(s): title (vi)',
+  'publish gate rejects empty vi title'
+);
+
+select throws_ok(
+  $$ select public.cms_upsert_blog_post('post-d', 'post-d', 'does-not-exist', null, 'published', null, 'T', 'S', 'C', 'T', 'S', 'C') $$,
+  null,
+  'Cannot publish: category "does-not-exist" does not exist.',
+  'publish gate rejects unknown category'
+);
+
+select throws_ok(
+  $$ select public.cms_upsert_blog_post('post-e', 'post-e', 'test-cat', null, 'live', null, 'T', 'S', 'C', 'T', 'S', 'C') $$,
+  null,
+  'Invalid status "live". Must be draft or published.',
+  'invalid status is rejected'
+);
+
+select throws_ok(
+  $$ select public.cms_upsert_blog_post('post-f', 'Bad Slug!', 'test-cat', null, 'draft', null, 'T', 'S', 'C', 'T', 'S', 'C') $$,
+  null,
+  'Invalid slug "Bad Slug!". Use lowercase letters, numbers, and hyphens.',
+  'invalid slug format is rejected'
+);
+
+select throws_ok(
+  $$ select public.cms_upsert_blog_post('post-g', 'post-g', 'test-cat', null, 'draft', array['nope'], 'T', 'S', 'C', 'T', 'S', 'C') $$,
+  null,
+  'One or more tag ids do not exist.',
+  'unknown tag id is rejected'
+);
+
+-- --- Publish lifecycle ---------------------------------------------------------
+select lives_ok(
+  $$ select public.cms_upsert_blog_post('post-a', 'post-a', 'test-cat', null, 'published', array['test-tag'], 'Title A', 'Summary A', 'Content A', 'Tiêu đề A', 'Tóm tắt A', 'Nội dung A') $$,
+  'publishing a complete post succeeds'
+);
+
+select isnt(
+  (select published_at from public.blog_posts where id = 'post-a'),
+  null,
+  'first publish stamps published_at'
+);
+
+-- Capture published_at before the edit round.
+create temp table _cap as
+  select published_at from public.blog_posts where id = 'post-a';
+
+select lives_ok(
+  $$ select public.cms_upsert_blog_post('post-a', 'post-a', 'test-cat', null, 'published', array['test-tag'], 'Title A v2', 'Summary A', 'Content A', 'Tiêu đề A', 'Tóm tắt A', 'Nội dung A') $$,
+  'editing a published post (kept published) succeeds'
+);
+
+select is(
+  (select published_at from public.blog_posts where id = 'post-a'),
+  (select published_at from _cap),
+  'editing a published post does not alter published_at'
+);
+
+select lives_ok(
+  $$ select public.cms_upsert_blog_post('post-a', 'post-a', 'test-cat', null, 'draft', array['test-tag'], 'Title A', 'Summary A', 'Content A', 'Tiêu đề A', 'Tóm tắt A', 'Nội dung A') $$,
+  'unpublishing a published post is always allowed'
+);
+
+select is(
+  (select status from public.blog_posts where id = 'post-a'),
+  'draft',
+  'post-a is draft after unpublish'
+);
+
+select lives_ok(
+  $$ select public.cms_upsert_blog_post('post-a', 'post-a', 'test-cat', null, 'published', array['test-tag'], 'Title A', 'Summary A', 'Content A', 'Tiêu đề A', 'Tóm tắt A', 'Nội dung A') $$,
+  're-publishing a post succeeds'
+);
+
+select is(
+  (select published_at from public.blog_posts where id = 'post-a'),
+  (select published_at from _cap),
+  're-publish preserves the original published_at'
+);
+
+select is(
+  (select count(*) from public.blog_post_tags where post_id = 'post-a'),
+  1::bigint,
+  'post tag links are written'
+);
+
+-- --- Slug / reference validation ----------------------------------------------
+select throws_ok(
+  $$ select public.cms_upsert_blog_post('post-h', 'post-a', 'test-cat', null, 'draft', null, 'T', 'S', 'C', 'T', 'S', 'C') $$,
+  null,
+  'Slug "post-a" is already in use by another post.',
+  'slug collision across posts is rejected'
+);
+
+select throws_ok(
+  $$ select public.cms_delete_blog_category('test-cat') $$,
+  null,
+  'Category "test-cat" cannot be deleted while posts reference it.',
+  'deleting a referenced category is blocked'
+);
+
+select throws_ok(
+  $$ select public.cms_delete_blog_tag('test-tag') $$,
+  null,
+  'Tag "test-tag" cannot be deleted while posts reference it.',
+  'deleting a referenced tag is blocked'
+);
+
+-- --- Owner direct INSERT (RLS with-check) -------------------------------------
+select lives_ok(
+  $$ insert into public.blog_tags (id, slug) values ('owner-direct', 'owner-direct') $$,
+  'owner can INSERT directly into blog_tags'
+);
+
+-- --- Cleanup via RPC, then unreferenced deletes --------------------------------
+select lives_ok(
+  $$ select public.cms_delete_blog_post('post-a') $$,
+  'owner can delete a post via RPC'
+);
+
+select lives_ok(
+  $$ select public.cms_delete_blog_category('test-cat') $$,
+  'deleting an unreferenced category succeeds'
+);
+
+select lives_ok(
+  $$ select public.cms_delete_blog_tag('test-tag') $$,
+  'deleting an unreferenced tag succeeds'
+);
+
+select lives_ok(
+  $$ delete from public.blog_tags where id = 'owner-direct' $$,
+  'owner can DELETE blog_tags directly'
+);
+
+select is(
+  (select count(*) from public.blog_categories),
+  3::bigint,
+  'owner can SELECT blog_categories (seeds remain)'
+);
+
+-- --- Non-owner authenticated: denied by RLS (owner-only policy) ----------------
+reset role;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  json_build_object('sub', 'ffffffff-ffff-ffff-ffff-ffffffffffff', 'role', 'authenticated')::text,
+  true
+);
+
+select is(
+  (select count(*) from public.blog_posts),
+  0::bigint,
+  'non-owner sees zero blog_posts rows (RLS filters)'
+);
+
+select is(
+  (select count(*) from public.blog_categories),
+  0::bigint,
+  'non-owner sees zero blog_categories rows (RLS filters)'
+);
+
+select throws_ok(
+  $$ insert into public.blog_tags (id, slug) values ('intruder', 'intruder') $$,
+  null,
+  null,
+  'non-owner cannot INSERT into blog_tags (RLS with-check)'
+);
+
+-- --- Anonymous: denied (zero privileges, deny-by-default) ----------------------
+reset role;
+set local role anon;
+select set_config('request.jwt.claims', '{}', true);
+
+select throws_ok(
+  $$ select * from public.blog_posts $$,
+  null,
+  'permission denied for table blog_posts',
+  'anonymous cannot SELECT blog_posts'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Slice 1 of the blog subsystem (spec `docs/superpowers/specs/2026-08-25-blog-design.md`, §3 + §12.1). Adds the full Supabase schema foundation behind a CMS-managed bilingual blog:

- **Tables** — `blog_categories`, `blog_tags`, `blog_posts` (+ `_translations` children, `blog_post_tags`), with DB-enforced constraints: locale CHECK, non-empty CHECKs on `title`/`summary`/`name`, normalized-slug regex + uniqueness, composite PKs, supporting indexes for `(status, published_at DESC)` and `category_id`.
- **Stable text ids** — follows the post-conversion convention (projects/resume/skills/social), not UUIDs. Categories/tags use `id = slug` (like `resume_categories`); posts keep an id independent of an editable slug (like `projects`), so a published slug change is a URL migration, not an id change. This deviates from the spec's "UUID ids" wording; documented in the migration header.
- **RLS** — anon = zero privileges (hardening #66); authenticated owner via `private.is_owner()`; service_role for the server read/write path. Public `status='published'` filtering is enforced in the repository adapter (slice 2), matching resume publicity's fail-closed philosophy rather than exposing a table-level anon read path.
- **Atomic SECURITY INVOKER RPCs** (granted to `authenticated, service_role`):
  - `cms_upsert_blog_category` / `cms_delete_blog_category` (deletion blocked while referenced)
  - `cms_upsert_blog_tag` / `cms_delete_blog_tag` (deletion blocked while referenced)
  - `cms_upsert_blog_post` / `cms_delete_blog_post`
- **Publish gate + update invariants inside the RPC** (never app-layer only): `draft→published` requires complete `en`+`vi` `title`/`summary`/`content_md` and a valid category, with a field-by-field error; `published→draft` always allowed; emptying a required translation of a published post is rejected (must unpublish first); `published_at` stamped once and preserved across edits/unpublish-republish; slug collisions and category/tag references validated in the same transaction.
- **`blog-media` Storage bucket** — public reads, owner-only writes (same convention as `project-media`).
- **Seed** — 3 starter categories (Knowledge / Techniques / Reviews) + 6 demo tags, bilingual.

## Acceptance criteria

- [x] Blog tables + `_translations` with DB-enforced constraints (locale, non-empty, slug regex, composite PKs)
- [x] RLS: owner-only writes via `private.is_owner()`; anon zero privileges; service_role server path
- [x] Atomic-mutation RPCs (base row + translations + tag links in one transaction)
- [x] Publish gate rejects incomplete/published posts field-by-field; `published_at` stamped once
- [x] Category/tag deletion blocked while referenced
- [x] Local-first: migration + seed applied and verified on the local stack only (no `--linked` promotion)
- [x] `docs/03-content-data-model.md` updated with blog entities
- [x] pgTAP tests for RLS + RPC invariants

## Verification

- `npm run test:rls` — PASS (48 tests: 35 new blog + 13 existing RLS)
- `npm run test:db` — PASS (2/2, with `.env.local` env)
- `npm run test:cms` — PASS (5/5, 1 pre-existing skip)
- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm run build -- --webpack` — PASS
- Local row counts verified identical to linked prod for all 16 content tables after the local `db reset` required to apply the migration cleanly.

## Screenshots

N/A — schema/test/docs change.

## Risks / follow-ups

- The local `supabase db reset` (needed to replay the edited migration) wiped local content + the local `admin_owner` row. Content was restored from linked prod via the documented mirror-back procedure (row counts verified). The local `admin_owner` row was restored to a placeholder uid — run `npm run seed:admin` (with your local `ADMIN_EMAIL`/`ADMIN_PASSWORD`) to restore the real local admin login.
- `content_md` is NOT NULL but permits empty string for drafts; the publish gate enforces non-empty content. This matches the spec's constraint list (non-empty CHECKs named only `title`/`summary`/`name`).
- The backfill script (`scripts/backfill-content.mjs`) fails on the newer grouped-skills structure — pre-existing, out of scope.