### PR TITLE
feat: expose blog-media bucket in the admin media library for post covers

### DIFF
--- a/src/app/admin/(dashboard)/media/page.tsx
+++ b/src/app/admin/(dashboard)/media/page.tsx
@@ -11,6 +11,7 @@ export const metadata = {
 const buckets: Array<{ id: MediaBucket; label: string; note: string }> = [
   { id: "resume-media", label: "Resume media (private)", note: "Served only through the gated /api/resume-media route." },
   { id: "project-media", label: "Project media (public)", note: "Public project images." },
+  { id: "blog-media", label: "Blog media (public)", note: "Public post covers and in-article images." },
   { id: "portfolio", label: "Portfolio (public)", note: "Profile / social images." },
 ];
 


### PR DESCRIPTION
## Summary

The blog post editor already has a cover picker over the `blog-media` bucket, but the **Media admin page never listed that bucket** — so there was no way to upload cover images through the UI, and the picker was always empty. This exposes `blog-media` in the Media library (same upload/delete flows as the other public buckets).

- `src/app/admin/(dashboard)/media/page.tsx`: added `{ id: "blog-media", label: "Blog media (public)", note: "Public post covers and in-article images." }` to the buckets list. The bucket, its RLS policies (`owner all blog-media objects`, `public read blog-media`), and the `uploadMedia`/`listBucketObjects`/`getMediaPublicUrl` paths already supported it — only the admin listing was missing.

## Acceptance criteria

- [x] Media admin lists and supports upload/delete for `blog-media`
- [x] Post editor cover picker lists uploaded blog-media objects and a selected cover appears on the public listing

## Verification

- `npx eslint src/app/admin/(dashboard)/media/page.tsx` — clean. (`npm run lint` also reports 3 pre-existing errors in the untracked `.gitnexus/run.cjs` tool file — not part of this repo's tracked source.)
- `npm run typecheck` — PASS.
- Playwright E2E (local Supabase, owner session): Media admin shows the Blog media section; uploading a PNG creates an object in `blog-media`; the post editor cover picker lists it and a radio selection persists; publishing a post with that cover renders the cover image on the public `/blog` listing with a `src` pointing at the `blog-media` public URL. Test objects + post cleaned up afterward (local `blog_posts` = 0, matching linked prod).
- Local storage quirk noted: the local storage service needed a restart (`supabase stop`/`start`) to pick up the migration-created bucket for its object-list path; production `blog-media` (public, with policies) was verified earlier during the schema promotion.

## Screenshots

N/A (verified via E2E DOM checks).

## Risks / follow-ups

- In-article images: the Markdown pipeline already renders `![]()` (`<img>` + prose CSS), but there is no in-editor upload/insert flow or `next/image` optimization for images inside post content yet — offered as a follow-up if wanted.
- The production owner still needs to log into the production admin to upload the first real cover and publish the first post.