### PR TITLE
fix(blog): address vision review - full-width related posts, pinned card meta, dark chip contrast, category breadcrumb

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,5 +11,6 @@ export default defineConfig([
     "build/**",
     "next-env.d.ts",
     "supabase/.temp/**",
+    ".gitnexus/**",
   ]),
 ]);

--- a/src/app/[locale]/blog/category/[slug]/page.tsx
+++ b/src/app/[locale]/blog/category/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { BlogCardGrid } from "@/components/blog/blog-card-grid";
@@ -12,6 +13,7 @@ import {
   getBlogCategoryMetadata,
 } from "@/features/blog/seo";
 import { getMessages } from "@/features/i18n/messages";
+import { getLocalizedPathname } from "@/features/i18n/routing";
 import { getLocaleFromParams } from "@/features/i18n/server";
 
 interface BlogCategoryPageProps {
@@ -41,9 +43,25 @@ export default async function BlogCategoryPage({
 
   if (!category) notFound();
 
+  const homePath = getLocalizedPathname("/", locale);
+  const blogPath = getLocalizedPathname("/blog", locale);
+
   return (
     <PageShell>
       <Section className="blog-section">
+        <nav aria-label={messages.blog.breadcrumbLabel} className="blog-breadcrumb">
+          <ol className="blog-breadcrumb__list">
+            <li className="blog-breadcrumb__item">
+              <Link href={homePath}>{messages.blog.homeLabel}</Link>
+            </li>
+            <li className="blog-breadcrumb__item">
+              <Link href={blogPath}>{messages.blog.eyebrow}</Link>
+            </li>
+            <li aria-current="page" className="blog-breadcrumb__item blog-breadcrumb__item--current">
+              {category.name}
+            </li>
+          </ol>
+        </nav>
         <SectionHeading
           description={messages.blog.intro}
           eyebrow={messages.blog.eyebrow}

--- a/src/components/blog/article.tsx
+++ b/src/components/blog/article.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { Container } from "@/components/layout/container";
 import type { PostDetail } from "@/features/blog/types";
 import type { Locale } from "@/features/i18n/config";
 import type { BlogMessages } from "@/features/i18n/messages/types";
@@ -96,28 +97,31 @@ export function Article({ locale, messages, post }: Readonly<ArticleProps>) {
             dangerouslySetInnerHTML={{ __html: post.html }}
           />
 
-          {post.relatedPosts.length > 0 ? (
-            <section
-              aria-labelledby="related-posts-title"
-              className="blog-article__related"
-            >
-              <h2 className="blog-article__related-title" id="related-posts-title">
-                {messages.relatedPosts}
-              </h2>
-              <div className="blog-grid">
-                {post.relatedPosts.map((related) => (
-                  <PostCard
-                    key={related.slug}
-                    locale={locale}
-                    messages={messages}
-                    post={related}
-                  />
-                ))}
-              </div>
-            </section>
-          ) : null}
         </div>
       </div>
+
+      {post.relatedPosts.length > 0 ? (
+        <section
+          aria-labelledby="related-posts-title"
+          className="blog-article__related"
+        >
+          <Container>
+            <h2 className="blog-article__related-title" id="related-posts-title">
+              {messages.relatedPosts}
+            </h2>
+            <div className="blog-grid">
+              {post.relatedPosts.map((related) => (
+                <PostCard
+                  key={related.slug}
+                  locale={locale}
+                  messages={messages}
+                  post={related}
+                />
+              ))}
+            </div>
+          </Container>
+        </section>
+      ) : null}
     </article>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3714,7 +3714,9 @@ video {
 }
 
 .blog-card__body {
-  display: grid;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
   gap: var(--space-2);
   padding: var(--space-5);
 }
@@ -3775,9 +3777,15 @@ video {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin: var(--space-2) 0 0;
+  margin-top: auto;
+  padding-top: var(--space-2);
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+}
+
+[data-theme="dark"] .blog-card__category {
+  color: oklch(88% 0.11 82);
+  background: oklch(31% 0.08 82);
 }
 
 /* --- Pagination --- */


### PR DESCRIPTION
## Summary

Bug-fix PR addressing the four findings from the `@vision` visual review of the blog UI (slices 1–5, already merged):

1. **BLOCKING — related posts squeezed**: On the article detail page, the "Related posts" grid was rendered inside the narrow article reading column (~42rem), forcing a multi-column grid into a ~250px-wide card — causing severe title truncation and broken/overlapping meta lines. Fixed by moving the related-posts section **out of the reading column** to full-width, using the normal `Container` + listing grid (spec §8.3).
2. **MINOR — card meta not pinned**: Cards with different title/summary line counts had the `date · N min read` meta floating at uneven heights. Fixed: `.blog-card__body` is now flex with `margin-top:auto` on `.blog-card__meta` so the meta aligns at the card bottom across a row.
3. **MINOR A11Y — dark-mode category chip contrast**: Gold-on-dark-amber chip fell below WCAG AA (≈3.5:1) in dark mode. Fixed with a lighter gold text + lighter amber background in `[data-theme="dark"]`.
4. **MINOR — missing category breadcrumb**: The category archive page had no `Home / Blog / [Category]` trail (detail page had one). Fixed by adding the same breadcrumb markup (and it was already in the JSON-LD).

Also adds `.gitnexus/**` to the eslint global ignores — `gitnexus analyze` generates a `run.cjs` in `.gitnexus/` that tripped the `no-require-imports` rule; that directory is a tool artifact and should never be linted.

## Acceptance criteria

- [x] Related posts render full-width with properly sized cards (no truncation / broken meta)
- [x] Card meta pinned to the bottom across varying line counts
- [x] Dark-mode category chip meets WCAG AA contrast
- [x] Category archive shows a breadcrumb trail
- [x] eslint ignores the `.gitnexus` tool artifact

## Verification

- `@vision` re-reviewed fresh screenshots: all 4 items **RESOLVED**; article body confirmed to render formatted Markdown (the earlier "raw markdown" was a bad test-seed value, not a code bug).
- `npm run lint` / `typecheck` / `build -- --webpack` — PASS
- `npm test` — PASS (137); `test:cms` PASS; `test:rls` PASS (48)
- Local smoke: `/blog/smoke-post` renders `<h2 id="section-one">` + `hljs language-ts` code (no literal markdown); related posts full-width.

## Screenshots

Updated screenshots captured in the working tree (post-desktop-light/dark, category-desktop-light, blog-desktop-light/dark); `@vision` confirmed all fixes.

## Risks / follow-ups

- Pure UI/CSS fix; no schema, route, or data changes. Merge order independent of PR #94 (blog-media admin, also open).
- The `.gitnexus` ignore only affects lint; the directory itself remains gitignored by its own `.gitignore`.