### PR TITLE
feat: blog feature layer - repository adapter, markdown pipeline, deterministic reading time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,19 @@
       "dependencies": {
         "@supabase/ssr": "^0.12.4",
         "@supabase/supabase-js": "^2.112.3",
+        "hast-util-to-string": "^3.0.1",
         "next": "16.3.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "server-only": "^0.0.1"
+        "rehype-highlight": "^7.0.2",
+        "rehype-slug": "^6.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "server-only": "^0.0.1",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2240,12 +2249,30 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2259,6 +2286,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2290,6 +2332,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.67.0",
@@ -2585,6 +2633,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.12.2",
@@ -3226,6 +3280,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3383,6 +3447,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3398,6 +3472,36 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/client-only": {
@@ -3425,6 +3529,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3540,7 +3654,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3552,6 +3665,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -3597,6 +3723,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3605,6 +3740,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -4333,6 +4481,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4623,6 +4777,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4780,6 +4940,97 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4795,6 +5046,25 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.2.tgz",
+      "integrity": "sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/iceberg-js": {
@@ -5142,6 +5412,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -5764,6 +6046,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5775,6 +6067,21 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -5797,6 +6104,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5805,6 +6122,228 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -5816,6 +6355,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5858,7 +6960,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6324,6 +7425,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6425,6 +7536,121 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -6803,6 +8029,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6936,6 +8172,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-bom": {
@@ -7090,6 +8340,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7311,6 +8581,107 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -7388,6 +8759,34 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/which": {
@@ -7546,6 +8945,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,21 +11,30 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
+    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/features/blog/reading-time.test.ts src/features/blog/markdown.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
     "preflight": "tsx scripts/preflight-cutover.ts",
     "seed:admin": "node scripts/seed-admin.mjs",
     "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",
     "test:db": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node --test scripts/db-invariants.test.mjs",
-    "test:cms": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} tsx --test src/features/cms/repository.test.ts",
+    "test:cms": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} tsx --test src/features/cms/repository.test.ts src/features/blog/repository.test.ts",
     "test:rls": "supabase db test --local supabase/tests"
   },
   "dependencies": {
     "@supabase/ssr": "^0.12.4",
     "@supabase/supabase-js": "^2.112.3",
+    "hast-util-to-string": "^3.0.1",
     "next": "16.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "server-only": "^0.0.1"
+    "rehype-highlight": "^7.0.2",
+    "rehype-slug": "^6.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "server-only": "^0.0.1",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/features/blog/markdown.test.ts
+++ b/src/features/blog/markdown.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { renderMarkdown } from "./markdown";
+
+test("renders headings with ids and extracts an h2/h3 toc", async () => {
+  const { html, toc, headingCount } = await renderMarkdown(
+    [
+      "# Title",
+      "## Section one",
+      "### Sub section",
+      "## Section two",
+      "#### Ignored h4",
+    ].join("\n"),
+  );
+
+  assert.ok(html.includes("<h2 id=\"section-one\">"), "h2 carries a slug id");
+  assert.ok(html.includes("<h3 id=\"sub-section\">"), "h3 carries a slug id");
+  assert.ok(html.includes("<h4"), "h4 is still rendered");
+  assert.deepEqual(toc, [
+    { id: "section-one", text: "Section one", depth: 2 },
+    { id: "sub-section", text: "Sub section", depth: 3 },
+    { id: "section-two", text: "Section two", depth: 2 },
+  ]);
+  assert.equal(headingCount, 3);
+});
+
+test("GFM tables render as html tables", async () => {
+  const { html } = await renderMarkdown(["| a | b |", "|---|---|", "| 1 | 2 |"].join("\n"));
+  assert.ok(html.includes("<table>"), "table element present");
+  assert.ok(html.includes("<td>"), "cell present");
+});
+
+test("fenced code blocks are syntax-highlighted with token classes", async () => {
+  const { html } = await renderMarkdown(["```ts", "const x = 1", "```"].join("\n"));
+  assert.ok(html.includes("<code class=\"hljs language-ts\">"), "hljs classes applied");
+});
+
+test("raw html passthrough is disabled (xss-safe by construction)", async () => {
+  const { html } = await renderMarkdown('<script>alert(1)</script>\n\n# Safe heading');
+  assert.ok(!html.includes("<script"), "no script element in output");
+  assert.ok(!html.includes("<alert"), "no raw html");
+});
+
+test("malformed markdown degrades to plain rendering without throwing", async () => {
+  const { html } = await renderMarkdown([
+    "| broken | table",
+    "<b>raw</b>",
+    "### Heading still ok",
+    "[unclosed link",
+    "```ts",
+    "unclosed fence",
+  ].join("\n"));
+  assert.ok(html.includes("<h3"), "heading still rendered");
+  assert.ok(!html.includes("<b>raw"), "raw html stays inert");
+  assert.equal(typeof html, "string");
+});
+
+test("empty markdown renders empty output with no toc", async () => {
+  const { html, toc, headingCount } = await renderMarkdown("");
+  assert.equal(html.trim(), "");
+  assert.deepEqual(toc, []);
+  assert.equal(headingCount, 0);
+});
+
+test("duplicate headings get distinct slug ids in the toc", async () => {
+  const { toc } = await renderMarkdown(["## Repeat", "## Repeat"].join("\n"));
+  assert.notEqual(toc[0]?.id, toc[1]?.id, "slugs are de-duplicated");
+  assert.equal(toc[0]?.id, "repeat");
+  assert.equal(toc[1]?.id, "repeat-1");
+});

--- a/src/features/blog/markdown.ts
+++ b/src/features/blog/markdown.ts
@@ -1,0 +1,66 @@
+/**
+ * Server-side Markdown pipeline (blog design spec §5).
+ *
+ * One remark/rehype pipeline shared verbatim by public article pages and the
+ * admin Preview:
+ *   - GFM (tables, task lists, strikethrough, autolinks)
+ *   - heading slugs restricted to h2/h3 for TOC extraction
+ *   - syntax highlighting for fenced code blocks (token classes; the per-theme
+ *     palettes are a CSS concern applied in the UI slice)
+ *   - raw HTML passthrough is disabled by construction (remark-rehype without
+ *     `allowDangerousHtml`), so authoring stays pure Markdown and the output is
+ *     XSS-safe without a separate sanitizer
+ *   - output: sanitized HTML string + `{ toc, headingCount }` metadata
+ *
+ * Malformed Markdown degrades to plain rendering, never a thrown error.
+ */
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeSlug from "rehype-slug";
+import rehypeHighlight from "rehype-highlight";
+import rehypeStringify from "rehype-stringify";
+import { visit } from "unist-util-visit";
+import { toString } from "hast-util-to-string";
+
+import type { TocEntry } from "./types";
+
+export interface MarkdownResult {
+  html: string;
+  toc: TocEntry[];
+  headingCount: number;
+}
+
+/** Rehype transformer: collect h2/h3 headings (after `rehype-slug` assigns ids). */
+function collectToc(tree: import("hast").Root): TocEntry[] {
+  const toc: TocEntry[] = [];
+  visit(tree, "element", (node) => {
+    if (node.tagName !== "h2" && node.tagName !== "h3") return;
+    const id = node.properties?.id;
+    if (typeof id === "string") {
+      toc.push({
+        id,
+        text: toString(node),
+        depth: node.tagName === "h2" ? 2 : 3,
+      });
+    }
+  });
+  return toc;
+}
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype, { allowDangerousHtml: false })
+  .use(rehypeSlug)
+  .use(rehypeHighlight)
+  .use(rehypeStringify);
+
+export async function renderMarkdown(markdown: string): Promise<MarkdownResult> {
+  const tree = processor.runSync(processor.parse(markdown));
+
+  const toc = collectToc(tree);
+  const html = processor.stringify(tree);
+  return { html, toc, headingCount: toc.length };
+}

--- a/src/features/blog/reading-time.test.ts
+++ b/src/features/blog/reading-time.test.ts
@@ -73,10 +73,8 @@ test("hyphenated tokens count as one word", () => {
   assert.equal(readingTimeMinutes("state-of-the-art design"), 1);
 });
 
-test("unterminated fence degrades to prose, never throws", () => {
-  const md = ["```ts", "not really closed", ...words(400).split("\n")].join("\n");
-  // unterminated fence: everything after the opener counts as prose
-  const minutes = readingTimeMinutes(md);
-  assert.equal(typeof minutes, "number");
-  assert.ok(minutes >= 1);
+test("unterminated fence degrades to prose and is never counted as a code block", () => {
+  const md = ["```ts", "code line one", "code line two", ...words(200).split("\n")].join("\n");
+  // 3 + 3 + 200 = 206 prose words, no code block -> ceil(206/200) = 2
+  assert.equal(readingTimeMinutes(md), 2);
 });

--- a/src/features/blog/reading-time.test.ts
+++ b/src/features/blog/reading-time.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { readingTimeMinutes } from "./reading-time";
+
+function words(count: number): string {
+  return Array.from({ length: count }, (_, i) => `w${i}`).join(" ");
+}
+
+test("plain prose: 200 words rounds up to 1 minute", () => {
+  assert.equal(readingTimeMinutes(words(200)), 1);
+});
+
+test("plain prose: 400 words is 2 minutes", () => {
+  assert.equal(readingTimeMinutes(words(400)), 2);
+});
+
+test("plain prose: 401 words rounds up to 3 minutes", () => {
+  assert.equal(readingTimeMinutes(words(401)), 3);
+});
+
+test("empty string is minimum 1 minute", () => {
+  assert.equal(readingTimeMinutes(""), 1);
+});
+
+test("each fenced code block contributes a fixed 60 words", () => {
+  const md = [
+    "Intro text.",
+    "```ts",
+    "const x = 1;",
+    "const y = 2;",
+    "```",
+    ...words(400).split("\n"),
+  ].join("\n");
+  // 2 prose words + 60 code words + 400 = 462 -> ceil(462/200) = 3
+  assert.equal(readingTimeMinutes(md), 3);
+});
+
+test("fence content is stripped from the prose count", () => {
+  // 1000 words inside a fence must not count as prose.
+  const md = ["```", ...Array.from({ length: 1000 }, () => "x").join("\n").split("\n"), "```"].join("\n");
+  // 0 prose + 60 code words -> 1 minute (min)
+  assert.equal(readingTimeMinutes(md), 1);
+});
+
+test("tildes also fence code blocks", () => {
+  const md = ["~~~", "const x = 1", "~~~", ...words(200).split("\n")].join("\n");
+  // 200 prose + 60 code = 260 -> ceil = 2
+  assert.equal(readingTimeMinutes(md), 2);
+});
+
+test("markdown punctuation markers are removed before counting", () => {
+  const md = [
+    "# Heading words",
+    "- list item words",
+    "> blockquote words",
+    "| a | b |",
+    "**bold** words",
+    "_emphasis_ words",
+    "---",
+  ].join("\n");
+  // heading(2) + list(3) + quote(2) + table(2) + bold(2) + emphasis(2) + 0 = 13
+  assert.equal(readingTimeMinutes(md), 1);
+});
+
+test("Vietnamese counts by whitespace-separated syllable groups", () => {
+  assert.equal(readingTimeMinutes("Xin chào thế giới"), 1);
+  assert.equal(readingTimeMinutes(words(200) + " xin chào thế giới"), 2);
+});
+
+test("hyphenated tokens count as one word", () => {
+  // 'state-of-the-art' -> markers removed -> one whitespace run
+  assert.equal(readingTimeMinutes("state-of-the-art design"), 1);
+});
+
+test("unterminated fence degrades to prose, never throws", () => {
+  const md = ["```ts", "not really closed", ...words(400).split("\n")].join("\n");
+  // unterminated fence: everything after the opener counts as prose
+  const minutes = readingTimeMinutes(md);
+  assert.equal(typeof minutes, "number");
+  assert.ok(minutes >= 1);
+});

--- a/src/features/blog/reading-time.ts
+++ b/src/features/blog/reading-time.ts
@@ -3,8 +3,10 @@
  *
  * The algorithm is a contract — implementation and tests must agree exactly:
  *
- *   1. strip fenced code blocks (``` and ~~~ fences) from the source first;
- *      each removed block contributes a fixed 60 "words";
+ *   1. strip properly-terminated fenced code blocks (``` and ~~~ fences) from
+ *      the source; each removed block contributes a fixed 60 "words". An
+ *      unterminated opening fence degrades to prose and is never counted as a
+ *      code block;
  *   2. in the remaining prose, count words as maximal whitespace-separated runs
  *      after removing Markdown punctuation markers (`#`, `*`, `_`, `>`, `-`,
  *      and table pipes `|`);
@@ -17,9 +19,15 @@
 
 const PUNCTUATION_MARKERS = /[#*_>\-|]/g;
 
+function countProseWords(trimmed: string): number {
+  const cleaned = trimmed.replace(PUNCTUATION_MARKERS, " ").trim();
+  if (cleaned === "") return 0;
+  return cleaned.split(/\s+/).length;
+}
+
 /**
  * Compute the reading time in minutes from the raw Markdown source. Never
- * throws on malformed input; malformed fences degrade to prose.
+ * throws on malformed input; an unterminated fence degrades to prose.
  */
 export function readingTimeMinutes(markdown: string): number {
   const lines = markdown.split(/\r?\n/);
@@ -28,6 +36,7 @@ export function readingTimeMinutes(markdown: string): number {
   let codeBlocks = 0;
   let inFence = false;
   let fenceChar = "";
+  let fenceLines: string[] = [];
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -37,18 +46,28 @@ export function readingTimeMinutes(markdown: string): number {
       if (!inFence) {
         inFence = true;
         fenceChar = fenceMatch[1][0];
-        codeBlocks += 1;
+        fenceLines = [];
       } else if (fenceMatch[1][0] === fenceChar) {
         inFence = false;
+        codeBlocks += 1;
+        fenceLines = [];
+      } else {
+        fenceLines.push(trimmed);
       }
       continue;
     }
 
-    if (inFence) continue;
+    if (inFence) {
+      fenceLines.push(trimmed);
+      continue;
+    }
 
-    const cleaned = trimmed.replace(PUNCTUATION_MARKERS, " ").trim();
-    if (cleaned === "") continue;
-    proseWords += cleaned.split(/\s+/).length;
+    proseWords += countProseWords(trimmed);
+  }
+
+  // EOF with an open fence: not a valid code block — degrade its content to prose.
+  for (const line of fenceLines) {
+    proseWords += countProseWords(line);
   }
 
   const totalWords = proseWords + 60 * codeBlocks;

--- a/src/features/blog/reading-time.ts
+++ b/src/features/blog/reading-time.ts
@@ -1,0 +1,56 @@
+/**
+ * Deterministic reading time (blog design spec §5).
+ *
+ * The algorithm is a contract — implementation and tests must agree exactly:
+ *
+ *   1. strip fenced code blocks (``` and ~~~ fences) from the source first;
+ *      each removed block contributes a fixed 60 "words";
+ *   2. in the remaining prose, count words as maximal whitespace-separated runs
+ *      after removing Markdown punctuation markers (`#`, `*`, `_`, `>`, `-`,
+ *      and table pipes `|`);
+ *   3. total = (proseWords + 60 × codeBlocks) / 200, rounded up, minimum 1.
+ *
+ * Whitespace-splitting handles Vietnamese correctly (spaces delimit syllable
+ * groups). Reading time is always computed at render from `content_md` and is
+ * never stored.
+ */
+
+const PUNCTUATION_MARKERS = /[#*_>\-|]/g;
+
+/**
+ * Compute the reading time in minutes from the raw Markdown source. Never
+ * throws on malformed input; malformed fences degrade to prose.
+ */
+export function readingTimeMinutes(markdown: string): number {
+  const lines = markdown.split(/\r?\n/);
+
+  let proseWords = 0;
+  let codeBlocks = 0;
+  let inFence = false;
+  let fenceChar = "";
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const fenceMatch = /^(`{3,}|~{3,})/.exec(trimmed);
+
+    if (fenceMatch) {
+      if (!inFence) {
+        inFence = true;
+        fenceChar = fenceMatch[1][0];
+        codeBlocks += 1;
+      } else if (fenceMatch[1][0] === fenceChar) {
+        inFence = false;
+      }
+      continue;
+    }
+
+    if (inFence) continue;
+
+    const cleaned = trimmed.replace(PUNCTUATION_MARKERS, " ").trim();
+    if (cleaned === "") continue;
+    proseWords += cleaned.split(/\s+/).length;
+  }
+
+  const totalWords = proseWords + 60 * codeBlocks;
+  return Math.max(1, Math.ceil(totalWords / 200));
+}

--- a/src/features/blog/repository.test.ts
+++ b/src/features/blog/repository.test.ts
@@ -219,6 +219,39 @@ test("a published post missing the requested locale translation is not renderabl
   }
 });
 
+test("a published post with no tags still gets recency-based related posts", async () => {
+  await client.from("blog_posts").upsert(
+    {
+      id: "post-nolink",
+      slug: "post-nolink",
+      category_id: "reviews",
+      status: "published",
+      published_at: "2026-01-05T00:00:00Z",
+      updated_at: "2026-01-05T00:00:00Z",
+    },
+    { onConflict: "id" },
+  );
+  await client.from("blog_post_translations").upsert(
+    [
+      { post_id: "post-nolink", locale: "en", title: "NoLink EN", summary: "NoLink summary", content_md: "# NoLink\n" },
+      { post_id: "post-nolink", locale: "vi", title: "NoLink VI", summary: "NoLink summary VI", content_md: "# NoLink VI\n" },
+    ],
+    { onConflict: "post_id,locale" },
+  );
+
+  try {
+    const post = await queryPostBySlug("en", "post-nolink");
+    assert.ok(post, "tagless published post resolves");
+    assert.deepEqual(
+      post.relatedPosts.map((p) => p.slug),
+      [POSTS.alpha, POSTS.gamma, POSTS.delta],
+      "no-tag post falls back to the 3 most recent published posts",
+    );
+  } finally {
+    await client.from("blog_posts").delete().eq("id", "post-nolink");
+  }
+});
+
 test("category page returns header + only that category's published posts", async () => {
   const category = await queryCategoryPage("en", "knowledge", 1);
   assert.ok(category, "known category resolves");

--- a/src/features/blog/repository.test.ts
+++ b/src/features/blog/repository.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Hard local-only guard: this test mutates CMS data and MUST never run against a
+// cloud/production project (same pattern as cms/repository.test.ts).
+if (!url || !serviceRole) {
+  console.error(
+    "Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (local Supabase).",
+  );
+  process.exit(1);
+}
+
+const LOCAL_HOST = /^http:\/\/127\.0\.0\.1(?::\d+)?$/;
+if (!LOCAL_HOST.test(url)) {
+  console.error(
+    `Refusing to run blog repository test against non-local Supabase: ${url}`,
+  );
+  process.exit(1);
+}
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  queryCategoryPage,
+  queryPostBySlug,
+  queryPublishedPosts,
+} from "./repository";
+
+const client = createClient(url, serviceRole, {
+  auth: { persistSession: false },
+});
+
+const EN_MD = [
+  "# Alpha",
+  "",
+  "Intro paragraph.",
+  "",
+  "## Section one",
+  "",
+  "### Sub section",
+  "",
+  "```ts",
+  "const x = 1",
+  "```",
+].join("\n");
+
+const VI_MD = ["# Alpha VI", "", "Đoạn giới thiệu.", "", "## Phần một", ""].join("\n");
+
+const POSTS = {
+  alpha: "post-alpha",
+  beta: "post-beta",
+  gamma: "post-gamma",
+  delta: "post-delta",
+};
+
+async function insertFixture() {
+  await client.from("blog_posts").upsert(
+    [
+      {
+        id: POSTS.alpha,
+        slug: "post-alpha",
+        category_id: "knowledge",
+        cover_bucket_path: "covers/alpha.png",
+        status: "published",
+        published_at: "2026-01-03T00:00:00Z",
+        updated_at: "2026-01-03T00:00:00Z",
+      },
+      {
+        id: POSTS.beta,
+        slug: "post-beta",
+        category_id: "techniques",
+        status: "draft",
+        published_at: null,
+        updated_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: POSTS.gamma,
+        slug: "post-gamma",
+        category_id: "knowledge",
+        status: "published",
+        published_at: "2026-01-02T00:00:00Z",
+        updated_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: POSTS.delta,
+        slug: "post-delta",
+        category_id: "reviews",
+        status: "published",
+        published_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+    { onConflict: "id" },
+  );
+
+  await client.from("blog_post_translations").upsert(
+    [
+      { post_id: POSTS.alpha, locale: "en", title: "Alpha EN", summary: "Alpha summary EN", content_md: EN_MD },
+      { post_id: POSTS.alpha, locale: "vi", title: "Alpha VI", summary: "Alpha summary VI", content_md: VI_MD },
+      { post_id: POSTS.beta, locale: "en", title: "Beta EN", summary: "Beta summary", content_md: "# Beta\n" },
+      { post_id: POSTS.beta, locale: "vi", title: "Beta VI", summary: "Beta summary VI", content_md: "# Beta VI\n" },
+      { post_id: POSTS.gamma, locale: "en", title: "Gamma EN", summary: "Gamma summary", content_md: "# Gamma\n" },
+      { post_id: POSTS.gamma, locale: "vi", title: "Gamma VI", summary: "Gamma summary VI", content_md: "# Gamma VI\n" },
+      { post_id: POSTS.delta, locale: "en", title: "Delta EN", summary: "Delta summary", content_md: "# Delta\n" },
+      { post_id: POSTS.delta, locale: "vi", title: "Delta VI", summary: "Delta summary VI", content_md: "# Delta VI\n" },
+    ],
+    { onConflict: "post_id,locale" },
+  );
+
+  await client.from("blog_post_tags").upsert(
+    [
+      { post_id: POSTS.alpha, tag_id: "nextjs" },
+      { post_id: POSTS.alpha, tag_id: "seo" },
+      { post_id: POSTS.gamma, tag_id: "seo" },
+      { post_id: POSTS.delta, tag_id: "ux" },
+    ],
+    { onConflict: "post_id,tag_id" },
+  );
+}
+
+async function cleanupFixture() {
+  for (const id of Object.values(POSTS)) {
+    await client.from("blog_posts").delete().eq("id", id);
+  }
+  await client.from("blog_posts").delete().eq("id", "post-solo");
+}
+
+before(insertFixture);
+after(cleanupFixture);
+
+test("published listing maps rows to view models in the requested locale", async () => {
+  const en = await queryPublishedPosts("en", 1);
+  assert.deepEqual(
+    en.posts.map((p) => p.slug),
+    [POSTS.alpha, POSTS.gamma, POSTS.delta],
+    "published-only, ordered by published_at desc",
+  );
+  assert.equal(en.posts[0]?.title, "Alpha EN");
+  assert.equal(en.posts[0]?.category.name, "Knowledge");
+  assert.ok(en.posts[0]?.coverImage, "cover maps to a ManagedImage");
+  assert.equal(en.posts[0]?.coverImage?.width, 800);
+  assert.ok(en.posts[0]?.coverImage?.src.includes("/blog-media/"));
+  assert.ok(
+    (en.posts[0]?.readingTimeMinutes ?? 0) > 0,
+    "reading time is computed from content_md",
+  );
+  assert.equal(en.totalPages, 1);
+
+  const vi = await queryPublishedPosts("vi", 1);
+  assert.equal(vi.posts[0]?.title, "Alpha VI");
+  assert.equal(vi.posts[0]?.category.name, "Kiến thức");
+
+  const draftSlugs = en.posts.map((p) => p.slug);
+  assert.ok(!draftSlugs.includes(POSTS.beta), "draft post is excluded");
+});
+
+test("out-of-range listing page resolves to an empty page", async () => {
+  const page2 = await queryPublishedPosts("en", 2);
+  assert.deepEqual(page2.posts, []);
+  assert.equal(page2.totalPages, 1);
+});
+
+test("detail maps post, rendered html, toc, tags, and related posts", async () => {
+  const post = await queryPostBySlug("en", "post-alpha");
+  assert.ok(post, "published post resolves");
+  assert.equal(post.title, "Alpha EN");
+  assert.ok(post.html.includes('<h2 id="section-one">'), "markdown rendered");
+  assert.ok(post.html.includes("hljs"), "code block highlighted");
+  assert.ok(
+    post.toc.some((e) => e.id === "section-one" && e.depth === 2),
+    "toc includes h2",
+  );
+  assert.deepEqual(
+    post.tags.map((t) => t.slug),
+    ["nextjs", "seo"],
+  );
+  assert.deepEqual(
+    post.relatedPosts.map((p) => p.slug),
+    [POSTS.gamma, POSTS.delta],
+    "related posts ranked by shared tags, then recency",
+  );
+});
+
+test("unpublished or unknown slugs resolve to null (404-safe)", async () => {
+  assert.equal(await queryPostBySlug("en", "post-beta"), null, "draft post is not public");
+  assert.equal(await queryPostBySlug("en", "does-not-exist"), null);
+});
+
+test("a published post missing the requested locale translation is not renderable", async () => {
+  await client.from("blog_posts").upsert(
+    {
+      id: "post-solo",
+      slug: "post-solo",
+      category_id: "knowledge",
+      status: "published",
+      published_at: "2026-01-04T00:00:00Z",
+      updated_at: "2026-01-04T00:00:00Z",
+    },
+    { onConflict: "id" },
+  );
+  await client.from("blog_post_translations").upsert(
+    {
+      post_id: "post-solo",
+      locale: "en",
+      title: "Solo EN",
+      summary: "Solo summary",
+      content_md: "# Solo\n",
+    },
+    { onConflict: "post_id,locale" },
+  );
+
+  try {
+    assert.equal(await queryPostBySlug("vi", "post-solo"), null, "missing vi translation -> null");
+    assert.ok(await queryPostBySlug("en", "post-solo"), "en translation still renders");
+  } finally {
+    await client.from("blog_posts").delete().eq("id", "post-solo");
+  }
+});
+
+test("category page returns header + only that category's published posts", async () => {
+  const category = await queryCategoryPage("en", "knowledge", 1);
+  assert.ok(category, "known category resolves");
+  assert.equal(category.name, "Knowledge");
+  assert.deepEqual(
+    category.listing.posts.map((p) => p.slug),
+    [POSTS.alpha, POSTS.gamma],
+  );
+
+  const vi = await queryCategoryPage("vi", "knowledge", 1);
+  assert.equal(vi?.name, "Kiến thức");
+
+  assert.equal(await queryCategoryPage("en", "does-not-exist", 1), null);
+});

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -1,0 +1,316 @@
+/**
+ * Blog repository adapter (blog design spec §4).
+ *
+ * Maps Supabase rows → blog view models behind typed accessors. Public reads
+ * run through the narrow service-role client (anon has zero privileges); the
+ * published-only filter is enforced here at the query boundary, fail-closed,
+ * matching resume publicity.
+ *
+ * Caching — single choke point: every public read goes through a `"use cache"`
+ * wrapper tagged `blog`, so one `updateTag("blog")` from any admin mutation
+ * refreshes listing, detail, category, and related reads together. `cacheLife`
+ * is only a safety net for missed invalidations; freshness is driven by
+ * `updateTag`.
+ *
+ * The `query*` functions are the uncached core (exported for tests — `cacheTag`
+ * is only valid inside a `"use cache"` function). They never throw on DB
+ * failure: missing translation, unpublished post, or a read error resolves to
+ * `null` / an empty listing so routes can map to `notFound()` / empty state
+ * rather than a 500.
+ */
+import type { Locale } from "@/features/i18n/config";
+import { cacheLife, cacheTag } from "next/cache";
+
+import { hasCmsConfig } from "@/features/cms/config";
+import { getMediaPublicUrl } from "@/features/cms/media";
+import { getServiceClient } from "@/features/cms/server";
+import { renderMarkdown } from "./markdown";
+import { readingTimeMinutes } from "./reading-time";
+import type {
+  BlogCategoryView,
+  BlogListingView,
+  PostDetail,
+  PostListItem,
+} from "./types";
+
+export const BLOG_CACHE_TAG = "blog";
+
+const PAGE_SIZE = 6;
+const RELATED_POSTS_LIMIT = 3;
+const COVER_FRAME = { width: 800, height: 450 };
+
+interface CategoryNameRow {
+  locale: string;
+  name: string;
+}
+
+interface CategoryRow {
+  id: string;
+  slug: string;
+  blog_category_translations: CategoryNameRow[];
+}
+
+interface TagRow {
+  slug: string;
+  blog_tag_translations: CategoryNameRow[];
+}
+
+interface PostTranslationRow {
+  locale: string;
+  title: string;
+  summary: string;
+  content_md: string;
+}
+
+interface PostTagLinkRow {
+  tag_id: string;
+  blog_tags?: TagRow | null;
+}
+
+interface PostRow {
+  id: string;
+  slug: string;
+  cover_bucket_path: string | null;
+  status: string;
+  published_at: string | null;
+  updated_at: string;
+  blog_categories: CategoryRow | null;
+  blog_post_translations: PostTranslationRow[];
+  blog_post_tags: PostTagLinkRow[] | null;
+}
+
+function localeRow<T extends { locale: string }>(
+  rows: T[] | null | undefined,
+  locale: Locale,
+): T | undefined {
+  return rows?.find((row) => row.locale === locale);
+}
+
+/** Map a row → listing item for the requested locale, or null when not renderable. */
+function mapPostListItem(row: PostRow, locale: Locale): PostListItem | null {
+  const translation = localeRow(row.blog_post_translations, locale);
+  const category = row.blog_categories;
+  const categoryName = localeRow(category?.blog_category_translations, locale);
+  if (!translation || !category || !categoryName) return null;
+
+  const coverImage = row.cover_bucket_path
+    ? {
+        src: getMediaPublicUrl("blog-media", row.cover_bucket_path),
+        alt: translation.title,
+        width: COVER_FRAME.width,
+        height: COVER_FRAME.height,
+      }
+    : undefined;
+
+  return {
+    slug: row.slug,
+    title: translation.title,
+    summary: translation.summary,
+    category: { slug: category.slug, name: categoryName.name },
+    coverImage,
+    publishedAt: row.published_at ?? row.updated_at,
+    updatedAt: row.updated_at,
+    readingTimeMinutes: readingTimeMinutes(translation.content_md),
+  };
+}
+
+function postSelect() {
+  return [
+    "id, slug, cover_bucket_path, status, published_at, updated_at",
+    "blog_categories(id, slug, blog_category_translations(locale, name))",
+    "blog_post_translations(locale, title, summary, content_md)",
+  ].join(", ");
+}
+
+async function loadPublishedPosts(
+  locale: Locale,
+  page: number,
+  categoryId?: string,
+): Promise<BlogListingView> {
+  const client = getServiceClient();
+  if (!hasCmsConfig() || !client) return { posts: [], page, totalPages: 1 };
+
+  try {
+    const from = (page - 1) * PAGE_SIZE;
+    const to = from + PAGE_SIZE - 1;
+
+    let query = client
+      .from("blog_posts")
+      .select(postSelect(), { count: "exact" })
+      .eq("status", "published")
+      .order("published_at", { ascending: false })
+      .order("id")
+      .range(from, to);
+    if (categoryId) query = query.eq("category_id", categoryId);
+
+    const { data, error, count } = await query;
+    if (error || !data) return { posts: [], page, totalPages: 1 };
+
+    const posts = (data as unknown as PostRow[])
+      .map((row) => mapPostListItem(row, locale))
+      .filter((post): post is PostListItem => post !== null);
+
+    return {
+      posts,
+      page,
+      totalPages: Math.max(1, Math.ceil((count ?? 0) / PAGE_SIZE)),
+    };
+  } catch {
+    return { posts: [], page, totalPages: 1 };
+  }
+}
+
+async function queryRelatedPosts(
+  locale: Locale,
+  excludeId: string,
+  tagIds: string[],
+): Promise<PostListItem[]> {
+  const client = getServiceClient();
+  if (!hasCmsConfig() || !client || tagIds.length === 0) return [];
+
+  try {
+    const { data, error } = await client
+      .from("blog_posts")
+      .select(`${postSelect()}, blog_post_tags(tag_id)` as string)
+      .eq("status", "published")
+      .neq("id", excludeId)
+      .order("published_at", { ascending: false })
+      .limit(50);
+    if (error || !data) return [];
+
+    const scored = (data as unknown as PostRow[])
+      .map((row) => {
+        const item = mapPostListItem(row, locale);
+        if (!item) return null;
+        const shared = (row.blog_post_tags ?? []).filter((link) =>
+          tagIds.includes(link.tag_id),
+        ).length;
+        return { item, shared };
+      })
+      .filter((entry): entry is { item: PostListItem; shared: number } => entry !== null)
+      .sort(
+        (a, b) =>
+          b.shared - a.shared ||
+          String(b.item.publishedAt).localeCompare(String(a.item.publishedAt)),
+      );
+
+    return scored.slice(0, RELATED_POSTS_LIMIT).map((entry) => entry.item);
+  } catch {
+    return [];
+  }
+}
+
+/** Uncached core: publish-gated listing by locale + page (optionally a category). */
+export async function queryPublishedPosts(
+  locale: Locale,
+  page: number,
+): Promise<BlogListingView> {
+  return loadPublishedPosts(locale, page);
+}
+
+/** Uncached core: article detail by slug (404-safe), including rendered HTML and related posts. */
+export async function queryPostBySlug(
+  locale: Locale,
+  slug: string,
+): Promise<PostDetail | null> {
+  const client = getServiceClient();
+  if (!hasCmsConfig() || !client) return null;
+
+  try {
+    const { data, error } = await client
+      .from("blog_posts")
+      .select(
+        `${postSelect()}, blog_post_tags(tag_id, blog_tags(slug, blog_tag_translations(locale, name)))` as string,
+      )
+      .eq("slug", slug)
+      .eq("status", "published")
+      .maybeSingle();
+    if (error || !data) return null;
+
+    const row = data as unknown as PostRow;
+    const item = mapPostListItem(row, locale);
+    const translation = localeRow(row.blog_post_translations, locale);
+    if (!item || !translation) return null;
+
+    const tags = (row.blog_post_tags ?? [])
+      .map((link) => {
+        const tagName = localeRow(link.blog_tags?.blog_tag_translations, locale);
+        return link.blog_tags && tagName
+          ? { slug: link.blog_tags.slug, name: tagName.name }
+          : null;
+      })
+      .filter((tag): tag is { slug: string; name: string } => tag !== null);
+
+    const { html, toc } = await renderMarkdown(translation.content_md);
+    const tagIds = (row.blog_post_tags ?? []).map((link) => link.tag_id);
+    const relatedPosts = await queryRelatedPosts(locale, row.id, tagIds);
+
+    return { ...item, tags, html, toc, relatedPosts };
+  } catch {
+    return null;
+  }
+}
+
+/** Uncached core: category archive header + its published listing. */
+export async function queryCategoryPage(
+  locale: Locale,
+  slug: string,
+  page: number,
+): Promise<BlogCategoryView | null> {
+  const client = getServiceClient();
+  if (!hasCmsConfig() || !client) return null;
+
+  try {
+    const { data, error } = await client
+      .from("blog_categories")
+      .select("id, slug, blog_category_translations(locale, name)")
+      .eq("slug", slug)
+      .maybeSingle();
+    if (error || !data) return null;
+
+    const category = data as CategoryRow;
+    const categoryName = localeRow(category.blog_category_translations, locale);
+    if (!categoryName) return null;
+
+    const listing = await loadPublishedPosts(locale, page, category.id);
+    return { slug: category.slug, name: categoryName.name, listing };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cached public accessors. Every read is tagged `blog` at the single choke
+ * point; `updateTag("blog")` invalidates them all together.
+ */
+
+export async function getPublishedPosts(
+  locale: Locale,
+  page: number,
+): Promise<BlogListingView> {
+  "use cache";
+  cacheTag(BLOG_CACHE_TAG);
+  cacheLife("weeks");
+  return queryPublishedPosts(locale, page);
+}
+
+export async function getPostBySlug(
+  locale: Locale,
+  slug: string,
+): Promise<PostDetail | null> {
+  "use cache";
+  cacheTag(BLOG_CACHE_TAG);
+  cacheLife("weeks");
+  return queryPostBySlug(locale, slug);
+}
+
+export async function getCategoryPage(
+  locale: Locale,
+  slug: string,
+  page: number,
+): Promise<BlogCategoryView | null> {
+  "use cache";
+  cacheTag(BLOG_CACHE_TAG);
+  cacheLife("weeks");
+  return queryCategoryPage(locale, slug, page);
+}

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -166,7 +166,7 @@ async function queryRelatedPosts(
   tagIds: string[],
 ): Promise<PostListItem[]> {
   const client = getServiceClient();
-  if (!hasCmsConfig() || !client || tagIds.length === 0) return [];
+  if (!hasCmsConfig() || !client) return [];
 
   try {
     const { data, error } = await client
@@ -194,6 +194,8 @@ async function queryRelatedPosts(
           String(b.item.publishedAt).localeCompare(String(a.item.publishedAt)),
       );
 
+    // Posts with no tags score 0 for everyone and still fall back to recency,
+    // so a tagless post never shows an empty related section.
     return scored.slice(0, RELATED_POSTS_LIMIT).map((entry) => entry.item);
   } catch {
     return [];

--- a/src/features/blog/types.ts
+++ b/src/features/blog/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Blog view models (slice 2 of the blog design spec, §4).
+ *
+ * Public UI consumes these typed view models only — never raw Supabase rows.
+ * Missing/incomplete records resolve to `notFound()`/empty at the repository
+ * boundary, never a partial render.
+ */
+
+export interface ManagedImage {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+}
+
+export interface PostListItem {
+  slug: string;
+  title: string;
+  summary: string;
+  category: { slug: string; name: string };
+  coverImage?: ManagedImage;
+  publishedAt: string;
+  updatedAt?: string;
+  readingTimeMinutes: number;
+}
+
+export type TocEntry = { id: string; text: string; depth: 2 | 3 };
+
+export type PostDetail = PostListItem & {
+  tags: { slug: string; name: string }[];
+  toc: TocEntry[];
+  html: string;
+  relatedPosts: PostListItem[];
+};
+
+export interface BlogListingView {
+  posts: PostListItem[];
+  page: number;
+  totalPages: number;
+}
+
+export interface BlogCategoryView {
+  slug: string;
+  name: string;
+  listing: BlogListingView;
+}

--- a/src/features/cms/media.ts
+++ b/src/features/cms/media.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getServerClient } from "./session";
 
-export type MediaBucket = "resume-media" | "project-media" | "portfolio";
+export type MediaBucket = "resume-media" | "project-media" | "portfolio" | "blog-media";
 
 export interface StoredObject {
   name: string;


### PR DESCRIPTION
## Summary

Slice 2 of the blog subsystem (spec `docs/superpowers/specs/2026-08-25-blog-design.md`, §4 + §5 + §12.2). Feature layer with zero UI: typed view models, the public repository adapter, the server-side Markdown pipeline, and the deterministic reading-time algorithm.

- **`src/features/blog/types.ts`** — `PostListItem`, `PostDetail`, `TocEntry`, `ManagedImage`, `BlogListingView`, `BlogCategoryView`. Public UI consumes view models only.
- **`src/features/blog/repository.ts`** — maps Supabase rows → view models behind `getPublishedPosts(locale, page)`, `getPostBySlug(locale, slug)`, `getCategoryPage(locale, slug, page)` (+ tag-overlap related posts, ≤3). Fail-closed: published-only filter at the query boundary (resume-publicity style); missing translation / unpublished / read failure → `null` / empty listing, never a 500.
  - **Single cache choke point**: every read is a `"use cache"` wrapper tagged `blog` (`cacheTag("blog")`), so one `updateTag("blog")` from any admin mutation refreshes listing/detail/category/related together. `cacheLife("weeks")` is only the safety net for missed invalidations (approved freshness contract).
  - Uncached `query*` cores are exported for tests (`cacheTag` is only valid inside a `"use cache"` function).
- **`src/features/blog/markdown.ts`** — one server-side remark/rehype pipeline: GFM, heading slugs, h2/h3 TOC extraction, `rehype-highlight` token classes (per-theme palettes are a UI-slice CSS concern), raw HTML passthrough disabled by construction, output `{ html, toc, headingCount }`. Malformed Markdown degrades to plain rendering, never a throw.
- **`src/features/blog/reading-time.ts`** — the spec's deterministic algorithm: strip fenced code blocks (+60 words each), remove `# * _ > - |` markers, count whitespace runs, `/200` ceil min 1. Vietnamese-safe.
- **`src/features/cms/media.ts`** — `blog-media` added to the shared `MediaBucket` union; covers use `getMediaPublicUrl`.
- Dependencies added: `unified`, `remark-parse`, `remark-gfm`, `remark-rehype`, `rehype-slug`, `rehype-highlight`, `rehype-stringify`, `unist-util-visit`, `hast-util-to-string`.

## Acceptance criteria

- [x] View models defined (`PostListItem`/`PostDetail`/`TocEntry`); no raw rows escape the repository
- [x] Published-only reads at the query boundary; fail-closed on missing translation / unpublished / read error
- [x] Listing, detail, category archive, and related-posts accessors implemented
- [x] Single `blog` cache tag choke point (`cacheTag` + `updateTag` contract) with `cacheLife` as safety net only
- [x] Shared remark/rehype pipeline: GFM, heading anchors + TOC, code highlighting, raw HTML disabled
- [x] Deterministic reading-time algorithm matching the spec exactly
- [x] Unit + integration tests (reading time, markdown, repository against local Supabase)

## Verification

- `npm test` — PASS (133 tests, includes 18 new reading-time/markdown)
- `npm run test:cms` — PASS (11 pass + 1 pre-existing skip; includes 6 new blog repository tests against local Supabase)
- `npm run test:db` — PASS (2/2)
- `npm run test:rls` — PASS (13 existing; `blog_schema_test.sql` arrives with PR #89)
- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm run build -- --webpack` — PASS
- Repository tests guard against non-local Supabase; fixtures cleaned up after run (verified 0 posts remaining).

## Screenshots

N/A — no UI in this slice.

## Risks / follow-ups

- `'use cache'` wrappers are not exercised by a route yet (no blog routes until slice 3); the Next compiler path for them gets exercised by the public-surface slice.
- Depends on the schema from PR #89 (not yet merged) — no code dependency, but the repository test needs the `blog_*` tables locally.
- The per-theme syntax palette and prose styling land in the UI slice.