### PR TITLE
feat: blog in-article image insert - upload and insert markdown images from the post editor

### DIFF
--- a/src/app/admin/(dashboard)/blog/media-insert.tsx
+++ b/src/app/admin/(dashboard)/blog/media-insert.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { uploadMedia } from "@/features/cms/media-actions";
+
+interface MediaOption {
+  name: string;
+  url: string;
+}
+
+interface MediaInsertButtonProps {
+  media: MediaOption[];
+  onInsert: (url: string, alt: string) => void;
+}
+
+function altFromName(name: string): string {
+  return name.replace(/\.[^.]+$/, "").replace(/^\d+-/, "").replace(/[-_]+/g, " ");
+}
+
+/** Inline "Insert image" picker for a Markdown content field: lists existing
+ *  blog-media objects and uploads new ones, inserting `![](url)` at the cursor. */
+export function MediaInsertButton({ media, onInsert }: Readonly<MediaInsertButtonProps>) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploading, startUpload] = useTransition();
+
+  function choose(url: string, name: string) {
+    onInsert(url, altFromName(name));
+    setOpen(false);
+  }
+
+  function upload(file: File | undefined) {
+    if (!file || file.size === 0) return;
+    setError(null);
+
+    startUpload(async () => {
+      const result = await uploadMedia("blog-media", file);
+      if (result.ok && result.publicUrl) {
+        onInsert(result.publicUrl, altFromName(file.name));
+        setOpen(false);
+      } else {
+        setError(result.error ?? "Upload failed.");
+      }
+    });
+  }
+
+  return (
+    <span className="media-insert">
+      <button
+        aria-expanded={open}
+        className="admin-link-button"
+        onClick={() => setOpen((current) => !current)}
+        type="button"
+      >
+        {open ? "Close image picker" : "Insert image"}
+      </button>
+
+      {open ? (
+        <span className="media-insert__panel">
+          {media.length > 0 ? (
+            <span className="media-insert__grid">
+              {media.map((item) => (
+                <button
+                  className="media-insert__thumb"
+                  key={item.name}
+                  onClick={() => choose(item.url, item.name)}
+                  title={item.name}
+                  type="button"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img alt={item.name} height={48} src={item.url} width={64} />
+                  <span className="media-insert__name">{item.name}</span>
+                </button>
+              ))}
+            </span>
+          ) : (
+            <p className="admin-note">No media uploaded yet.</p>
+          )}
+
+          <span className="media-insert__upload">
+            <input
+              accept="image/jpeg,image/png,image/webp"
+              aria-label="Upload image to insert"
+              onChange={(event) => upload(event.currentTarget.files?.[0])}
+              type="file"
+            />
+            {isUploading ? <span className="admin-note">Uploading…</span> : null}
+          </span>
+          {error ? <p className="admin-error">{error}</p> : null}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/post-form.tsx
+++ b/src/app/admin/(dashboard)/blog/post-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -13,6 +13,7 @@ import {
   type BlogPostFormData,
 } from "./actions";
 import type { AdminCategoryRow, AdminPostRow, AdminTagRow } from "./data";
+import { MediaInsertButton } from "./media-insert";
 
 interface CoverOption {
   name: string;
@@ -67,6 +68,26 @@ export function PostForm({
   const [titleVi, setTitleVi] = useState(existing?.titleVi ?? "");
   const [summaryVi, setSummaryVi] = useState(existing?.summaryVi ?? "");
   const [contentMdVi, setContentMdVi] = useState(existing?.contentMdVi ?? "");
+
+  const enContentRef = useRef<HTMLTextAreaElement>(null);
+  const viContentRef = useRef<HTMLTextAreaElement>(null);
+
+  function insertMarkdownImage(tab: LocaleTab, url: string, alt: string) {
+    const textarea = tab === "en" ? enContentRef.current : viContentRef.current;
+    const value = tab === "en" ? contentMdEn : contentMdVi;
+    const setter = tab === "en" ? setContentMdEn : setContentMdVi;
+
+    const position = textarea?.selectionStart ?? value.length;
+    const markdown = `![${alt}](${url})`;
+    setter(`${value.slice(0, position)}${markdown}${value.slice(position)}`);
+
+    window.requestAnimationFrame(() => {
+      if (textarea) {
+        textarea.selectionStart = textarea.selectionEnd = position + markdown.length;
+        textarea.focus();
+      }
+    });
+  }
 
   const [newTagName, setNewTagName] = useState("");
   const [newTagError, setNewTagError] = useState<string | null>(null);
@@ -315,9 +336,16 @@ export function PostForm({
             </label>
             <label className="admin-field">
               <span>Markdown content (EN)</span>
+              <div className="admin-form-row">
+                <MediaInsertButton
+                  media={coverOptions}
+                  onInsert={(url, alt) => insertMarkdownImage("en", url, alt)}
+                />
+              </div>
               <textarea
                 className="admin-markdown"
                 onChange={(event) => setContentMdEn(event.target.value)}
+                ref={enContentRef}
                 rows={14}
                 value={contentMdEn}
               />
@@ -346,9 +374,16 @@ export function PostForm({
             </label>
             <label className="admin-field">
               <span>Markdown content (VI)</span>
+              <div className="admin-form-row">
+                <MediaInsertButton
+                  media={coverOptions}
+                  onInsert={(url, alt) => insertMarkdownImage("vi", url, alt)}
+                />
+              </div>
               <textarea
                 className="admin-markdown"
                 onChange={(event) => setContentMdVi(event.target.value)}
+                ref={viContentRef}
                 rows={14}
                 value={contentMdVi}
               />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4326,3 +4326,57 @@ video {
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
+
+/* --- Blog admin: in-article image insert --- */
+
+.media-insert__panel {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 28rem;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.media-insert__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.media-insert__thumb {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  cursor: pointer;
+  text-align: start;
+}
+
+.media-insert__thumb:hover {
+  border-color: var(--color-accent);
+}
+
+.media-insert__thumb img {
+  width: 100%;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.media-insert__name {
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.media-insert__upload {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary

The Markdown pipeline already rendered in-article images, but there was no way to insert one from the editor. This adds an inline image picker to each Markdown content field (EN and VI) in the post editor.

- `MediaInsertButton` (`src/app/admin/(dashboard)/blog/media-insert.tsx`): lists existing `blog-media` objects (click-to-insert `![](url)`) and supports uploading a new image inline (reuses `uploadMedia("blog-media", file)` from the shared CMS actions, owner-session RLS path). Alt text is derived from the filename.
- `post-form.tsx`: each Markdown textarea now has an "Insert image" button above it; inserting places the markdown at the current cursor position and restores focus.
- CSS for the picker panel/thumbnails following the admin styles.

## Acceptance criteria

- [x] In-article image can be inserted as Markdown from existing blog-media objects
- [x] In-article image can be uploaded inline from the editor and inserted
- [x] Works in both EN and VI content fields
- [x] Inserted images render on the public article page (shared Markdown pipeline)

## Verification

- `npm run lint` / `typecheck` / `build -- --webpack` — PASS
- `npm test` — PASS (137)
- Playwright E2E (local Supabase, owner session) — 5/5 PASS: picker opens; uploading an image via the picker inserts `![cover test](http://…/blog-media/…png)` into the EN Markdown; post saves; the published article renders the in-article `<img>` with a blog-media public URL. Test post + uploaded object cleaned up (`blog_posts` = 0, matching linked prod).

## Screenshots

N/A (verified via E2E DOM checks).

## Risks / follow-ups

- Depends on PR #94 (media-admin exposing the `blog-media` bucket) for the full flow; #94 is already merged to main, so this is independent.
- Images inside article content use plain `<img>` + prose CSS (not `next/image` optimization); that remains an optional follow-up.