### PR TITLE
feat: blog admin - posts/categories CRUD, locale-tab editor with preview, publish gate, updateTag choke point

### DIFF
--- a/src/app/admin/(dashboard)/admin-sidebar.tsx
+++ b/src/app/admin/(dashboard)/admin-sidebar.tsx
@@ -90,6 +90,19 @@ function MediaIcon() {
   );
 }
 
+function BlogIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="18" viewBox="0 0 24 24" width="18">
+      <path
+        d="M4 5h16M4 12h16M4 19h10"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
 const navLinks: Array<{ href: string; label: string; icon: () => ReactNode }> = [
   { href: "/admin/settings", label: "Settings", icon: SettingsIcon },
   { href: "/admin/profile", label: "Profile", icon: ProfileIcon },
@@ -100,9 +113,39 @@ const navLinks: Array<{ href: string; label: string; icon: () => ReactNode }> = 
   { href: "/admin/media", label: "Media", icon: MediaIcon },
 ];
 
+const blogLinks: Array<{ href: string; label: string; icon: () => ReactNode }> = [
+  { href: "/admin/blog", label: "Posts", icon: BlogIcon },
+  { href: "/admin/blog/categories", label: "Categories", icon: BlogIcon },
+];
+
 function isActive(pathname: string, href: string): boolean {
   if (href === "/admin/settings") return pathname === href;
   return pathname.startsWith(href);
+}
+
+function SidebarLinks({
+  links,
+  pathname,
+}: {
+  links: Array<{ href: string; label: string; icon: () => ReactNode }>;
+  pathname: string;
+}) {
+  return links.map((link) => {
+    const Icon = link.icon;
+    return (
+      <Link
+        aria-current={isActive(pathname, link.href) ? "page" : undefined}
+        className="admin-sidebar__link"
+        href={link.href}
+        key={link.href}
+      >
+        <span className="admin-sidebar__icon">
+          <Icon />
+        </span>
+        {link.label}
+      </Link>
+    );
+  });
 }
 
 export function AdminSidebar() {
@@ -115,22 +158,9 @@ export function AdminSidebar() {
         <span className="admin-brand__name">Khoa Watt</span>
       </div>
       <nav className="admin-sidebar__nav">
-        {navLinks.map((link) => {
-          const Icon = link.icon;
-          return (
-            <Link
-              aria-current={isActive(pathname, link.href) ? "page" : undefined}
-              className="admin-sidebar__link"
-              href={link.href}
-              key={link.href}
-            >
-              <span className="admin-sidebar__icon">
-                <Icon />
-              </span>
-              {link.label}
-            </Link>
-          );
-        })}
+        <SidebarLinks links={navLinks} pathname={pathname} />
+        <p className="admin-sidebar__group-label">Blog</p>
+        <SidebarLinks links={blogLinks} pathname={pathname} />
       </nav>
     </aside>
   );

--- a/src/app/admin/(dashboard)/admin-sidebar.tsx
+++ b/src/app/admin/(dashboard)/admin-sidebar.tsx
@@ -118,9 +118,23 @@ const blogLinks: Array<{ href: string; label: string; icon: () => ReactNode }> =
   { href: "/admin/blog/categories", label: "Categories", icon: BlogIcon },
 ];
 
-function isActive(pathname: string, href: string): boolean {
+function matchesHref(pathname: string, href: string): boolean {
   if (href === "/admin/settings") return pathname === href;
-  return pathname.startsWith(href);
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/** Longest matching href wins, so `/admin/blog/categories` marks only the
+ *  Categories link active, never the sibling Posts link. */
+function activeHref(
+  pathname: string,
+  links: ReadonlyArray<{ href: string }>,
+): string | null {
+  const matched = links.filter((link) => matchesHref(pathname, link.href));
+  if (matched.length === 0) return null;
+  return matched.reduce(
+    (longest, link) => (link.href.length > longest.href.length ? link : longest),
+    matched[0],
+  ).href;
 }
 
 function SidebarLinks({
@@ -130,11 +144,12 @@ function SidebarLinks({
   links: Array<{ href: string; label: string; icon: () => ReactNode }>;
   pathname: string;
 }) {
+  const current = activeHref(pathname, links);
   return links.map((link) => {
     const Icon = link.icon;
     return (
       <Link
-        aria-current={isActive(pathname, link.href) ? "page" : undefined}
+        aria-current={link.href === current ? "page" : undefined}
         className="admin-sidebar__link"
         href={link.href}
         key={link.href}

--- a/src/app/admin/(dashboard)/blog/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/blog/[id]/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from "next/navigation";
+
+import { getPost } from "../data";
+import { PostForm } from "../post-form";
+import { listCategories, listBlogMedia, listTags } from "../data";
+import { getMediaPublicUrl } from "@/features/cms/media";
+import { AdminFormCard, AdminPage } from "../../admin-page";
+
+interface AdminEditPostPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "Edit blog post",
+};
+
+export default async function AdminEditPostPage({
+  params,
+}: Readonly<AdminEditPostPageProps>) {
+  const { id } = await params;
+  const post = await getPost(id);
+
+  if (!post) {
+    notFound();
+  }
+
+  const [categories, tags, media] = await Promise.all([
+    listCategories(),
+    listTags(),
+    listBlogMedia(),
+  ]);
+
+  return (
+    <AdminPage backHref="/admin/blog" title="Edit post">
+      <AdminFormCard>
+        <h2>Post details</h2>
+        <PostForm
+          categories={categories}
+          coverOptions={media.map((object) => ({
+            name: object.name,
+            url: getMediaPublicUrl("blog-media", object.name),
+          }))}
+          existing={post}
+          tags={tags}
+        />
+      </AdminFormCard>
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/actions.ts
+++ b/src/app/admin/(dashboard)/blog/actions.ts
@@ -1,0 +1,273 @@
+"use server";
+
+import { revalidatePath, updateTag } from "next/cache";
+
+import { renderMarkdown } from "@/features/blog/markdown";
+import { BLOG_CACHE_TAG } from "@/features/blog/repository";
+import { getServerClient, isAdminUser } from "@/features/cms/session";
+import { required } from "@/features/cms/validation";
+
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function invalidSlug(slug: string): string | null {
+  if (!required(slug)) return "Slug is required.";
+  if (!SLUG_RE.test(slug)) {
+    return "Slug must be lowercase letters, numbers, and single hyphens.";
+  }
+  return null;
+}
+
+function publishGateMessage(error: { message: string }): string {
+  const message = error.message;
+  if (message.includes("Cannot publish: missing required translation(s)")) {
+    return message;
+  }
+  return message;
+}
+
+export interface BlogPostFormData {
+  id?: string;
+  slug: string;
+  categoryId: string;
+  coverBucketPath: string;
+  status: "draft" | "published";
+  tagIds: string[];
+  titleEn: string;
+  summaryEn: string;
+  contentMdEn: string;
+  titleVi: string;
+  summaryVi: string;
+  contentMdVi: string;
+}
+
+export interface BlogCategoryFormData {
+  id?: string;
+  sortOrder: number;
+  nameEn: string;
+  nameVi: string;
+}
+
+export interface BlogActionResult {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Record<string, string>;
+}
+
+function validatePost(data: BlogPostFormData): BlogActionResult | null {
+  const errors: Record<string, string> = {};
+
+  const slugError = invalidSlug(data.slug);
+  if (slugError) errors.slug = slugError;
+  if (!required(data.categoryId)) errors.categoryId = "Category is required.";
+  if (!required(data.titleEn)) errors.titleEn = "EN title is required.";
+  if (!required(data.titleVi)) errors.titleVi = "VI title is required.";
+  if (!required(data.summaryEn)) errors.summaryEn = "EN summary is required.";
+  if (!required(data.summaryVi)) errors.summaryVi = "VI summary is required.";
+
+  if (Object.keys(errors).length > 0) return { ok: false, fieldErrors: errors };
+  return null;
+}
+
+async function withBlogClient() {
+  if (!(await isAdminUser())) return null;
+  return getServerClient();
+}
+
+/** Single cache choke point: every successful blog mutation refreshes all
+ *  cached blog reads together (spec §4 + §9). */
+function invalidateBlog() {
+  updateTag(BLOG_CACHE_TAG);
+}
+
+// --- Posts --------------------------------------------------------------------
+
+export async function createPost(
+  data: BlogPostFormData,
+): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+
+  const invalid = validatePost(data);
+  if (invalid) return invalid;
+
+  const id = data.id && data.id.length > 0 ? data.id : data.slug;
+
+  const { error } = await client.rpc("cms_upsert_blog_post", {
+    p_id: id,
+    p_slug: data.slug.trim(),
+    p_category_id: data.categoryId,
+    p_cover_bucket_path: data.coverBucketPath || null,
+    p_status: data.status,
+    p_tags: data.tagIds,
+    p_title_en: data.titleEn.trim(),
+    p_summary_en: data.summaryEn.trim(),
+    p_content_md_en: data.contentMdEn,
+    p_title_vi: data.titleVi.trim(),
+    p_summary_vi: data.summaryVi.trim(),
+    p_content_md_vi: data.contentMdVi,
+  });
+  if (error) return { ok: false, error: publishGateMessage(error) };
+
+  invalidateBlog();
+  revalidatePath("/admin/blog");
+  revalidatePath("/admin/blog/[id]");
+  return { ok: true };
+}
+
+export async function updatePost(
+  data: BlogPostFormData,
+): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+
+  const invalid = validatePost(data);
+  if (invalid) return invalid;
+  if (!data.id) return { ok: false, error: "Missing post id." };
+
+  const { error } = await client.rpc("cms_upsert_blog_post", {
+    p_id: data.id,
+    p_slug: data.slug.trim(),
+    p_category_id: data.categoryId,
+    p_cover_bucket_path: data.coverBucketPath || null,
+    p_status: data.status,
+    p_tags: data.tagIds,
+    p_title_en: data.titleEn.trim(),
+    p_summary_en: data.summaryEn.trim(),
+    p_content_md_en: data.contentMdEn,
+    p_title_vi: data.titleVi.trim(),
+    p_summary_vi: data.summaryVi.trim(),
+    p_content_md_vi: data.contentMdVi,
+  });
+  if (error) return { ok: false, error: publishGateMessage(error) };
+
+  invalidateBlog();
+  revalidatePath("/admin/blog");
+  revalidatePath(`/admin/blog/${data.id}`);
+  return { ok: true };
+}
+
+export async function deletePost(id: string): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+
+  const { error } = await client.rpc("cms_delete_blog_post", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+
+  invalidateBlog();
+  revalidatePath("/admin/blog");
+  return { ok: true };
+}
+
+// --- Categories ---------------------------------------------------------------
+
+export async function createCategory(
+  data: BlogCategoryFormData,
+): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+
+  const id = data.id && data.id.length > 0 ? data.id : slugify(data.nameEn);
+  if (invalidSlug(id)) return { ok: false, fieldErrors: { id: "Invalid category slug." } };
+  if (!required(data.nameEn) || !required(data.nameVi)) {
+    return { ok: false, fieldErrors: { nameEn: "EN and VI names are required." } };
+  }
+
+  const { error } = await client.rpc("cms_upsert_blog_category", {
+    p_id: id,
+    p_sort_order: data.sortOrder,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+  });
+  if (error) return { ok: false, error: error.message };
+
+  invalidateBlog();
+  revalidatePath("/admin/blog/categories");
+  return { ok: true };
+}
+
+export async function updateCategory(
+  data: BlogCategoryFormData,
+): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+  if (!data.id) return { ok: false, error: "Missing category id." };
+
+  const { error } = await client.rpc("cms_upsert_blog_category", {
+    p_id: data.id,
+    p_sort_order: data.sortOrder,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+  });
+  if (error) return { ok: false, error: error.message };
+
+  invalidateBlog();
+  revalidatePath("/admin/blog/categories");
+  return { ok: true };
+}
+
+export async function deleteCategory(id: string): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+
+  const { error } = await client.rpc("cms_delete_blog_category", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+
+  invalidateBlog();
+  revalidatePath("/admin/blog/categories");
+  revalidatePath("/admin/blog");
+  return { ok: true };
+}
+
+// --- Tags (inline creation in the post editor) --------------------------------
+
+export interface CreateTagResult {
+  ok: boolean;
+  id?: string;
+  error?: string;
+}
+
+export async function createTag(name: string): Promise<CreateTagResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+
+  const id = slugify(name);
+  if (invalidSlug(id)) return { ok: false, error: "Invalid tag name." };
+
+  const { error } = await client.rpc("cms_upsert_blog_tag", {
+    p_id: id,
+    p_name_en: name.trim(),
+    p_name_vi: name.trim(),
+  });
+  if (error) return { ok: false, error: error.message };
+
+  invalidateBlog();
+  return { ok: true, id };
+}
+
+// --- Markdown preview (shared pipeline, same as the public site) --------------
+
+export async function previewMarkdown(
+  markdown: string,
+): Promise<{ ok: boolean; html?: string; error?: string }> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+
+  try {
+    const { html } = await renderMarkdown(markdown);
+    return { ok: true, html };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Preview failed.",
+    };
+  }
+}

--- a/src/app/admin/(dashboard)/blog/categories/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/blog/categories/[id]/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+
+import { getCategory } from "../../data";
+import { CategoryForm } from "../category-form";
+import { AdminFormCard, AdminPage } from "../../../admin-page";
+
+interface AdminEditCategoryPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata = {
+  title: "Edit blog category",
+};
+
+export default async function AdminEditCategoryPage({
+  params,
+}: Readonly<AdminEditCategoryPageProps>) {
+  const { id } = await params;
+  const category = await getCategory(id);
+
+  if (!category) {
+    notFound();
+  }
+
+  return (
+    <AdminPage backHref="/admin/blog/categories" title="Edit category">
+      <AdminFormCard>
+        <h2>Category details</h2>
+        <CategoryForm existing={category} />
+      </AdminFormCard>
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/categories/category-form.tsx
+++ b/src/app/admin/(dashboard)/blog/categories/category-form.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import {
+  createCategory,
+  updateCategory,
+  type BlogActionResult,
+  type BlogCategoryFormData,
+} from "../actions";
+import type { AdminCategoryRow } from "../data";
+
+interface CategoryFormProps {
+  existing?: AdminCategoryRow;
+}
+
+export function CategoryForm({ existing }: Readonly<CategoryFormProps>) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+    setError(null);
+    setFieldErrors({});
+
+    const data: BlogCategoryFormData = {
+      id: existing?.id ?? String(fd.get("id") ?? ""),
+      sortOrder: Number(fd.get("sortOrder") ?? 0),
+      nameEn: String(fd.get("nameEn") ?? ""),
+      nameVi: String(fd.get("nameVi") ?? ""),
+    };
+
+    startTransition(async () => {
+      const result: BlogActionResult = existing
+        ? await updateCategory(data)
+        : await createCategory(data);
+      if (result.ok) {
+        router.push("/admin/blog/categories");
+        router.refresh();
+      } else if (result.fieldErrors) {
+        setFieldErrors(result.fieldErrors);
+        setError(Object.values(result.fieldErrors).join(" "));
+      } else {
+        setError(result.error ?? "Failed to save category.");
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      {!existing ? (
+        <label className="admin-field">
+          <span>ID (slug, optional)</span>
+          <input name="id" defaultValue="" />
+          {fieldErrors.id ? <small className="admin-error">{fieldErrors.id}</small> : null}
+        </label>
+      ) : null}
+
+      <div className="admin-form-grid">
+        <label className="admin-field">
+          <span>Name (EN)</span>
+          <input name="nameEn" required defaultValue={existing?.nameEn ?? ""} />
+          {fieldErrors.nameEn ? <small className="admin-error">{fieldErrors.nameEn}</small> : null}
+        </label>
+        <label className="admin-field">
+          <span>Name (VI)</span>
+          <input name="nameVi" required defaultValue={existing?.nameVi ?? ""} />
+        </label>
+      </div>
+
+      <label className="admin-field">
+        <span>Sort order</span>
+        <input name="sortOrder" type="number" defaultValue={existing?.sortOrder ?? 0} />
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">{error}</p>
+      ) : null}
+
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update category" : "Create category"}
+        </button>
+        <Link href="/admin/blog/categories">Cancel</Link>
+      </div>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/categories/delete-category.tsx
+++ b/src/app/admin/(dashboard)/blog/categories/delete-category.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { deleteCategory } from "../actions";
+
+interface DeleteCategoryButtonProps {
+  id: string;
+  name: string;
+}
+
+export function DeleteCategoryButton({ id, name }: DeleteCategoryButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm(`Delete category "${name}"?`)) return;
+
+    startTransition(async () => {
+      const result = await deleteCategory(id);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to delete.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        className="admin-link-button admin-link-button--danger"
+        disabled={isPending}
+        onClick={handleDelete}
+        type="button"
+      >
+        {isPending ? "…" : "Delete"}
+      </button>
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/categories/new/page.tsx
+++ b/src/app/admin/(dashboard)/blog/categories/new/page.tsx
@@ -1,0 +1,17 @@
+import { CategoryForm } from "../category-form";
+import { AdminFormCard, AdminPage } from "../../../admin-page";
+
+export const metadata = {
+  title: "New blog category",
+};
+
+export default function AdminNewCategoryPage() {
+  return (
+    <AdminPage backHref="/admin/blog/categories" title="New category">
+      <AdminFormCard>
+        <h2>Category details</h2>
+        <CategoryForm />
+      </AdminFormCard>
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/categories/page.tsx
+++ b/src/app/admin/(dashboard)/blog/categories/page.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+
+import { listCategories } from "../data";
+import { DeleteCategoryButton } from "./delete-category";
+import { AdminPage, AdminTable } from "../../admin-page";
+
+export const metadata = {
+  title: "Admin blog categories",
+};
+
+export default async function AdminBlogCategoriesPage() {
+  const categories = await listCategories();
+
+  return (
+    <AdminPage
+      action={
+        <Link className="admin-button" href="/admin/blog/categories/new">
+          New category
+        </Link>
+      }
+      backHref="/admin/blog"
+      backLabel="Posts"
+      title="Blog categories"
+    >
+      {categories.length === 0 ? (
+        <p className="admin-empty">No categories yet.</p>
+      ) : (
+        <AdminTable label="Blog categories">
+          <thead>
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">Name</th>
+              <th scope="col">Order</th>
+              <th scope="col"><span className="sr-only">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {categories.map((category) => (
+              <tr key={category.id}>
+                <td>{category.id}</td>
+                <td>{category.nameEn} / {category.nameVi}</td>
+                <td>{category.sortOrder}</td>
+                <td className="admin-row-actions">
+                  <Link href={`/admin/blog/categories/${category.id}`}>Edit</Link>
+                  <DeleteCategoryButton id={category.id} name={category.nameEn} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </AdminTable>
+      )}
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/data.ts
+++ b/src/app/admin/(dashboard)/blog/data.ts
@@ -1,0 +1,198 @@
+import { getServerClient } from "@/features/cms/session";
+import { listBucketObjects } from "@/features/cms/media";
+
+export interface AdminPostRow {
+  id: string;
+  slug: string;
+  categoryId: string;
+  categorySlug: string;
+  categoryNameEn: string;
+  categoryNameVi: string;
+  coverBucketPath: string | null;
+  status: "draft" | "published";
+  publishedAt: string | null;
+  updatedAt: string;
+  titleEn: string;
+  summaryEn: string;
+  contentMdEn: string;
+  titleVi: string;
+  summaryVi: string;
+  contentMdVi: string;
+  tagIds: string[];
+}
+
+export interface AdminCategoryRow {
+  id: string;
+  slug: string;
+  sortOrder: number;
+  nameEn: string;
+  nameVi: string;
+}
+
+export interface AdminTagRow {
+  id: string;
+  slug: string;
+  nameEn: string;
+  nameVi: string;
+}
+
+interface PostTranslation {
+  locale: string;
+  title: string;
+  summary: string;
+  content_md: string;
+}
+
+interface CategoryName {
+  locale: string;
+  name: string;
+}
+
+interface PostCategory {
+  id: string;
+  slug: string;
+  blog_category_translations: CategoryName[];
+}
+
+interface PostTagLink {
+  tag_id: string;
+}
+
+interface PostRowWithChildren {
+  id: string;
+  slug: string;
+  category_id: string;
+  cover_bucket_path: string | null;
+  status: string;
+  published_at: string | null;
+  updated_at: string;
+  blog_categories: PostCategory | null;
+  blog_post_translations: PostTranslation[];
+  blog_post_tags: PostTagLink[] | null;
+}
+
+function localeValue<T extends { locale: string }>(
+  rows: T[] | null | undefined,
+  locale: string,
+): T | undefined {
+  return rows?.find((row) => row.locale === locale);
+}
+
+export async function listPosts(): Promise<AdminPostRow[]> {
+  const client = await getServerClient();
+
+  const { data, error } = await client
+    .from("blog_posts")
+    .select(
+      "id, slug, category_id, cover_bucket_path, status, published_at, updated_at, blog_categories(id, slug, blog_category_translations(locale, name)), blog_post_translations(locale, title, summary, content_md), blog_post_tags(tag_id)",
+    )
+    .order("published_at", { ascending: false })
+    .order("updated_at", { ascending: false })
+    .order("id");
+
+  if (error || !data) return [];
+
+  return (data as unknown as PostRowWithChildren[]).map((row) => {
+    const en = localeValue(row.blog_post_translations, "en");
+    const vi = localeValue(row.blog_post_translations, "vi");
+    const categoryNameEn = localeValue(
+      row.blog_categories?.blog_category_translations,
+      "en",
+    );
+    const categoryNameVi = localeValue(
+      row.blog_categories?.blog_category_translations,
+      "vi",
+    );
+
+    return {
+      id: row.id,
+      slug: row.slug,
+      categoryId: row.category_id,
+      categorySlug: row.blog_categories?.slug ?? "",
+      categoryNameEn: categoryNameEn?.name ?? "",
+      categoryNameVi: categoryNameVi?.name ?? "",
+      coverBucketPath: row.cover_bucket_path,
+      status: row.status === "published" ? "published" : "draft",
+      publishedAt: row.published_at,
+      updatedAt: row.updated_at,
+      titleEn: en?.title ?? "",
+      summaryEn: en?.summary ?? "",
+      contentMdEn: en?.content_md ?? "",
+      titleVi: vi?.title ?? "",
+      summaryVi: vi?.summary ?? "",
+      contentMdVi: vi?.content_md ?? "",
+      tagIds: (row.blog_post_tags ?? []).map((link) => link.tag_id),
+    };
+  });
+}
+
+export async function getPost(id: string): Promise<AdminPostRow | null> {
+  const posts = await listPosts();
+  return posts.find((post) => post.id === id) ?? null;
+}
+
+export async function listCategories(): Promise<AdminCategoryRow[]> {
+  const client = await getServerClient();
+
+  const { data, error } = await client
+    .from("blog_categories")
+    .select(
+      "id, slug, sort_order, blog_category_translations(locale, name)",
+    )
+    .order("sort_order")
+    .order("id");
+
+  if (error || !data) return [];
+
+  return (data as unknown as {
+    id: string;
+    slug: string;
+    sort_order: number;
+    blog_category_translations: CategoryName[];
+  }[]).map((row) => {
+    const en = localeValue(row.blog_category_translations, "en");
+    const vi = localeValue(row.blog_category_translations, "vi");
+    return {
+      id: row.id,
+      slug: row.slug,
+      sortOrder: row.sort_order,
+      nameEn: en?.name ?? "",
+      nameVi: vi?.name ?? "",
+    };
+  });
+}
+
+export async function getCategory(id: string): Promise<AdminCategoryRow | null> {
+  const categories = await listCategories();
+  return categories.find((category) => category.id === id) ?? null;
+}
+
+export async function listTags(): Promise<AdminTagRow[]> {
+  const client = await getServerClient();
+
+  const { data, error } = await client
+    .from("blog_tags")
+    .select("id, slug, blog_tag_translations(locale, name)")
+    .order("id");
+
+  if (error || !data) return [];
+
+  return (data as unknown as {
+    id: string;
+    slug: string;
+    blog_tag_translations: CategoryName[];
+  }[]).map((row) => {
+    const en = localeValue(row.blog_tag_translations, "en");
+    const vi = localeValue(row.blog_tag_translations, "vi");
+    return {
+      id: row.id,
+      slug: row.slug,
+      nameEn: en?.name ?? "",
+      nameVi: vi?.name ?? "",
+    };
+  });
+}
+
+export async function listBlogMedia() {
+  return listBucketObjects("blog-media");
+}

--- a/src/app/admin/(dashboard)/blog/delete-post.tsx
+++ b/src/app/admin/(dashboard)/blog/delete-post.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { deletePost } from "./actions";
+
+interface DeletePostButtonProps {
+  id: string;
+  title: string;
+}
+
+export function DeletePostButton({ id, title }: DeletePostButtonProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm(`Delete post "${title}"?`)) return;
+
+    startTransition(async () => {
+      const result = await deletePost(id);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to delete.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        className="admin-link-button admin-link-button--danger"
+        disabled={isPending}
+        onClick={handleDelete}
+        type="button"
+      >
+        {isPending ? "…" : "Delete"}
+      </button>
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/new/page.tsx
+++ b/src/app/admin/(dashboard)/blog/new/page.tsx
@@ -1,0 +1,32 @@
+import { PostForm } from "../post-form";
+import { listCategories, listBlogMedia, listTags } from "../data";
+import { getMediaPublicUrl } from "@/features/cms/media";
+import { AdminFormCard, AdminPage } from "../../admin-page";
+
+export const metadata = {
+  title: "New blog post",
+};
+
+export default async function AdminNewPostPage() {
+  const [categories, tags, media] = await Promise.all([
+    listCategories(),
+    listTags(),
+    listBlogMedia(),
+  ]);
+
+  return (
+    <AdminPage backHref="/admin/blog" title="New post">
+      <AdminFormCard>
+        <h2>Post details</h2>
+        <PostForm
+          categories={categories}
+          coverOptions={media.map((object) => ({
+            name: object.name,
+            url: getMediaPublicUrl("blog-media", object.name),
+          }))}
+          tags={tags}
+        />
+      </AdminFormCard>
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/page.tsx
+++ b/src/app/admin/(dashboard)/blog/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+
+import { listPosts } from "./data";
+import { DeletePostButton } from "./delete-post";
+import { AdminPage, AdminTable } from "../admin-page";
+
+export const metadata = {
+  title: "Admin blog",
+};
+
+export default async function AdminBlogPage() {
+  const posts = await listPosts();
+
+  return (
+    <AdminPage
+      action={
+        <Link className="admin-button" href="/admin/blog/new">
+          New post
+        </Link>
+      }
+      title="Blog posts"
+    >
+      {posts.length === 0 ? (
+        <p className="admin-empty">No posts yet.</p>
+      ) : (
+        <AdminTable label="Blog posts">
+          <thead>
+            <tr>
+              <th scope="col">Title</th>
+              <th scope="col">Category</th>
+              <th scope="col">Status</th>
+              <th scope="col">Published</th>
+              <th scope="col"><span className="sr-only">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {posts.map((post) => (
+              <tr key={post.id}>
+                <td>{post.titleEn}</td>
+                <td>{post.categoryNameEn}</td>
+                <td>
+                  <span className={`admin-badge ${post.status === "published" ? "admin-badge--success" : "admin-badge--muted"}`}>
+                    {post.status}
+                  </span>
+                </td>
+                <td>
+                  {post.publishedAt
+                    ? new Date(post.publishedAt).toLocaleDateString()
+                    : "—"}
+                </td>
+                <td className="admin-row-actions">
+                  <Link href={`/admin/blog/${post.id}`}>Edit</Link>
+                  <DeletePostButton id={post.id} title={post.titleEn} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </AdminTable>
+      )}
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/post-form.tsx
+++ b/src/app/admin/(dashboard)/blog/post-form.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import {
+  createPost,
+  createTag,
+  previewMarkdown,
+  updatePost,
+  type BlogActionResult,
+  type BlogPostFormData,
+} from "./actions";
+import type { AdminCategoryRow, AdminPostRow, AdminTagRow } from "./data";
+
+interface CoverOption {
+  name: string;
+  url: string;
+}
+
+interface PostFormProps {
+  categories: AdminCategoryRow[];
+  coverOptions: CoverOption[];
+  existing?: AdminPostRow;
+  tags: AdminTagRow[];
+}
+
+type LocaleTab = "en" | "vi";
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+export function PostForm({
+  categories,
+  coverOptions,
+  existing,
+  tags,
+}: Readonly<PostFormProps>) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [isPending, startTransition] = useTransition();
+
+  const [localeTab, setLocaleTab] = useState<LocaleTab>("en");
+  const [slug, setSlug] = useState(existing?.slug ?? "");
+  const [slugTouched, setSlugTouched] = useState(Boolean(existing));
+  const [categoryId, setCategoryId] = useState(existing?.categoryId ?? "");
+  const [coverBucketPath, setCoverBucketPath] = useState(
+    existing?.coverBucketPath ?? "",
+  );
+  const [status, setStatus] = useState<"draft" | "published">(
+    existing?.status ?? "draft",
+  );
+  const [tagIds, setTagIds] = useState<string[]>(existing?.tagIds ?? []);
+
+  const [titleEn, setTitleEn] = useState(existing?.titleEn ?? "");
+  const [summaryEn, setSummaryEn] = useState(existing?.summaryEn ?? "");
+  const [contentMdEn, setContentMdEn] = useState(existing?.contentMdEn ?? "");
+  const [titleVi, setTitleVi] = useState(existing?.titleVi ?? "");
+  const [summaryVi, setSummaryVi] = useState(existing?.summaryVi ?? "");
+  const [contentMdVi, setContentMdVi] = useState(existing?.contentMdVi ?? "");
+
+  const [newTagName, setNewTagName] = useState("");
+  const [newTagError, setNewTagError] = useState<string | null>(null);
+
+  const [previewTab, setPreviewTab] = useState<LocaleTab | null>(null);
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+
+  function onTitleEnChange(value: string) {
+    setTitleEn(value);
+    if (!slugTouched) setSlug(slugify(value));
+  }
+
+  function toggleTag(id: string) {
+    setTagIds((current) =>
+      current.includes(id) ? current.filter((t) => t !== id) : [...current, id],
+    );
+  }
+
+  function runPreview(locale: LocaleTab) {
+    const markdown = locale === "en" ? contentMdEn : contentMdVi;
+    setPreviewTab(locale);
+    setPreviewHtml(null);
+    setPreviewError(null);
+    setIsPreviewing(true);
+
+    startTransition(async () => {
+      const result = await previewMarkdown(markdown);
+      setIsPreviewing(false);
+      if (result.ok && result.html) {
+        setPreviewHtml(result.html);
+      } else {
+        setPreviewError(result.error ?? "Preview failed.");
+      }
+    });
+  }
+
+  function addTag() {
+    const name = newTagName.trim();
+    if (!name) return;
+    setNewTagError(null);
+
+    startTransition(async () => {
+      const result = await createTag(name);
+      if (result.ok && result.id) {
+        setTagIds((current) =>
+          current.includes(result.id as string) ? current : [...current, result.id as string],
+        );
+        setNewTagName("");
+      } else {
+        setNewTagError(result.error ?? "Failed to create tag.");
+      }
+    });
+  }
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setFieldErrors({});
+
+    const data: BlogPostFormData = {
+      id: existing?.id,
+      slug,
+      categoryId,
+      coverBucketPath,
+      status,
+      tagIds,
+      titleEn,
+      summaryEn,
+      contentMdEn,
+      titleVi,
+      summaryVi,
+      contentMdVi,
+    };
+
+    startTransition(async () => {
+      const result: BlogActionResult = existing
+        ? await updatePost(data)
+        : await createPost(data);
+      if (result.ok) {
+        router.push("/admin/blog");
+        router.refresh();
+      } else if (result.fieldErrors) {
+        setFieldErrors(result.fieldErrors);
+        setError(Object.values(result.fieldErrors).join(" "));
+      } else {
+        setError(result.error ?? "Failed to save post.");
+      }
+    });
+  }
+
+  return (
+    <form className="admin-form admin-form--blog" onSubmit={onSubmit}>
+      <label className="admin-field">
+        <span>Slug</span>
+        <input
+          name="slug"
+          onChange={(event) => {
+            setSlug(event.target.value);
+            setSlugTouched(true);
+          }}
+          required
+          value={slug}
+        />
+        {fieldErrors.slug ? <small className="admin-error">{fieldErrors.slug}</small> : null}
+      </label>
+
+      <div className="admin-form-grid">
+        <label className="admin-field">
+          <span>Category</span>
+          <select
+            name="categoryId"
+            onChange={(event) => setCategoryId(event.target.value)}
+            required
+            value={categoryId}
+          >
+            <option value="">Select a category…</option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.nameEn} / {category.nameVi}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="admin-field">
+          <span>Status</span>
+          <select
+            name="status"
+            onChange={(event) =>
+              setStatus(event.target.value as "draft" | "published")
+            }
+            value={status}
+          >
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+          </select>
+        </label>
+      </div>
+
+      <fieldset className="admin-field">
+        <legend>Tags</legend>
+        {tags.length > 0 ? (
+          <div className="admin-check-group">
+            {tags.map((tag) => (
+              <label className="admin-check" key={tag.id}>
+                <input
+                  checked={tagIds.includes(tag.id)}
+                  onChange={() => toggleTag(tag.id)}
+                  type="checkbox"
+                />
+                <span>{tag.nameEn}</span>
+              </label>
+            ))}
+          </div>
+        ) : (
+          <p className="admin-note">No tags yet.</p>
+        )}
+        <div className="admin-form-row">
+          <input
+            aria-label="New tag name"
+            onChange={(event) => setNewTagName(event.target.value)}
+            placeholder="Quick-add a tag"
+            value={newTagName}
+          />
+          <button disabled={isPending} onClick={addTag} type="button">
+            Add tag
+          </button>
+        </div>
+        {newTagError ? <p className="admin-error">{newTagError}</p> : null}
+      </fieldset>
+
+      <fieldset className="admin-field">
+        <legend>Cover (blog-media bucket)</legend>
+        {coverOptions.length === 0 ? (
+          <p className="admin-note">No media uploaded yet — upload under Admin → Media.</p>
+        ) : (
+          <div className="admin-check-group">
+            <label className="admin-check">
+              <input
+                checked={coverBucketPath === ""}
+                onChange={() => setCoverBucketPath("")}
+                type="radio"
+                name="cover"
+              />
+              <span>No cover</span>
+            </label>
+            {coverOptions.map((cover) => (
+              <label className="admin-check admin-check--media" key={cover.name}>
+                <input
+                  checked={coverBucketPath === cover.name}
+                  onChange={() => setCoverBucketPath(cover.name)}
+                  type="radio"
+                  name="cover"
+                />
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img alt={cover.name} height={48} src={cover.url} width={64} />
+                <span>{cover.name}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </fieldset>
+
+      <div className="admin-locale-tabs" role="tablist" aria-label="Post language">
+        <button
+          aria-selected={localeTab === "en"}
+          onClick={() => setLocaleTab("en")}
+          role="tab"
+          type="button"
+        >
+          English
+        </button>
+        <button
+          aria-selected={localeTab === "vi"}
+          onClick={() => setLocaleTab("vi")}
+          role="tab"
+          type="button"
+        >
+          Tiếng Việt
+        </button>
+      </div>
+
+      <div role="tabpanel">
+        {localeTab === "en" ? (
+          <>
+            <label className="admin-field">
+              <span>Title (EN)</span>
+              <input
+                onChange={(event) => onTitleEnChange(event.target.value)}
+                required
+                value={titleEn}
+              />
+              {fieldErrors.titleEn ? <small className="admin-error">{fieldErrors.titleEn}</small> : null}
+            </label>
+            <label className="admin-field">
+              <span>Summary (EN)</span>
+              <textarea
+                onChange={(event) => setSummaryEn(event.target.value)}
+                required
+                rows={3}
+                value={summaryEn}
+              />
+              {fieldErrors.summaryEn ? <small className="admin-error">{fieldErrors.summaryEn}</small> : null}
+            </label>
+            <label className="admin-field">
+              <span>Markdown content (EN)</span>
+              <textarea
+                className="admin-markdown"
+                onChange={(event) => setContentMdEn(event.target.value)}
+                rows={14}
+                value={contentMdEn}
+              />
+            </label>
+          </>
+        ) : (
+          <>
+            <label className="admin-field">
+              <span>Title (VI)</span>
+              <input
+                onChange={(event) => setTitleVi(event.target.value)}
+                required
+                value={titleVi}
+              />
+              {fieldErrors.titleVi ? <small className="admin-error">{fieldErrors.titleVi}</small> : null}
+            </label>
+            <label className="admin-field">
+              <span>Summary (VI)</span>
+              <textarea
+                onChange={(event) => setSummaryVi(event.target.value)}
+                required
+                rows={3}
+                value={summaryVi}
+              />
+              {fieldErrors.summaryVi ? <small className="admin-error">{fieldErrors.summaryVi}</small> : null}
+            </label>
+            <label className="admin-field">
+              <span>Markdown content (VI)</span>
+              <textarea
+                className="admin-markdown"
+                onChange={(event) => setContentMdVi(event.target.value)}
+                rows={14}
+                value={contentMdVi}
+              />
+            </label>
+          </>
+        )}
+      </div>
+
+      <div className="admin-form-row">
+        <button
+          disabled={isPreviewing}
+          onClick={() => runPreview(localeTab)}
+          type="button"
+        >
+          {isPreviewing ? "Rendering…" : `Preview ${localeTab === "en" ? "EN" : "VI"}`}
+        </button>
+      </div>
+
+      {previewError ? (
+        <p className="admin-error" role="alert">{previewError}</p>
+      ) : null}
+      {previewTab && previewHtml ? (
+        <div className="admin-preview">
+          <h3>Preview ({previewTab === "en" ? "EN" : "VI"})</h3>
+          <div
+            className="blog-article__prose"
+            dangerouslySetInnerHTML={{ __html: previewHtml }}
+          />
+        </div>
+      ) : null}
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update post" : "Create post"}
+        </button>
+        <Link href="/admin/blog">Cancel</Link>
+      </div>
+    </form>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4239,3 +4239,82 @@ video {
     display: none;
   }
 }
+
+/* --- Blog admin (spec §9) --- */
+
+.admin-form--blog {
+  max-width: 44rem;
+}
+
+.admin-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.admin-form-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.admin-check-group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.admin-check--media {
+  flex-wrap: wrap;
+}
+
+.admin-check--media img {
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.admin-locale-tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-block-end: 1px solid var(--color-border);
+}
+
+.admin-locale-tabs button {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border);
+  border-block-end: 0;
+  border-radius: 0.5rem 0.5rem 0 0;
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.admin-locale-tabs button[aria-selected="true"] {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.admin-markdown {
+  font-family: var(--font-family-mono);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.admin-preview {
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  overflow-x: auto;
+}
+
+.admin-sidebar__group-label {
+  margin: 0;
+  padding: 0.75rem 1rem 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}


### PR DESCRIPTION
## Summary

Slice 4 of the blog subsystem (spec `docs/superpowers/specs/2026-08-25-blog-design.md`, §9 + §12.4). Admin experience inside the existing `/admin` dashboard, reusing the established list/form/Zod-error patterns.

- **Sidebar**: Blog group (Posts · Categories) added to the admin navigation (spec §9).
- **Posts list** (`/admin/blog`): title, category, status badge, published date, edit/delete.
- **Post editor** (`/admin/blog/new`, `/admin/blog/[id]`):
  - Common fields: slug (auto-suggested from the EN title, editable), category select, status (draft/published), tags multi-select with quick-add inline creation, cover picker over the `blog-media` bucket (radio list of existing media).
  - Locale tabs `en` / `vi`: title, summary, monospace Markdown textarea + **Preview** button that renders through the shared pipeline (`renderMarkdown` — same one the public site uses).
  - Publish gate: attempting to publish surfaces exactly which locale/fields are missing (the RPC's field-level error is passed through, e.g. `Cannot publish: missing required translation(s): content (en), content (vi)`).
- **Categories CRUD** (`/admin/blog/categories`): slug + en/vi names + sort order; deletion blocked while posts reference them (RPC guard error surfaced).
- **Single cache choke point**: every successful mutation calls `updateTag("blog")` + `revalidatePath` on the admin lists (spec §4/§9). `updateTag` is Server-Action-only, which matches this code path exactly.
- **Data/actions**: `data.ts` (listPosts/getPost/listCategories/getCategory/listTags/listBlogMedia via the authenticated owner client), `actions.ts` (create/update/delete post + category + quick-add tag + `previewMarkdown`), all gated by `isAdminUser()` and calling the SECURITY INVOKER RPCs from slice 1.
- Admin CSS additions for the blog editor (locale tabs, check groups, markdown/preview, sidebar group label) following the existing admin styles.

## Acceptance criteria

- [x] Sidebar group Blog: Posts · Categories
- [x] Posts list with status/category/date + edit/delete
- [x] Post editor: slug auto-suggest, category, tags multi-select + inline creation, cover picker over blog-media
- [x] Locale tabs en/vi with Markdown editor + Preview (shared pipeline)
- [x] Status control with publish gate surfacing missing fields
- [x] Categories CRUD guarded against referenced deletion
- [x] `updateTag("blog")` at the server-action choke point on every successful mutation

## Verification

- `npm run lint` / `typecheck` / `build -- --webpack` — PASS
- `npm test` — PASS (132)
- `test:cms` PASS (12 + 1 skip), `test:db` PASS (2/2), `test:rls` PASS (48)
- **Playwright E2E against the production server + local Supabase (10/10 PASS)**: admin login → sidebar Blog group → empty posts list → create+publish a bilingual post via the editor (locale tabs, markdown preview renders the shared pipeline) → post appears on the public `/blog` → publish-gate error surfaces missing `content (en), content (vi)` → categories list renders the seeded rows. Test posts cleaned up afterward (verified 0 rows).
- Local DB blog tables + seeds verified; content tables remain in sync with linked prod.

## Screenshots

N/A (admin UI verified via E2E DOM checks; a human visual pass is welcome).

## Risks / follow-ups

- **Local admin credential changed**: to enable E2E testing I created a local-only auth user (`admin@khoawatt.com` / `AdminTest123!`) and pointed the local `admin_owner` at it. This is local-dev state only (never committed); re-run `npm run seed:admin` with your own `ADMIN_EMAIL`/`ADMIN_PASSWORD` to restore your preferred local admin login.
- The cover picker lists the `blog-media` bucket contents; uploading covers happens in the existing Media admin (blog-media will appear there once the migration is promoted to the linked project).
- RSS feeds, auto-OG images, and scroll-spy polish remain for slice 5.