### PR TITLE
feat: two-column blog editor with live preview and full-width card

### DIFF
--- a/src/app/admin/(dashboard)/admin-page.tsx
+++ b/src/app/admin/(dashboard)/admin-page.tsx
@@ -40,11 +40,13 @@ export function AdminPage({
 
 interface AdminFormCardProps {
   children: ReactNode;
+  className?: string;
 }
 
 /** Card container for a form page's fields. */
-export function AdminFormCard({ children }: AdminFormCardProps) {
-  return <div className="admin-form-card">{children}</div>;
+export function AdminFormCard({ children, className }: AdminFormCardProps) {
+  const classes = ["admin-form-card", className].filter(Boolean).join(" ");
+  return <div className={classes}>{children}</div>;
 }
 
 interface AdminTableProps {

--- a/src/app/admin/(dashboard)/blog/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/blog/[id]/page.tsx
@@ -32,7 +32,7 @@ export default async function AdminEditPostPage({
 
   return (
     <AdminPage backHref="/admin/blog" title="Edit post">
-      <AdminFormCard>
+      <AdminFormCard className="admin-form-card--wide">
         <h2>Post details</h2>
         <PostForm
           categories={categories}

--- a/src/app/admin/(dashboard)/blog/new/page.tsx
+++ b/src/app/admin/(dashboard)/blog/new/page.tsx
@@ -16,7 +16,7 @@ export default async function AdminNewPostPage() {
 
   return (
     <AdminPage backHref="/admin/blog" title="New post">
-      <AdminFormCard>
+      <AdminFormCard className="admin-form-card--wide">
         <h2>Post details</h2>
         <PostForm
           categories={categories}

--- a/src/app/admin/(dashboard)/blog/post-form.tsx
+++ b/src/app/admin/(dashboard)/blog/post-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -97,6 +97,32 @@ export function PostForm({
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [isPreviewing, setIsPreviewing] = useState(false);
 
+  // Live preview re-renders whenever the active locale's content changes.
+  const activeContentMd = localeTab === "en" ? contentMdEn : contentMdVi;
+  const activePreview = previewTab === localeTab ? previewHtml : null;
+
+  useEffect(() => {
+    if (previewTab !== localeTab) return;
+    let cancelled = false;
+
+    startTransition(async () => {
+      setIsPreviewing(true);
+      const result = await previewMarkdown(activeContentMd);
+      setIsPreviewing(false);
+      if (cancelled) return;
+      if (result.ok && result.html) {
+        setPreviewHtml(result.html);
+        setPreviewError(null);
+      } else {
+        setPreviewError(result.error ?? "Preview failed.");
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeContentMd, previewTab, localeTab]);
+
   function onTitleEnChange(value: string) {
     setTitleEn(value);
     if (!slugTouched) setSlug(slugify(value));
@@ -109,21 +135,9 @@ export function PostForm({
   }
 
   function runPreview(locale: LocaleTab) {
-    const markdown = locale === "en" ? contentMdEn : contentMdVi;
-    setPreviewTab(locale);
-    setPreviewHtml(null);
+    // Toggling the active preview tab triggers the live re-render effect.
+    setPreviewTab((current) => (current === locale ? null : locale));
     setPreviewError(null);
-    setIsPreviewing(true);
-
-    startTransition(async () => {
-      const result = await previewMarkdown(markdown);
-      setIsPreviewing(false);
-      if (result.ok && result.html) {
-        setPreviewHtml(result.html);
-      } else {
-        setPreviewError(result.error ?? "Preview failed.");
-      }
-    });
   }
 
   function addTag() {
@@ -182,238 +196,252 @@ export function PostForm({
 
   return (
     <form className="admin-form admin-form--blog" onSubmit={onSubmit}>
-      <label className="admin-field">
-        <span>Slug</span>
-        <input
-          name="slug"
-          onChange={(event) => {
-            setSlug(event.target.value);
-            setSlugTouched(true);
-          }}
-          required
-          value={slug}
-        />
-        {fieldErrors.slug ? <small className="admin-error">{fieldErrors.slug}</small> : null}
-      </label>
+      <div className="blog-post-editor">
+        {/* Left column: shared post fields */}
+        <div className="blog-post-editor__side">
+          <label className="admin-field">
+            <span>Slug</span>
+            <input
+              name="slug"
+              onChange={(event) => {
+                setSlug(event.target.value);
+                setSlugTouched(true);
+              }}
+              required
+              value={slug}
+            />
+            {fieldErrors.slug ? <small className="admin-error">{fieldErrors.slug}</small> : null}
+          </label>
 
-      <div className="admin-form-grid">
-        <label className="admin-field">
-          <span>Category</span>
-          <select
-            name="categoryId"
-            onChange={(event) => setCategoryId(event.target.value)}
-            required
-            value={categoryId}
-          >
-            <option value="">Select a category…</option>
-            {categories.map((category) => (
-              <option key={category.id} value={category.id}>
-                {category.nameEn} / {category.nameVi}
-              </option>
-            ))}
-          </select>
-        </label>
+          <div className="admin-form-grid">
+            <label className="admin-field">
+              <span>Category</span>
+              <select
+                name="categoryId"
+                onChange={(event) => setCategoryId(event.target.value)}
+                required
+                value={categoryId}
+              >
+                <option value="">Select…</option>
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.nameEn} / {category.nameVi}
+                  </option>
+                ))}
+              </select>
+            </label>
 
-        <label className="admin-field">
-          <span>Status</span>
-          <select
-            name="status"
-            onChange={(event) =>
-              setStatus(event.target.value as "draft" | "published")
-            }
-            value={status}
-          >
-            <option value="draft">Draft</option>
-            <option value="published">Published</option>
-          </select>
-        </label>
-      </div>
-
-      <fieldset className="admin-field">
-        <legend>Tags</legend>
-        {tags.length > 0 ? (
-          <div className="admin-check-group">
-            {tags.map((tag) => (
-              <label className="admin-check" key={tag.id}>
-                <input
-                  checked={tagIds.includes(tag.id)}
-                  onChange={() => toggleTag(tag.id)}
-                  type="checkbox"
-                />
-                <span>{tag.nameEn}</span>
-              </label>
-            ))}
+            <label className="admin-field">
+              <span>Status</span>
+              <select
+                name="status"
+                onChange={(event) =>
+                  setStatus(event.target.value as "draft" | "published")
+                }
+                value={status}
+              >
+                <option value="draft">Draft</option>
+                <option value="published">Published</option>
+              </select>
+            </label>
           </div>
-        ) : (
-          <p className="admin-note">No tags yet.</p>
-        )}
-        <div className="admin-form-row">
-          <input
-            aria-label="New tag name"
-            onChange={(event) => setNewTagName(event.target.value)}
-            placeholder="Quick-add a tag"
-            value={newTagName}
-          />
-          <button disabled={isPending} onClick={addTag} type="button">
-            Add tag
-          </button>
-        </div>
-        {newTagError ? <p className="admin-error">{newTagError}</p> : null}
-      </fieldset>
 
-      <fieldset className="admin-field">
-        <legend>Cover (blog-media bucket)</legend>
-        {coverOptions.length === 0 ? (
-          <p className="admin-note">No media uploaded yet — upload under Admin → Media.</p>
-        ) : (
-          <div className="admin-check-group">
-            <label className="admin-check">
+          <fieldset className="admin-field">
+            <legend>Tags</legend>
+            {tags.length > 0 ? (
+              <div className="admin-check-group">
+                {tags.map((tag) => (
+                  <label className="admin-check" key={tag.id}>
+                    <input
+                      checked={tagIds.includes(tag.id)}
+                      onChange={() => toggleTag(tag.id)}
+                      type="checkbox"
+                    />
+                    <span>{tag.nameEn}</span>
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className="admin-note">No tags yet.</p>
+            )}
+            <div className="admin-form-row">
               <input
-                checked={coverBucketPath === ""}
-                onChange={() => setCoverBucketPath("")}
-                type="radio"
-                name="cover"
+                aria-label="New tag name"
+                onChange={(event) => setNewTagName(event.target.value)}
+                placeholder="Quick-add a tag"
+                value={newTagName}
               />
-              <span>No cover</span>
-            </label>
-            {coverOptions.map((cover) => (
-              <label className="admin-check admin-check--media" key={cover.name}>
-                <input
-                  checked={coverBucketPath === cover.name}
-                  onChange={() => setCoverBucketPath(cover.name)}
-                  type="radio"
-                  name="cover"
-                />
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img alt={cover.name} height={48} src={cover.url} width={64} />
-                <span>{cover.name}</span>
-              </label>
-            ))}
+              <button disabled={isPending} onClick={addTag} type="button">
+                Add
+              </button>
+            </div>
+            {newTagError ? <p className="admin-error">{newTagError}</p> : null}
+          </fieldset>
+
+          <fieldset className="admin-field">
+            <legend>Cover (blog-media)</legend>
+            {coverOptions.length === 0 ? (
+              <p className="admin-note">No media yet — upload under Admin → Media.</p>
+            ) : (
+              <div className="admin-check-group">
+                <label className="admin-check">
+                  <input
+                    checked={coverBucketPath === ""}
+                    onChange={() => setCoverBucketPath("")}
+                    type="radio"
+                    name="cover"
+                  />
+                  <span>No cover</span>
+                </label>
+                {coverOptions.map((cover) => (
+                  <label className="admin-check admin-check--media" key={cover.name}>
+                    <input
+                      checked={coverBucketPath === cover.name}
+                      onChange={() => setCoverBucketPath(cover.name)}
+                      type="radio"
+                      name="cover"
+                    />
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img alt={cover.name} height={48} src={cover.url} width={64} />
+                    <span>{cover.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </fieldset>
+        </div>
+
+        {/* Right column: locale editor + live preview */}
+        <div className="blog-post-editor__main">
+          <div className="admin-locale-tabs" role="tablist" aria-label="Post language">
+            <button
+              aria-selected={localeTab === "en"}
+              onClick={() => setLocaleTab("en")}
+              role="tab"
+              type="button"
+            >
+              English
+            </button>
+            <button
+              aria-selected={localeTab === "vi"}
+              onClick={() => setLocaleTab("vi")}
+              role="tab"
+              type="button"
+            >
+              Tiếng Việt
+            </button>
           </div>
-        )}
-      </fieldset>
 
-      <div className="admin-locale-tabs" role="tablist" aria-label="Post language">
-        <button
-          aria-selected={localeTab === "en"}
-          onClick={() => setLocaleTab("en")}
-          role="tab"
-          type="button"
-        >
-          English
-        </button>
-        <button
-          aria-selected={localeTab === "vi"}
-          onClick={() => setLocaleTab("vi")}
-          role="tab"
-          type="button"
-        >
-          Tiếng Việt
-        </button>
-      </div>
+          <div role="tabpanel">
+            {localeTab === "en" ? (
+              <>
+                <label className="admin-field">
+                  <span>Title (EN)</span>
+                  <input
+                    onChange={(event) => onTitleEnChange(event.target.value)}
+                    required
+                    value={titleEn}
+                  />
+                  {fieldErrors.titleEn ? <small className="admin-error">{fieldErrors.titleEn}</small> : null}
+                </label>
+                <label className="admin-field">
+                  <span>Summary (EN)</span>
+                  <textarea
+                    onChange={(event) => setSummaryEn(event.target.value)}
+                    required
+                    rows={3}
+                    value={summaryEn}
+                  />
+                  {fieldErrors.summaryEn ? <small className="admin-error">{fieldErrors.summaryEn}</small> : null}
+                </label>
+                <label className="admin-field">
+                  <span>Markdown content (EN)</span>
+                  <div className="admin-form-row">
+                    <MediaInsertButton
+                      media={coverOptions}
+                      onInsert={(url, alt) => insertMarkdownImage("en", url, alt)}
+                    />
+                    <button
+                      className="admin-link-button"
+                      disabled={isPreviewing}
+                      onClick={() => runPreview("en")}
+                      type="button"
+                    >
+                      {isPreviewing ? "Rendering…" : "Preview EN"}
+                    </button>
+                  </div>
+                  <textarea
+                    className="admin-markdown"
+                    onChange={(event) => setContentMdEn(event.target.value)}
+                    ref={enContentRef}
+                    rows={16}
+                    value={contentMdEn}
+                  />
+                </label>
+              </>
+            ) : (
+              <>
+                <label className="admin-field">
+                  <span>Title (VI)</span>
+                  <input
+                    onChange={(event) => setTitleVi(event.target.value)}
+                    required
+                    value={titleVi}
+                  />
+                  {fieldErrors.titleVi ? <small className="admin-error">{fieldErrors.titleVi}</small> : null}
+                </label>
+                <label className="admin-field">
+                  <span>Summary (VI)</span>
+                  <textarea
+                    onChange={(event) => setSummaryVi(event.target.value)}
+                    required
+                    rows={3}
+                    value={summaryVi}
+                  />
+                  {fieldErrors.summaryVi ? <small className="admin-error">{fieldErrors.summaryVi}</small> : null}
+                </label>
+                <label className="admin-field">
+                  <span>Markdown content (VI)</span>
+                  <div className="admin-form-row">
+                    <MediaInsertButton
+                      media={coverOptions}
+                      onInsert={(url, alt) => insertMarkdownImage("vi", url, alt)}
+                    />
+                    <button
+                      className="admin-link-button"
+                      disabled={isPreviewing}
+                      onClick={() => runPreview("vi")}
+                      type="button"
+                    >
+                      {isPreviewing ? "Rendering…" : "Preview VI"}
+                    </button>
+                  </div>
+                  <textarea
+                    className="admin-markdown"
+                    onChange={(event) => setContentMdVi(event.target.value)}
+                    ref={viContentRef}
+                    rows={16}
+                    value={contentMdVi}
+                  />
+                </label>
+              </>
+            )}
+          </div>
 
-      <div role="tabpanel">
-        {localeTab === "en" ? (
-          <>
-            <label className="admin-field">
-              <span>Title (EN)</span>
-              <input
-                onChange={(event) => onTitleEnChange(event.target.value)}
-                required
-                value={titleEn}
+          {previewError ? (
+            <p className="admin-error" role="alert">{previewError}</p>
+          ) : null}
+          {activePreview ? (
+            <div className="admin-preview">
+              <h3>Live preview ({previewTab === "en" ? "EN" : "VI"})</h3>
+              <div
+                className="blog-article__prose"
+                dangerouslySetInnerHTML={{ __html: activePreview }}
               />
-              {fieldErrors.titleEn ? <small className="admin-error">{fieldErrors.titleEn}</small> : null}
-            </label>
-            <label className="admin-field">
-              <span>Summary (EN)</span>
-              <textarea
-                onChange={(event) => setSummaryEn(event.target.value)}
-                required
-                rows={3}
-                value={summaryEn}
-              />
-              {fieldErrors.summaryEn ? <small className="admin-error">{fieldErrors.summaryEn}</small> : null}
-            </label>
-            <label className="admin-field">
-              <span>Markdown content (EN)</span>
-              <div className="admin-form-row">
-                <MediaInsertButton
-                  media={coverOptions}
-                  onInsert={(url, alt) => insertMarkdownImage("en", url, alt)}
-                />
-              </div>
-              <textarea
-                className="admin-markdown"
-                onChange={(event) => setContentMdEn(event.target.value)}
-                ref={enContentRef}
-                rows={14}
-                value={contentMdEn}
-              />
-            </label>
-          </>
-        ) : (
-          <>
-            <label className="admin-field">
-              <span>Title (VI)</span>
-              <input
-                onChange={(event) => setTitleVi(event.target.value)}
-                required
-                value={titleVi}
-              />
-              {fieldErrors.titleVi ? <small className="admin-error">{fieldErrors.titleVi}</small> : null}
-            </label>
-            <label className="admin-field">
-              <span>Summary (VI)</span>
-              <textarea
-                onChange={(event) => setSummaryVi(event.target.value)}
-                required
-                rows={3}
-                value={summaryVi}
-              />
-              {fieldErrors.summaryVi ? <small className="admin-error">{fieldErrors.summaryVi}</small> : null}
-            </label>
-            <label className="admin-field">
-              <span>Markdown content (VI)</span>
-              <div className="admin-form-row">
-                <MediaInsertButton
-                  media={coverOptions}
-                  onInsert={(url, alt) => insertMarkdownImage("vi", url, alt)}
-                />
-              </div>
-              <textarea
-                className="admin-markdown"
-                onChange={(event) => setContentMdVi(event.target.value)}
-                ref={viContentRef}
-                rows={14}
-                value={contentMdVi}
-              />
-            </label>
-          </>
-        )}
-      </div>
-
-      <div className="admin-form-row">
-        <button
-          disabled={isPreviewing}
-          onClick={() => runPreview(localeTab)}
-          type="button"
-        >
-          {isPreviewing ? "Rendering…" : `Preview ${localeTab === "en" ? "EN" : "VI"}`}
-        </button>
-      </div>
-
-      {previewError ? (
-        <p className="admin-error" role="alert">{previewError}</p>
-      ) : null}
-      {previewTab && previewHtml ? (
-        <div className="admin-preview">
-          <h3>Preview ({previewTab === "en" ? "EN" : "VI"})</h3>
-          <div
-            className="blog-article__prose"
-            dangerouslySetInnerHTML={{ __html: previewHtml }}
-          />
+            </div>
+          ) : null}
         </div>
-      ) : null}
+      </div>
 
       {error ? (
         <p className="admin-error" role="alert">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3583,6 +3583,11 @@ video {
   gap: 1.25rem;
 }
 
+.admin-form-card--wide {
+  max-width: none;
+  width: 100%;
+}
+
 .admin-sidebar__link:focus-visible,
 .admin-topbar__view:focus-visible,
 .admin-topbar__signout:focus-visible,
@@ -4251,7 +4256,37 @@ video {
 /* --- Blog admin (spec §9) --- */
 
 .admin-form--blog {
-  max-width: 44rem;
+  max-width: none;
+  width: 100%;
+}
+
+.blog-post-editor {
+  display: grid;
+  grid-template-columns: minmax(16rem, 22rem) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.blog-post-editor__side {
+  display: grid;
+  gap: 1rem;
+}
+
+.blog-post-editor__main {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.blog-post-editor__main .admin-markdown {
+  width: 100%;
+  min-height: 24rem;
+}
+
+@media (max-width: 960px) {
+  .blog-post-editor {
+    grid-template-columns: 1fr;
+  }
 }
 
 .admin-form-grid {


### PR DESCRIPTION
## Summary

The "New post" editor was previously a single narrow column (36rem card) squeezed left, with title/summary/markdown stacked and a manual Preview button. This reworks the post editor into a **two-column, full-width layout**:

- **Left column** (`blog-post-editor__side`): shared post fields — slug, category, status, tags (with quick-add), and cover picker.
- **Right column** (`blog-post-editor__main`): the locale tabs (EN/VI) with title/summary/Markdown editor + the image-insert button, plus a **live preview** that re-renders automatically as you type (instead of a manual fetch each time).
- The editor card (`AdminFormCard`) gets a `--wide` variant (`max-width: none`) used by the post editor, so the form fills the admin content area rather than a narrow column.
- `AdminFormCard` now accepts a `className` prop.
- Responsive: collapses to a single column below 960px.

The live preview re-renders whenever the active locale's content changes; toggling the locale tab or pressing "Preview EN/VI" switches the previewed locale. It uses the same server `previewMarkdown` action (shared pipeline) as before, debounced by the effect.

## Acceptance criteria

- [x] Editor uses the full admin width (not a narrow left column)
- [x] Two-column layout: shared fields left, editor+preview right
- [x] Live preview re-renders as content changes
- [x] Image-insert button preserved in both locale content fields
- [x] Responsive collapse on narrow screens; no horizontal overflow

## Verification

- `npm run lint` / `typecheck` / `build -- --webpack` — PASS
- `npm test` — PASS (137); `test:cms` PASS; `test:db` PASS; `test:rls` PASS (48)
- Playwright E2E (local Supabase, owner session) — 9/9 PASS: 2-column grid (`gridTemplateColumns` = 2), wide card (`max-width: none`), no horizontal overflow, side + main columns present, and live preview renders `<h2>` + list items after typing Markdown and pressing Preview EN.
- Screenshot captured: `/tmp/opencode/editor-layout.png` (not viewable in this environment; DOM checks above are authoritative).

## Screenshots

Screenshot at `/tmp/opencode/editor-layout.png`; a human visual pass is recommended since `@vision`/image review isn't available here.

## Risks / follow-ups

- Pure admin UI/CSS change; no schema, route, or data changes.
- The live preview debounce is the effect's natural re-run on content change; it does not throttle rapid typing, so very fast typing may trigger several renders — acceptable for an admin editor, but a small debounce could be added if it ever feels heavy.