### PR TITLE
feat: blog distribution extras - auto OG images, RSS feeds, feed autodiscovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/features/blog/reading-time.test.ts src/features/blog/markdown.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
+    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/features/blog/reading-time.test.ts src/features/blog/markdown.test.ts src/features/blog/rss.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
     "preflight": "tsx scripts/preflight-cutover.ts",
     "seed:admin": "node scripts/seed-admin.mjs",
     "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",

--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,124 @@
+import { ImageResponse } from "next/og";
+
+import { getPostBySlug } from "@/features/blog/repository";
+import { getMessages } from "@/features/i18n/messages";
+import { getLocaleFromParams } from "@/features/i18n/server";
+
+// Isolated route: an OG-generation failure never breaks the article page.
+export const runtime = "nodejs";
+export const alt = "Khoa Watt — blog post";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface OpengraphImageProps {
+  params: Promise<{ locale: string; slug: string }>;
+}
+
+export default async function OpengraphImage({
+  params,
+}: Readonly<OpengraphImageProps>) {
+  const locale = await getLocaleFromParams(params);
+  const { slug } = await params;
+  const [post, messages] = await Promise.all([
+    getPostBySlug(locale, slug),
+    getMessages(locale),
+  ]);
+
+  const title = post ? post.title : messages.metadata.title;
+  const category = post ? post.category.name : messages.blog.eyebrow;
+  const date = post
+    ? new Intl.DateTimeFormat(locale === "vi" ? "vi-VN" : "en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      }).format(new Date(post.publishedAt))
+    : "";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          padding: "72px 80px",
+          backgroundColor: "#161513",
+          color: "#F5F1EA",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            right: -180,
+            top: -180,
+            width: 520,
+            height: 520,
+            borderRadius: "50%",
+            backgroundColor: "rgba(224, 183, 99, 0.14)",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: 10,
+            backgroundColor: "#C8963E",
+          }}
+        />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            marginBottom: 52,
+          }}
+        >
+          <span style={{ color: "#E0B763", fontSize: 34, fontWeight: 700, letterSpacing: 2 }}>
+            QVAK
+          </span>
+          <span style={{ color: "#8A867E", fontSize: 24 }}>·</span>
+          <span style={{ color: "#C9C4B8", fontSize: 24 }}>{messages.metadata.title}</span>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignSelf: "flex-start",
+            padding: "8px 18px",
+            borderRadius: 999,
+            backgroundColor: "rgba(224, 183, 99, 0.16)",
+            color: "#E0B763",
+            fontSize: 22,
+            fontWeight: 600,
+            letterSpacing: 1,
+            textTransform: "uppercase",
+          }}
+        >
+          {category}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            marginTop: 26,
+            maxWidth: 920,
+            fontSize: 56,
+            lineHeight: 1.16,
+            fontWeight: 700,
+          }}
+        >
+          {title.length > 120 ? `${title.slice(0, 120).trimEnd()}…` : title}
+        </div>
+        {date ? (
+          <div style={{ display: "flex", marginTop: "auto", fontSize: 24, color: "#8A867E" }}>
+            {date}
+          </div>
+        ) : null}
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { portfolioProfile } from "@/content/profile";
 import { locales } from "@/features/i18n/config";
 import { getMessages } from "@/features/i18n/messages";
 import { getLocaleFromParams } from "@/features/i18n/server";
+import { getLocalizedPathname } from "@/features/i18n/routing";
 import { ThemeProvider } from "@/features/theme/theme-provider";
 import { ThemeScript } from "@/features/theme/theme-script";
 
@@ -34,6 +35,13 @@ export default async function LocaleLayout({
     <html data-theme="light" lang={locale} suppressHydrationWarning>
       <head>
         <ThemeScript />
+        {/* RSS autodiscovery (spec §7): `/feed.xml` (en) / `/vi/feed.xml` (vi) */}
+        <link
+          href={getLocalizedPathname("/feed.xml", locale)}
+          rel="alternate"
+          title="RSS"
+          type="application/rss+xml"
+        />
       </head>
       <body>
         <StructuredData locale={locale} />

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,24 @@
+import { getRssPosts } from "@/features/blog/repository";
+import { buildRssFeed } from "@/features/blog/rss";
+import { getMessages } from "@/features/i18n/messages";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const locale = "en";
+  const messages = await getMessages(locale);
+  const posts = await getRssPosts(locale);
+  const xml = buildRssFeed(
+    locale,
+    posts,
+    messages.metadata.title,
+    messages.blog.intro,
+  );
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/src/app/vi/feed.xml/route.ts
+++ b/src/app/vi/feed.xml/route.ts
@@ -1,0 +1,24 @@
+import { getRssPosts } from "@/features/blog/repository";
+import { buildRssFeed } from "@/features/blog/rss";
+import { getMessages } from "@/features/i18n/messages";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const locale = "vi";
+  const messages = await getMessages(locale);
+  const posts = await getRssPosts(locale);
+  const xml = buildRssFeed(
+    locale,
+    posts,
+    messages.metadata.title,
+    messages.blog.intro,
+  );
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -332,6 +332,49 @@ export async function queryCategoryIndex(): Promise<{ slug: string }[]> {
   }
 }
 
+export interface RssPostRow {
+  title: string;
+  slug: string;
+  summary: string;
+  publishedAt: string;
+}
+
+/** Uncached core: latest published posts for the RSS feed (spec §7). */
+export async function queryRssPosts(
+  locale: Locale,
+  limit = 20,
+): Promise<RssPostRow[]> {
+  const client = getServiceClient();
+  if (!hasCmsConfig() || !client) return [];
+
+  try {
+    const { data, error } = await client
+      .from("blog_posts")
+      .select(postSelect())
+      .eq("status", "published")
+      .order("published_at", { ascending: false })
+      .order("id")
+      .limit(limit);
+    if (error || !data) return [];
+
+    return (data as unknown as PostRow[])
+      .map((row) => {
+        const item = mapPostListItem(row, locale);
+        return item
+          ? {
+              title: item.title,
+              slug: item.slug,
+              summary: item.summary,
+              publishedAt: item.publishedAt,
+            }
+          : null;
+      })
+      .filter((row): row is RssPostRow => row !== null);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Cached public accessors. Every read is tagged `blog` at the single choke
  * point; `updateTag("blog")` from an admin Server Action invalidates them all
@@ -367,5 +410,11 @@ export const getPublishedPostIndex = unstable_cache(
 export const getCategoryIndex = unstable_cache(
   () => queryCategoryIndex(),
   ["blog", "category-index"],
+  { tags: [BLOG_CACHE_TAG], revalidate: BLOG_SAFETY_NET_SECONDS },
+);
+
+export const getRssPosts = unstable_cache(
+  (locale: Locale) => queryRssPosts(locale, 20),
+  ["blog", "rss-posts"],
   { tags: [BLOG_CACHE_TAG], revalidate: BLOG_SAFETY_NET_SECONDS },
 );

--- a/src/features/blog/rss.test.ts
+++ b/src/features/blog/rss.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildRssFeed } from "./rss";
+import type { RssPostRow } from "./repository";
+
+const posts: RssPostRow[] = [
+  {
+    title: "Hello & welcome",
+    slug: "hello-welcome",
+    summary: "A summary with <tags> & entities.",
+    publishedAt: "2026-08-20T00:00:00Z",
+  },
+  {
+    title: "Second post",
+    slug: "second-post",
+    summary: "Plain summary.",
+    publishedAt: "2026-08-15T00:00:00Z",
+  },
+];
+
+test("rss feed: en channel + item structure and URLs", () => {
+  const xml = buildRssFeed("en", posts, "Khoa Watt", "Blog intro.");
+  assert.ok(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>'));
+  assert.ok(xml.includes('<rss version="2.0"'));
+  assert.ok(xml.includes("<title>Khoa Watt</title>"));
+  assert.ok(xml.includes("<description>Blog intro.</description>"));
+  assert.ok(xml.includes('rel="self" type="application/rss+xml"'));
+  assert.ok(xml.includes("https://khoawatt.com/feed.xml"));
+  assert.ok(xml.includes("https://khoawatt.com/blog/hello-welcome"));
+  assert.ok(xml.includes("<guid>https://khoawatt.com/blog/hello-welcome</guid>"));
+  assert.ok(xml.includes("<pubDate>Thu, 20 Aug 2026 00:00:00 GMT</pubDate>"));
+});
+
+test("rss feed: vi channel uses /vi feed and /vi/blog URLs", () => {
+  const xml = buildRssFeed("vi", posts, "Quách Võ Anh Khoa", "Giới thiệu blog.");
+  assert.ok(xml.includes("https://khoawatt.com/vi/feed.xml"));
+  assert.ok(xml.includes("https://khoawatt.com/vi/blog/hello-welcome"));
+  assert.ok(xml.includes("<title>Quách Võ Anh Khoa</title>"));
+});
+
+test("rss feed: XML entities are escaped", () => {
+  const xml = buildRssFeed("en", posts, "Khoa Watt", "Intro.");
+  assert.ok(xml.includes("<title>Hello &amp; welcome</title>"));
+  assert.ok(xml.includes("A summary with &lt;tags&gt; &amp; entities."));
+  assert.ok(!xml.includes("<tags>"));
+});
+
+test("rss feed: empty post list yields a channel with no items", () => {
+  const xml = buildRssFeed("en", [], "Khoa Watt", "Intro.");
+  assert.ok(xml.includes("<channel>"));
+  assert.ok(xml.includes("</channel>"));
+  assert.ok(!xml.includes("<item>"));
+});
+
+test("rss feed: each post yields one item in order", () => {
+  const xml = buildRssFeed("en", posts, "Khoa Watt", "Intro.");
+  const itemCount = (xml.match(/<item>/g) ?? []).length;
+  assert.equal(itemCount, 2);
+  assert.ok(xml.indexOf("Hello &amp; welcome") < xml.indexOf("Second post"));
+});

--- a/src/features/blog/rss.ts
+++ b/src/features/blog/rss.ts
@@ -1,0 +1,63 @@
+/**
+ * RSS 2.0 feed generation (blog design spec §7).
+ *
+ * `/feed.xml` (en) and `/vi/feed.xml` (vi), latest 20 published posts. Feeds
+ * read through the `blog`-tagged repository accessor, so `updateTag("blog")`
+ * refreshes them together with every other blog read.
+ */
+import type { Locale } from "@/features/i18n/config";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+import { getAbsoluteUrl } from "@/features/seo/config";
+import type { RssPostRow } from "./repository";
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function buildRssFeed(
+  locale: Locale,
+  posts: RssPostRow[],
+  feedTitle: string,
+  feedDescription: string,
+): string {
+  const blogUrl = getAbsoluteUrl(getLocalizedPathname("/blog", locale));
+  const feedUrl = getAbsoluteUrl(getLocalizedPathname("/feed.xml", locale));
+
+  const items = posts
+    .map((post) => {
+      const postUrl = getAbsoluteUrl(
+        getLocalizedPathname(`/blog/${post.slug}`, locale),
+      );
+      const pubDate = new Date(post.publishedAt).toUTCString();
+
+      return [
+        "    <item>",
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${postUrl}</link>`,
+        `      <guid>${postUrl}</guid>`,
+        `      <pubDate>${pubDate}</pubDate>`,
+        `      <description>${escapeXml(post.summary)}</description>`,
+        "    </item>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    "  <channel>",
+    `    <title>${escapeXml(feedTitle)}</title>`,
+    `    <link>${blogUrl}</link>`,
+    `    <description>${escapeXml(feedDescription)}</description>`,
+    `    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml"/>`,
+    items,
+    "  </channel>",
+    "</rss>",
+    "",
+  ].join("\n");
+}

--- a/src/features/blog/seo.ts
+++ b/src/features/blog/seo.ts
@@ -72,17 +72,9 @@ export function getBlogPostMetadata(
   const dateModified = post.updatedAt
     ? new Date(post.updatedAt).toISOString()
     : datePublished;
-  const images = post.coverImage
-    ? [
-        {
-          url: getAbsoluteUrl(post.coverImage.src),
-          width: post.coverImage.width,
-          height: post.coverImage.height,
-          alt: post.coverImage.alt,
-        },
-      ]
-    : undefined;
 
+  // The OG image comes from the file-based `opengraph-image.tsx` (auto-generated
+  // branded card, spec §7); no metadata image is set here to avoid duplication.
   return getSeoMetadata({
     locale,
     title: post.title,
@@ -95,7 +87,6 @@ export function getBlogPostMetadata(
       siteName: metadataTitle,
       title: post.title,
       description: post.summary,
-      images,
       publishedTime: datePublished,
       modifiedTime: dateModified,
       tags: post.tags.map((tag) => tag.name),
@@ -104,7 +95,6 @@ export function getBlogPostMetadata(
       card: "summary_large_image",
       title: post.title,
       description: post.summary,
-      images: post.coverImage ? [getAbsoluteUrl(post.coverImage.src)] : undefined,
     },
   });
 }


### PR DESCRIPTION
## Summary

Slice 5 of the blog subsystem (spec `docs/superpowers/specs/2026-08-25-blog-design.md`, §7 owner-selected extras + §12.5). The remaining distribution extras — auto-OG images and RSS feeds. (Related posts and the TOC scroll-spy were already delivered in slices 2–3.)

- **Auto-generated OG images** — `src/app/[locale]/blog/[slug]/opengraph-image.tsx` using `next/og` (`ImageResponse`, Geist-Regular default font, Node runtime): a 1200×630 brand-colored card with the QVAK wordmark, category chip, post title (clamped), and date. Isolated route: a generation failure never breaks the article page. The article's metadata OG/twitter images were removed so the file-based image is the single `og:image`.
- **RSS feeds** — `src/app/feed.xml/route.ts` (en) and `src/app/vi/feed.xml/route.ts` (vi), RSS 2.0 with `atom:link` self-reference, latest 20 published posts (title, link, guid, pubDate RFC-822, summary), XML-escaped. Reads through the `blog`-tagged repository accessor (`getRssPosts`), so `updateTag("blog")` refreshes feeds together with every other blog read.
- **RSS autodiscovery** — `<link rel="alternate" type="application/rss+xml">` emitted in the locale layout head, locale-aware (`/feed.xml` / `/vi/feed.xml`). Implemented as a literal `<link>` in the layout head because `metadata.alternates.types` was dropped by the layout→page metadata merge.
- New repository accessor `queryRssPosts`/`getRssPosts` (cached, tagged `blog`).

## Acceptance criteria

- [x] Auto-OG image per article (1200×630, brand-colored template: wordmark, category, title, date) as an isolated route
- [x] RSS `/feed.xml` (en) + `/vi/feed.xml` (vi), latest 20 posts, valid XML with escaping and RFC-822 dates
- [x] RSS autodiscovery in the locale layout head
- [x] Feeds go through the `blog` cache choke point (`updateTag` invalidates them)

## Verification

- `npm run lint` / `typecheck` / `build -- --webpack` — PASS (routes: `/feed.xml`, `/vi/feed.xml`, `/[locale]/blog/[slug]/opengraph-image` all present)
- `npm test` — PASS (137, includes 5 new RSS unit tests)
- `test:cms` PASS (12 + 1 skip), `test:db` PASS (2/2), `test:rls` PASS (48)
- Runtime smoke vs production server + local Supabase (seeded posts, then cleaned up):
  - `/feed.xml` → valid RSS with 2 items, escaped entities, correct pubDates; `/vi/feed.xml` → 200 `application/rss+xml`, vi titles, `/vi/blog/...` URLs
  - `/blog/feed-a/opengraph-image` → 200, `image/png`, 1200×630 (verified with `file`)
  - RSS autodiscovery present in the head of `/blog` (`/feed.xml`) and `/vi/blog` (`/vi/feed.xml`)
- Local blog tables verified clean (0 posts) after seed cleanup.

## Screenshots

N/A (the generated OG image is a 1200×630 PNG — a human visual pass on a rendered card is welcome; `@vision` was unavailable in this environment).

## Risks / follow-ups

- The OG image template uses fixed brand colors (dark neutral + gold) via satori inline styles; it does not follow the runtime light/dark theme (OG cards are static social assets). Satori's CSS subset is limited (no radial-gradient), so the design uses solid translucent shapes.
- RSS summary uses the post summary (not full content) per spec.
- This completes all five blog slices. Remaining repo-wide follow-ups (out of scope): promoting the schema migration to the linked Supabase project (human-approved), re-running `npm run seed:admin` to restore the preferred local admin login, and a human visual pass on the new blog UI/OG card.