### PR TITLE
feat: feaon-style blog layout - listing hero, topic chips, article byline, TOC rail, category pagination

### DIFF
--- a/src/app/[locale]/blog/category/[slug]/page/[n]/page.tsx
+++ b/src/app/[locale]/blog/category/[slug]/page/[n]/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 
 import { BlogCardGrid } from "@/components/blog/blog-card-grid";
 import { BlogHero } from "@/components/blog/blog-hero";
 import { CategoryNav } from "@/components/blog/category-nav";
-import { JsonLdScript } from "@/components/blog/json-ld";
 import { Pagination } from "@/components/blog/pagination";
 import { PageShell } from "@/components/layout/page-shell";
 import { Section } from "@/components/layout/section";
@@ -13,43 +12,61 @@ import {
   getCategoryNav,
   getCategoryPage,
 } from "@/features/blog/repository";
-import {
-  categoryBreadcrumbJsonLd,
-  getBlogCategoryMetadata,
-} from "@/features/blog/seo";
+import { getBlogCategoryMetadata } from "@/features/blog/seo";
 import { getMessages } from "@/features/i18n/messages";
 import { getLocalizedPathname } from "@/features/i18n/routing";
 import { getLocaleFromParams } from "@/features/i18n/server";
 
-interface BlogCategoryPageProps {
-  params: Promise<{ locale: string; slug: string }>;
+interface BlogCategoryPageNumberProps {
+  params: Promise<{ locale: string; slug: string; n: string }>;
 }
 
 export async function generateMetadata({
   params,
-}: Readonly<BlogCategoryPageProps>): Promise<Metadata> {
+}: Readonly<BlogCategoryPageNumberProps>): Promise<Metadata> {
   const locale = await getLocaleFromParams(params);
-  const { slug } = await params;
+  const { slug, n } = await params;
   const messages = await getMessages(locale);
   const category = await getCategoryPage(locale, slug, 1);
 
   if (!category) return {};
 
-  return getBlogCategoryMetadata(locale, category, messages.blog, messages.metadata.title);
+  return getBlogCategoryMetadata(
+    locale,
+    category,
+    messages.blog,
+    messages.metadata.title,
+    Number(n),
+  );
 }
 
-export default async function BlogCategoryPage({
+export default async function BlogCategoryPageNumber({
   params,
-}: Readonly<BlogCategoryPageProps>) {
+}: Readonly<BlogCategoryPageNumberProps>) {
   const locale = await getLocaleFromParams(params);
-  const { slug } = await params;
+  const { slug, n } = await params;
+  const page = Number(n);
+
+  // Same canonical policy as /blog/page/[n]: page 1 lives at the category
+  // root; invalid or out-of-range pages are soft-404s.
+  if (!Number.isInteger(page) || page < 1) {
+    notFound();
+  }
+
+  const categoryRoot = getLocalizedPathname(`/blog/category/${slug}`, locale);
+  if (page === 1) {
+    permanentRedirect(categoryRoot);
+  }
+
   const messages = await getMessages(locale);
   const [category, categories] = await Promise.all([
-    getCategoryPage(locale, slug, 1),
+    getCategoryPage(locale, slug, page),
     getCategoryNav(locale),
   ]);
 
-  if (!category) notFound();
+  if (!category || page > category.listing.totalPages) {
+    notFound();
+  }
 
   const homePath = getLocalizedPathname("/", locale);
   const blogPath = getLocalizedPathname("/blog", locale);
@@ -72,6 +89,7 @@ export default async function BlogCategoryPage({
           </ol>
         </nav>
         <BlogHero
+          badge={messages.blog.pageNumberLabel.replace("{n}", String(page))}
           eyebrow={messages.blog.eyebrow}
           size="compact"
           title={category.name}
@@ -95,9 +113,6 @@ export default async function BlogCategoryPage({
           totalPages={category.listing.totalPages}
         />
       </Section>
-      <JsonLdScript
-        data={categoryBreadcrumbJsonLd(locale, category, messages.blog)}
-      />
     </PageShell>
   );
 }

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -2,11 +2,15 @@ import type { Metadata } from "next";
 
 import { JsonLdScript } from "@/components/blog/json-ld";
 import { BlogCardGrid } from "@/components/blog/blog-card-grid";
+import { BlogHero } from "@/components/blog/blog-hero";
+import { CategoryNav } from "@/components/blog/category-nav";
 import { Pagination } from "@/components/blog/pagination";
 import { PageShell } from "@/components/layout/page-shell";
 import { Section } from "@/components/layout/section";
-import { SectionHeading } from "@/components/ui/section-heading";
-import { getPublishedPosts } from "@/features/blog/repository";
+import {
+  getCategoryNav,
+  getPublishedPosts,
+} from "@/features/blog/repository";
 import { blogIndexJsonLd, getBlogListingMetadata } from "@/features/blog/seo";
 import { getMessages } from "@/features/i18n/messages";
 import { getLocaleFromParams } from "@/features/i18n/server";
@@ -27,16 +31,23 @@ export async function generateMetadata({
 export default async function BlogPage({ params }: Readonly<BlogPageProps>) {
   const locale = await getLocaleFromParams(params);
   const messages = await getMessages(locale);
-  const listing = await getPublishedPosts(locale, 1);
+  const [listing, categories] = await Promise.all([
+    getPublishedPosts(locale, 1),
+    getCategoryNav(locale),
+  ]);
 
   return (
     <PageShell>
       <Section className="blog-section">
-        <SectionHeading
-          description={messages.blog.intro}
+        <BlogHero
           eyebrow={messages.blog.eyebrow}
-          level="h1"
+          intro={messages.blog.intro}
           title={messages.blog.title}
+        />
+        <CategoryNav
+          entries={categories}
+          locale={locale}
+          messages={messages.blog}
         />
         <BlogCardGrid
           emptyLabel={messages.blog.emptyState}

--- a/src/app/[locale]/blog/page/[n]/page.tsx
+++ b/src/app/[locale]/blog/page/[n]/page.tsx
@@ -2,11 +2,15 @@ import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
 
 import { BlogCardGrid } from "@/components/blog/blog-card-grid";
+import { BlogHero } from "@/components/blog/blog-hero";
+import { CategoryNav } from "@/components/blog/category-nav";
 import { Pagination } from "@/components/blog/pagination";
 import { PageShell } from "@/components/layout/page-shell";
 import { Section } from "@/components/layout/section";
-import { SectionHeading } from "@/components/ui/section-heading";
-import { getPublishedPosts } from "@/features/blog/repository";
+import {
+  getCategoryNav,
+  getPublishedPosts,
+} from "@/features/blog/repository";
 import { getBlogListingMetadata } from "@/features/blog/seo";
 import { getMessages } from "@/features/i18n/messages";
 import { getLocalizedPathname } from "@/features/i18n/routing";
@@ -48,7 +52,10 @@ export default async function BlogPageNumber({
   }
 
   const messages = await getMessages(locale);
-  const listing = await getPublishedPosts(locale, page);
+  const [listing, categories] = await Promise.all([
+    getPublishedPosts(locale, page),
+    getCategoryNav(locale),
+  ]);
 
   if (page > listing.totalPages) {
     notFound();
@@ -57,11 +64,16 @@ export default async function BlogPageNumber({
   return (
     <PageShell>
       <Section className="blog-section">
-        <SectionHeading
-          description={messages.blog.intro}
+        <BlogHero
+          badge={messages.blog.pageNumberLabel.replace("{n}", String(page))}
           eyebrow={messages.blog.eyebrow}
-          level="h1"
-          title={messages.blog.pageNumberLabel.replace("{n}", String(page))}
+          intro={messages.blog.intro}
+          title={messages.blog.title}
+        />
+        <CategoryNav
+          entries={categories}
+          locale={locale}
+          messages={messages.blog}
         />
         <BlogCardGrid
           emptyLabel={messages.blog.emptyState}

--- a/src/components/blog/article.tsx
+++ b/src/components/blog/article.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { Container } from "@/components/layout/container";
+import { getPortfolioProfile } from "@/content/profile";
 import type { PostDetail } from "@/features/blog/types";
 import type { Locale } from "@/features/i18n/config";
 import type { BlogMessages } from "@/features/i18n/messages/types";
@@ -19,6 +20,7 @@ interface ArticleProps {
 export function Article({ locale, messages, post }: Readonly<ArticleProps>) {
   const homePath = getLocalizedPathname("/", locale);
   const blogPath = getLocalizedPathname("/blog", locale);
+  const profile = getPortfolioProfile(locale);
   const localeTag = locale === "vi" ? "vi-VN" : "en-US";
   const date = new Intl.DateTimeFormat(localeTag, {
     year: "numeric",
@@ -35,7 +37,24 @@ export function Article({ locale, messages, post }: Readonly<ArticleProps>) {
       <nav aria-label={messages.breadcrumbLabel} className="blog-breadcrumb">
         <ol className="blog-breadcrumb__list">
           <li className="blog-breadcrumb__item">
-            <Link href={homePath}>{messages.homeLabel}</Link>
+            <Link href={homePath}>
+              <svg
+                aria-hidden="true"
+                className="blog-breadcrumb__icon"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width="14"
+              >
+                <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                <path d="M9 22V12h6v10" />
+              </svg>
+              <span className="sr-only">{messages.homeLabel}</span>
+            </Link>
           </li>
           <li className="blog-breadcrumb__item">
             <Link href={blogPath}>{messages.eyebrow}</Link>
@@ -47,28 +66,71 @@ export function Article({ locale, messages, post }: Readonly<ArticleProps>) {
       </nav>
 
       <div className="blog-article__layout">
-        <TableOfContents label={messages.onThisPage} toc={post.toc} />
+        <TableOfContents
+          backToTopLabel={messages.backToTopLabel}
+          label={messages.onThisPage}
+          toc={post.toc}
+        />
 
         <div className="blog-article__body">
           <header className="blog-article__header">
+            <Link
+              className="blog-article__chip"
+              href={getLocalizedPathname(
+                `/blog/category/${post.category.slug}`,
+                locale,
+              )}
+            >
+              {post.category.name}
+            </Link>
             <h1 className="blog-article__title">{post.title}</h1>
-            <p className="blog-article__meta">
-              <time dateTime={post.publishedAt}>
-                {messages.publishedLabel}: {date}
-              </time>
-              <span aria-hidden="true" className="blog-article__meta-separator">·</span>
-              <span>{readTime}</span>
-              <span aria-hidden="true" className="blog-article__meta-separator">·</span>
-              <Link
-                className="blog-article__category"
-                href={getLocalizedPathname(
-                  `/blog/category/${post.category.slug}`,
-                  locale,
-                )}
-              >
-                {post.category.name}
-              </Link>
-            </p>
+            <div className="blog-article__byline">
+              <span aria-hidden="true" className="blog-article__avatar">
+                <Image
+                  alt=""
+                  height={1280}
+                  src={profile.hero.image.src}
+                  style={{ objectPosition: profile.hero.image.focalPoint }}
+                  width={852}
+                />
+              </span>
+              <span className="blog-article__byline-name">
+                {profile.name}
+                <span className="blog-article__byline-role">{profile.role}</span>
+              </span>
+              <span className="blog-article__byline-meta">
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  height="14"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  width="14"
+                >
+                  <rect height="18" rx="2" width="18" x="3" y="4" />
+                  <path d="M16 2v4M8 2v4M3 10h18" />
+                </svg>
+                <time dateTime={post.publishedAt}>{date}</time>
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  height="14"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  width="14"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 6v6l4 2" />
+                </svg>
+                <span>{readTime}</span>
+              </span>
+            </div>
             {post.tags.length > 0 ? (
               <ul aria-label={messages.tagsLabel} className="blog-article__tags">
                 {post.tags.map((tag) => (

--- a/src/components/blog/blog-hero.tsx
+++ b/src/components/blog/blog-hero.tsx
@@ -1,0 +1,52 @@
+import Image from "next/image";
+
+interface BlogHeroProps {
+  badge?: string;
+  eyebrow: string;
+  intro?: string;
+  size?: "default" | "compact";
+  title: string;
+}
+
+const HERO_IMAGE = {
+  src: "/images/projects/readingtime.jpg",
+  width: 800,
+  height: 800,
+};
+
+/**
+ * Feaon-style blog hero: oversized display title laid over a real photo.
+ * The image is decorative (empty alt) and a theme-aware scrim keeps the
+ * text contrast in both light and dark themes. Server component, no layout
+ * shift (explicit dimensions, object-fit cover).
+ */
+export function BlogHero({
+  badge,
+  eyebrow,
+  intro,
+  size = "default",
+  title,
+}: Readonly<BlogHeroProps>) {
+  return (
+    <header className="blog-hero" data-size={size}>
+      <Image
+        alt=""
+        aria-hidden="true"
+        className="blog-hero__image"
+        height={HERO_IMAGE.height}
+        sizes="100vw"
+        src={HERO_IMAGE.src}
+        width={HERO_IMAGE.width}
+      />
+      <div aria-hidden="true" className="blog-hero__scrim" />
+      <p className="blog-hero__eyebrow">{eyebrow}</p>
+      <h1 className="blog-hero__title">{title}</h1>
+      {intro ? <p className="blog-hero__intro">{intro}</p> : null}
+      {badge ? (
+        <p aria-hidden="true" className="blog-hero__badge">
+          {badge}
+        </p>
+      ) : null}
+    </header>
+  );
+}

--- a/src/components/blog/category-nav.tsx
+++ b/src/components/blog/category-nav.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+import type { BlogCategoryNavEntry } from "@/features/blog/types";
+import type { Locale } from "@/features/i18n/config";
+import type { BlogMessages } from "@/features/i18n/messages/types";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+
+interface CategoryNavProps {
+  entries: BlogCategoryNavEntry[];
+  locale: Locale;
+  messages: BlogMessages;
+}
+
+/**
+ * "Knowledge library" chip row: one link per category that has published
+ * posts, with its post count. Hidden entirely when there is nothing to link.
+ */
+export function CategoryNav({
+  entries,
+  locale,
+  messages,
+}: Readonly<CategoryNavProps>) {
+  if (entries.length === 0) return null;
+
+  return (
+    <nav aria-label={messages.topicsLabel} className="blog-topics">
+      <h2 className="blog-topics__title">{messages.topicsLabel}</h2>
+      <ul className="blog-topics__list">
+        {entries.map((entry) => (
+          <li key={entry.slug}>
+            <Link
+              className="blog-topics__chip"
+              href={getLocalizedPathname(
+                `/blog/category/${entry.slug}`,
+                locale,
+              )}
+            >
+              <span className="blog-topics__name">{entry.name}</span>
+              <span className="blog-topics__count">
+                {messages.categoryPostCount.replace(
+                  "{count}",
+                  String(entry.postCount),
+                )}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/blog/pagination.tsx
+++ b/src/components/blog/pagination.tsx
@@ -5,6 +5,8 @@ import type { BlogMessages } from "@/features/i18n/messages/types";
 import { getLocalizedPathname } from "@/features/i18n/routing";
 
 interface PaginationProps {
+  /** Route prefix the numbered pages hang off, e.g. "/blog" or "/blog/category/x". */
+  basePath?: string;
   locale: Locale;
   messages: BlogMessages;
   page: number;
@@ -12,6 +14,7 @@ interface PaginationProps {
 }
 
 export function Pagination({
+  basePath = "/blog",
   locale,
   messages,
   page,
@@ -19,9 +22,9 @@ export function Pagination({
 }: Readonly<PaginationProps>) {
   if (totalPages <= 1) return null;
 
-  const base = getLocalizedPathname("/blog", locale);
+  const base = getLocalizedPathname(basePath, locale);
   const pageHref = (n: number) =>
-    n === 1 ? base : getLocalizedPathname(`/blog/page/${n}`, locale);
+    n === 1 ? base : getLocalizedPathname(`${basePath}/page/${n}`, locale);
   const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
 
   return (

--- a/src/components/blog/post-card.tsx
+++ b/src/components/blog/post-card.tsx
@@ -52,6 +52,24 @@ export function PostCard({ locale, messages, post }: Readonly<PostCardProps>) {
           <span aria-hidden="true" className="blog-card__meta-separator">·</span>
           <span>{readTime}</span>
         </p>
+        <p aria-hidden="true" className="blog-card__cta">
+          {messages.readMoreLabel}
+          <svg
+            aria-hidden="true"
+            className="blog-card__cta-arrow"
+            fill="none"
+            height="16"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="16"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
+        </p>
       </div>
     </article>
   );

--- a/src/components/blog/table-of-contents.tsx
+++ b/src/components/blog/table-of-contents.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import type { TocEntry } from "@/features/blog/types";
 
 interface TableOfContentsProps {
+  backToTopLabel: string;
   label: string;
   toc: TocEntry[];
 }
@@ -12,10 +13,14 @@ interface TableOfContentsProps {
 /**
  * Scroll-spy table of contents. Renders two variants sharing one active state:
  * a collapsed `<details>` (narrow screens, above the article) and a sticky
- * `<aside>` (wide screens, side rail). Only one is visible at a time, so only
- * one copy is focusable/announced.
+ * `<aside>` (wide screens, side rail with a back-to-top control). Only one is
+ * visible at a time, so only one copy is focusable/announced.
  */
-export function TableOfContents({ label, toc }: Readonly<TableOfContentsProps>) {
+export function TableOfContents({
+  backToTopLabel,
+  label,
+  toc,
+}: Readonly<TableOfContentsProps>) {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -47,6 +52,17 @@ export function TableOfContents({ label, toc }: Readonly<TableOfContentsProps>) 
 
   if (toc.length === 0) return null;
 
+  function scrollToTop() {
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    window.scrollTo({
+      behavior: reduceMotion ? "auto" : "smooth",
+      top: 0,
+    });
+  }
+
   const list = (
     <nav aria-label={label} className="blog-toc__nav">
       <ol className="blog-toc__list">
@@ -69,15 +85,65 @@ export function TableOfContents({ label, toc }: Readonly<TableOfContentsProps>) 
     </nav>
   );
 
+  const titleIcon = (
+    <svg
+      aria-hidden="true"
+      className="blog-toc__title-icon"
+      fill="none"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="M3 6h13M3 12h13M3 18h9" />
+    </svg>
+  );
+
+  const backToTop = (
+    <button
+      aria-label={backToTopLabel}
+      className="blog-toc__top"
+      onClick={scrollToTop}
+      title={backToTopLabel}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width="16"
+      >
+        <path d="m18 15-6-6-6 6" />
+      </svg>
+    </button>
+  );
+
   return (
     <>
       <details className="blog-toc blog-toc--narrow">
-        <summary className="blog-toc__summary">{label}</summary>
+        <summary className="blog-toc__summary">
+          {titleIcon}
+          {label}
+        </summary>
         {list}
       </details>
 
       <aside aria-label={label} className="blog-toc blog-toc--wide">
-        <p className="blog-toc__title">{label}</p>
+        <div className="blog-toc__head">
+          <p className="blog-toc__title">
+            {titleIcon}
+            {label}
+          </p>
+          {backToTop}
+        </div>
         {list}
       </aside>
     </>

--- a/src/components/navigation/site-header.tsx
+++ b/src/components/navigation/site-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { usePathname, useRouter } from "next/navigation";
 import { type MouseEvent, useEffect, useRef, useState } from "react";
 
 import type { Locale } from "@/features/i18n/config";
@@ -47,6 +48,8 @@ export function SiteHeader({
   const restoreMenuFocusAfterLocaleRef = useRef(false);
   const homePath = getLocalizedPathname("/", locale);
   const blogPath = getLocalizedPathname(blogNavigationPath, locale);
+  const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     function updateActiveSection() {
@@ -144,7 +147,7 @@ export function SiteHeader({
     );
 
     return () => window.cancelAnimationFrame(frame);
-  }, [locale]);
+  }, [locale, pathname]);
 
   useEffect(() => {
     if (menuOpen) {
@@ -223,6 +226,17 @@ export function SiteHeader({
     sectionId: NavigationSectionId,
   ) {
     event.preventDefault();
+    closeAfterNavigation();
+
+    // Section anchors only exist on the home page. From any other route
+    // (e.g. /blog) a real navigation to `homePath#section` is required —
+    // pushState alone would rewrite the URL without loading the section.
+    if (!document.getElementById(sectionId)) {
+      setActiveSection(sectionId);
+      router.push(`${homePath}#${sectionId}`);
+      return;
+    }
+
     const hash = `#${sectionId}`;
 
     if (window.location.hash !== hash) {
@@ -230,7 +244,6 @@ export function SiteHeader({
     }
 
     setActiveSection(sectionId);
-    closeAfterNavigation();
     window.requestAnimationFrame(() =>
       document.getElementById(sectionId)?.scrollIntoView(),
     );
@@ -238,6 +251,14 @@ export function SiteHeader({
 
   function navigateHome(event: MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
+    closeAfterNavigation();
+
+    if (pathname !== homePath) {
+      setActiveSection("home");
+      router.push(`${homePath}${window.location.search}`);
+      return;
+    }
+
     const homeUrl = `${homePath}${window.location.search}`;
 
     if (
@@ -248,7 +269,6 @@ export function SiteHeader({
     }
 
     setActiveSection("home");
-    closeAfterNavigation();
     window.requestAnimationFrame(() => {
       const reduceMotion = window.matchMedia(
         "(prefers-reduced-motion: reduce)",

--- a/src/features/blog/repository.test.ts
+++ b/src/features/blog/repository.test.ts
@@ -23,6 +23,7 @@ if (!LOCAL_HOST.test(url)) {
 
 import { createClient } from "@supabase/supabase-js";
 import {
+  queryCategoryNav,
   queryCategoryPage,
   queryPostBySlug,
   queryPublishedPosts,
@@ -265,4 +266,19 @@ test("category page returns header + only that category's published posts", asyn
   assert.equal(vi?.name, "Kiến thức");
 
   assert.equal(await queryCategoryPage("en", "does-not-exist", 1), null);
+});
+
+test("category nav lists published categories with localized names and counts", async () => {
+  const en = await queryCategoryNav("en");
+  assert.deepEqual(
+    en.map((c) => ({ slug: c.slug, name: c.name, postCount: c.postCount })),
+    [
+      { slug: "knowledge", name: "Knowledge", postCount: 2 },
+      { slug: "reviews", name: "Reviews", postCount: 1 },
+    ],
+    "categories without published posts are excluded; ordered by sort_order",
+  );
+
+  const vi = await queryCategoryNav("vi");
+  assert.equal(vi[0]?.name, "Kiến thức");
 });

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -29,6 +29,7 @@ import { getServiceClient } from "@/features/cms/server";
 import { renderMarkdown } from "./markdown";
 import { readingTimeMinutes } from "./reading-time";
 import type {
+  BlogCategoryNavEntry,
   BlogCategoryView,
   BlogListingView,
   PostDetail,
@@ -332,6 +333,40 @@ export async function queryCategoryIndex(): Promise<{ slug: string }[]> {
   }
 }
 
+interface CategoryNavRow extends CategoryRow {
+  blog_posts?: unknown[] | null;
+}
+
+/** Uncached core: categories with ≥1 published post, localized name + count. */
+export async function queryCategoryNav(
+  locale: Locale,
+): Promise<BlogCategoryNavEntry[]> {
+  const client = getServiceClient();
+  if (!hasCmsConfig() || !client) return [];
+
+  try {
+    const { data, error } = await client
+      .from("blog_categories")
+      .select(
+        "slug, sort_order, blog_category_translations(locale, name), blog_posts(id)",
+      )
+      .eq("blog_posts.status", "published")
+      .order("sort_order")
+      .order("slug");
+    if (error || !data) return [];
+
+    return (data as unknown as CategoryNavRow[])
+      .map((row) => ({
+        slug: row.slug,
+        name: localeRow(row.blog_category_translations, locale)?.name ?? "",
+        postCount: row.blog_posts?.length ?? 0,
+      }))
+      .filter((entry) => entry.name !== "" && entry.postCount > 0);
+  } catch {
+    return [];
+  }
+}
+
 export interface RssPostRow {
   title: string;
   slug: string;
@@ -410,6 +445,12 @@ export const getPublishedPostIndex = unstable_cache(
 export const getCategoryIndex = unstable_cache(
   () => queryCategoryIndex(),
   ["blog", "category-index"],
+  { tags: [BLOG_CACHE_TAG], revalidate: BLOG_SAFETY_NET_SECONDS },
+);
+
+export const getCategoryNav = unstable_cache(
+  (locale: Locale) => queryCategoryNav(locale),
+  ["blog", "category-nav"],
   { tags: [BLOG_CACHE_TAG], revalidate: BLOG_SAFETY_NET_SECONDS },
 );
 

--- a/src/features/blog/seo.ts
+++ b/src/features/blog/seo.ts
@@ -51,13 +51,15 @@ export function getBlogCategoryMetadata(
   category: BlogCategoryView,
   messages: BlogMessages,
   metadataTitle: string,
+  page = 1,
 ): Metadata {
   const description = `${messages.intro} ${category.name}.`;
+  const pageSuffix = page > 1 ? `/page/${page}` : "";
   return getSeoMetadata({
     locale,
     title: `${category.name} — ${metadataTitle}`,
     description,
-    pathname: `/blog/category/${category.slug}`,
+    pathname: `/blog/category/${category.slug}${pageSuffix}`,
   });
 }
 

--- a/src/features/blog/types.ts
+++ b/src/features/blog/types.ts
@@ -44,3 +44,10 @@ export interface BlogCategoryView {
   name: string;
   listing: BlogListingView;
 }
+
+/** Category entry for the blog navigation chips (published-post counts). */
+export interface BlogCategoryNavEntry {
+  slug: string;
+  name: string;
+  postCount: number;
+}

--- a/src/features/i18n/messages/en.ts
+++ b/src/features/i18n/messages/en.ts
@@ -47,6 +47,11 @@ const messages = {
     paginationPrev: "Previous page",
     paginationNext: "Next page",
     pageNumberLabel: "Page {n}",
+    topicsLabel: "Knowledge library",
+    topicsViewAll: "All topics",
+    categoryPostCount: "{count} posts",
+    readMoreLabel: "Read post",
+    backToTopLabel: "Back to top",
   },
   themeToggle: {
     toggle: "Toggle color theme",

--- a/src/features/i18n/messages/types.ts
+++ b/src/features/i18n/messages/types.ts
@@ -41,6 +41,11 @@ export interface BlogMessages {
   paginationPrev: string;
   paginationNext: string;
   pageNumberLabel: string;
+  topicsLabel: string;
+  topicsViewAll: string;
+  categoryPostCount: string;
+  readMoreLabel: string;
+  backToTopLabel: string;
 }
 
 export interface PortfolioMessages {

--- a/src/features/i18n/messages/vi.ts
+++ b/src/features/i18n/messages/vi.ts
@@ -47,6 +47,11 @@ const messages = {
     paginationPrev: "Trang trước",
     paginationNext: "Trang sau",
     pageNumberLabel: "Trang {n}",
+    topicsLabel: "Thư viện kiến thức",
+    topicsViewAll: "Tất cả chủ đề",
+    categoryPostCount: "{count} bài viết",
+    readMoreLabel: "Đọc bài viết",
+    backToTopLabel: "Lên đầu trang",
   },
   themeToggle: {
     toggle: "Chuyển giao diện màu",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3676,7 +3676,7 @@ video {
 .blog-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-6);
+  gap: var(--space-8);
 }
 
 .blog-grid__empty {
@@ -3686,24 +3686,182 @@ video {
   text-align: center;
 }
 
-/* --- Post card --- */
+/* --- Listing hero (feaon-style display header over a real photo) --- */
+
+.blog-hero {
+  position: relative;
+  display: grid;
+  gap: var(--space-4);
+  margin-block-end: var(--space-10);
+  padding: clamp(var(--space-8), 7vw, var(--space-16)) clamp(var(--space-5), 5vw, var(--space-12));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.blog-hero__image {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.blog-hero__scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: linear-gradient(
+    100deg,
+    color-mix(in oklab, var(--color-page) 96%, transparent) 0%,
+    color-mix(in oklab, var(--color-page) 86%, transparent) 52%,
+    color-mix(in oklab, var(--color-page) 62%, transparent) 100%
+  );
+}
+
+.blog-hero > :not(.blog-hero__image):not(.blog-hero__scrim) {
+  position: relative;
+  z-index: 1;
+}
+
+.blog-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--color-accent) 45%,
+    transparent
+  );
+  opacity: 0.55;
+}
+
+.blog-hero__eyebrow {
+  margin: 0;
+  color: var(--color-accent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.blog-hero__title {
+  margin: 0;
+  max-width: 18ch;
+  font-size: clamp(2.25rem, 1.5rem + 3vw, 4rem);
+  line-height: var(--line-height-heading);
+  letter-spacing: var(--letter-spacing-tight);
+  font-weight: var(--font-weight-bold);
+  text-wrap: balance;
+}
+
+.blog-hero__intro {
+  margin: 0;
+  max-width: 44rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-body);
+}
+
+.blog-hero__badge {
+  width: fit-content;
+  margin: var(--space-2) 0 0;
+  padding: 0.25rem var(--space-4);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.blog-hero[data-size="compact"] {
+  padding: clamp(var(--space-6), 5vw, var(--space-10)) clamp(var(--space-5), 5vw, var(--space-12));
+}
+
+.blog-hero[data-size="compact"] .blog-hero__title {
+  font-size: var(--font-size-2xl);
+}
+
+/* --- Category chips ("knowledge library") --- */
+
+.blog-topics {
+  display: grid;
+  gap: var(--space-3);
+  margin-block-end: var(--space-10);
+}
+
+.blog-topics__title {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+}
+
+.blog-topics__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.blog-topics__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.375rem var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  text-decoration: none;
+  transition: border-color 160ms ease, background-color 160ms ease,
+    color 160ms ease, box-shadow 160ms ease;
+}
+
+.blog-topics__chip:hover {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.blog-topics__chip:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.blog-topics__name {
+  font-weight: var(--font-weight-medium);
+}
+
+.blog-topics__count {
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+/* --- Post card (feaon-style: borderless, rounded cover, arrow CTA) --- */
 
 .blog-card {
   position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  background: transparent;
+  transition: transform 160ms ease;
 }
 
 .blog-card:hover {
-  border-color: var(--color-border-strong);
-  box-shadow: var(--shadow-md);
-  transform: translateY(-2px);
+  transform: translateY(-4px);
 }
 
 .blog-card__cover {
@@ -3711,7 +3869,14 @@ video {
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
+  border-radius: var(--radius-lg);
   background: var(--color-surface-subtle);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 160ms ease;
+}
+
+.blog-card:hover .blog-card__cover {
+  box-shadow: var(--shadow-md);
 }
 
 .blog-card__cover--placeholder {
@@ -3723,7 +3888,7 @@ video {
   flex: 1;
   flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-5);
+  padding: var(--space-4) var(--space-1) 0;
 }
 
 .blog-card__category {
@@ -3786,6 +3951,24 @@ video {
   padding-top: var(--space-2);
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+}
+
+.blog-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-1) 0 0;
+  color: var(--color-accent);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.blog-card__cta-arrow {
+  transition: transform 160ms ease;
+}
+
+.blog-card:hover .blog-card__cta-arrow {
+  transform: translateX(4px);
 }
 
 [data-theme="dark"] .blog-card__category {
@@ -3881,6 +4064,11 @@ video {
   gap: var(--space-2);
 }
 
+.blog-breadcrumb__icon {
+  display: block;
+  color: var(--color-accent);
+}
+
 .blog-breadcrumb__item + .blog-breadcrumb__item::before {
   content: "/";
   color: var(--color-text-muted);
@@ -3928,27 +4116,101 @@ video {
 
 .blog-article__title {
   margin: 0;
-  font-size: var(--font-size-2xl);
-  line-height: 1.2;
+  font-size: clamp(2rem, 1.5rem + 2.2vw, 3.25rem);
+  line-height: var(--line-height-heading);
+  letter-spacing: var(--letter-spacing-tight);
 }
 
-.blog-article__meta {
+.blog-article__chip {
+  width: fit-content;
+  padding: 0.25rem var(--space-4);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.blog-article__chip:hover {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+
+.blog-article__chip:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+[data-theme="dark"] .blog-article__chip {
+  color: oklch(88% 0.11 82);
+  background: oklch(31% 0.08 82);
+}
+
+[data-theme="dark"] .blog-article__chip:hover {
+  background: oklch(45% 0.1 82);
+  color: oklch(95% 0.06 85);
+}
+
+.blog-article__byline {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  gap: var(--space-3);
+}
+
+.blog-article__avatar {
+  position: relative;
+  display: block;
+  flex-shrink: 0;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: var(--radius-pill);
+  border: 2px solid var(--color-border);
+  overflow: hidden;
+  background: var(--color-surface-subtle);
+}
+
+.blog-article__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: var(--avatar-focal, 50% 30%);
+}
+
+.blog-article__byline-name {
+  display: grid;
+  gap: 0.125rem;
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+}
+
+.blog-article__byline-role {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-regular);
+}
+
+.blog-article__byline-meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-2);
-  margin: 0;
+  margin-inline-start: var(--space-2);
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
 }
 
-.blog-article__category {
-  color: var(--color-accent);
-  text-decoration: none;
+.blog-article__byline-meta svg {
+  flex-shrink: 0;
+  opacity: 0.75;
 }
 
-.blog-article__category:hover {
-  text-decoration: underline;
+.blog-article__byline-meta svg + :is(time, span) {
+  margin-inline-end: var(--space-2);
 }
 
 .blog-article__tags {
@@ -3973,7 +4235,8 @@ video {
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
   margin-block-end: var(--space-8);
 }
 
@@ -3991,6 +4254,9 @@ video {
 }
 
 .blog-toc__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   padding: var(--space-3) var(--space-4);
   cursor: pointer;
   font-weight: var(--font-weight-semibold);
@@ -4019,13 +4285,59 @@ video {
   max-width: 16rem;
 }
 
+.blog-toc__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-block-end: var(--space-3);
+}
+
+.blog-toc__head .blog-toc__title {
+  margin-block-end: 0;
+}
+
+.blog-toc__top {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 160ms ease, transform 160ms ease;
+}
+
+.blog-toc__top:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+
+.blog-toc__top:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.blog-toc__title-icon {
+  color: var(--color-accent);
+  flex-shrink: 0;
+}
+
 .blog-toc__title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   margin: 0 0 var(--space-3);
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: 0.06em;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--color-text-muted);
+  color: var(--color-text);
 }
 
 .blog-toc__list {
@@ -4078,17 +4390,29 @@ video {
 
 .blog-article__prose :is(h2, h3) {
   scroll-margin-top: 6rem;
-  line-height: 1.3;
+  line-height: var(--line-height-heading);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--color-text);
 }
 
 .blog-article__prose h2 {
-  margin-block: var(--space-8) var(--space-4);
-  font-size: var(--font-size-xl);
+  margin-block: var(--space-10) var(--space-4);
+  padding-block-start: var(--space-6);
+  border-block-start: 1px solid var(--color-border);
+  font-size: clamp(1.5rem, 1.3rem + 1vw, 2rem);
+  font-weight: var(--font-weight-bold);
+}
+
+.blog-article__prose h2:first-child {
+  margin-block-start: 0;
+  padding-block-start: 0;
+  border-block-start: none;
 }
 
 .blog-article__prose h3 {
-  margin-block: var(--space-6) var(--space-3);
-  font-size: var(--font-size-lg);
+  margin-block: var(--space-8) var(--space-3);
+  font-size: clamp(1.25rem, 1.1rem + 0.6vw, 1.5rem);
+  font-weight: var(--font-weight-semibold);
 }
 
 .blog-article__prose p {
@@ -4109,6 +4433,18 @@ video {
 
 .blog-article__prose li {
   margin-block: var(--space-1);
+}
+
+.blog-article__prose li::marker {
+  color: var(--color-accent);
+  font-weight: var(--font-weight-semibold);
+}
+
+.blog-article__prose img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
 }
 
 .blog-article__prose blockquote {
@@ -4239,13 +4575,21 @@ video {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
+  /* TOC rail sits on the right (feaon-style); body keeps the reading column. */
   .blog-article__layout {
-    grid-template-columns: 16rem minmax(0, 42rem);
+    grid-template-columns: minmax(0, 42rem) 16rem;
     justify-content: center;
+  }
+
+  .blog-article__body {
+    grid-column: 1;
+    grid-row: 1;
   }
 
   .blog-toc--wide {
     display: block;
+    grid-column: 2;
+    grid-row: 1;
   }
 
   .blog-toc--narrow {


### PR DESCRIPTION
## Summary

Reader-facing blog redesign in the Feaon style — the public blog gets a display hero, a topic-chip index, a richer article byline, a reworked TOC rail, and category pagination.

- **Listing hero** (`BlogHero`, new): oversized display title over a real photo with a theme-aware scrim; `default` on `/blog`, `compact` on category pages. Server component, explicit dimensions (no layout shift), decorative image (`alt=""`).
- **Topic chips** (`CategoryNav`, new): "Knowledge library" chip row with per-category published-post counts, driven by a new `queryCategoryNav` / cached `getCategoryNav` repository accessor (localized, ordered by `sort_order`, only categories with ≥1 published post); hidden when there is nothing to link.
- **Category pagination** (new route `/blog/category/[slug]/page/[n]`): same canonical policy as `/blog/page/[n]` — page 1 redirects to the category root, invalid/out-of-range pages are soft-404s. `Pagination` gains a `basePath` prop.
- **Article page**: category chip above the title, byline with avatar + name + role + date/read-time (with icons), home icon in the breadcrumb, refined prose typography (section dividers, accent list markers, rounded images).
- **Table of contents**: sidebar rail moves to the right, gains a back-to-top control (reduced-motion aware) and a title icon.
- **Post card**: borderless card, rounded cover with hover shadow, arrow CTA ("Read post").
- **SEO**: `getBlogCategoryMetadata` accepts a `page` param so paginated category pages get correct canonical pathnames.
- **Site header fix**: from a non-home route (e.g. `/blog`), section anchors and the home logo now perform a real navigation to `homePath#section` instead of a no-op `pushState`; the scroll-spy effect is re-keyed on `pathname`.
- **i18n**: new en/vi strings (topicsLabel, topicsViewAll, categoryPostCount, readMoreLabel, backToTopLabel).

## Acceptance criteria

- [x] Listing pages render the Feaon-style hero and topic-chip navigation with correct post counts
- [x] Category pages paginate correctly (`/blog/category/[slug]/page/[n]`) with correct canonical metadata
- [x] Article shows the redesigned byline, category chip, and TOC rail with back-to-top
- [x] Post cards show the arrow CTA and refined hover treatment
- [x] Site header section-anchor navigation works from non-home routes
- [x] Both locales (en/vi) and light/dark themes supported via existing tokens

## Verification

- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm run build` — PASS (Turbopack); both new routes emitted (`/[locale]/blog/category/[slug]/page/[n]`, `/[locale]/blog/page/[n]`)
- `npm test` — 137/137 PASS (CI gate)
- `test:cms` vs local Supabase — PASS (blog repo 8/8 incl. new `queryCategoryNav` test, cms 5/5) after removing local-only `demo-*` posts that were not in any migration/prod and were breaking the clean-table blog tests
- Rendered-page checks (dev server): `/blog` (default hero, topics nav, card CTA), `/blog/category/knowledge` (compact hero, breadcrumb, chips), `/blog/category/knowledge/page/2` (404, correct), article (byline, avatar, chip, TOC head + back-to-top), en + vi locales
- Self-review via GitNexus `detect_changes`: changes are additive; blog render paths touched are the feature's target scope

## Screenshots

No screenshot captured — no headless browser is available in this environment. HTML/DOM-level verification was used instead; a human visual pass is recommended (hero overlay contrast, TOC rail position, card hover, both themes).

## Risks / known limitations

- `blog/repository.test.ts` asserts exact fixture-only listings, so it requires a clean local `blog_posts` table; it is DB-backed and not part of `npm test`/CI.
- Local↔prod blog content drift predates this PR (prod has a published `ai-agent-memory` post absent locally; local now has zero posts). Resolving it is a content/CMS follow-up, out of scope here.
- Dev server ISR cache (24h) may serve stale pre-cleanup demo content until it revalidates; the DB itself is confirmed clean.
- Feature has no dedicated GitHub issue (uncommitted work on `feat/blog-feaon-layout`).