### PR TITLE
fix: allowlist Supabase storage host for the next/image optimizer (blog covers never displayed)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,52 @@
 import type { NextConfig } from "next";
 
+/**
+ * Allow-list of remote image hosts the next/image optimizer may fetch from.
+ *
+ * CMS media (blog covers, project/resume/portfolio buckets) lives in Supabase
+ * Storage, so its host is derived from NEXT_PUBLIC_SUPABASE_URL — local and
+ * production resolve automatically. To serve images from another service
+ * later, append one entry to EXTRA_IMAGE_HOSTS (protocol + hostname, optional
+ * port); no other change is needed.
+ */
+function supabaseStoragePattern(): {
+  protocol: "http" | "https";
+  hostname: string;
+  port?: string;
+} | null {
+  const raw = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return {
+      protocol: url.protocol === "https:" ? "https" : "http",
+      hostname: url.hostname,
+      ...(url.port ? { port: url.port } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+const EXTRA_IMAGE_HOSTS: {
+  protocol: "http" | "https";
+  hostname: string;
+  port?: string;
+}[] = [];
+
+const supabaseHost = supabaseStoragePattern();
+
 const nextConfig: NextConfig = {
   skipTrailingSlashRedirect: true,
   outputFileTracingIncludes: {
     "/api/resume-media/[file]": ["./private-assets/resume/**/*"],
+  },
+  images: {
+    remotePatterns: [
+      ...(supabaseHost ? [supabaseHost] : []),
+      ...EXTRA_IMAGE_HOSTS,
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary

Blog post covers never displayed because the CMS cover is rendered through `next/image` with an absolute Supabase Storage URL, but `next.config.ts` configured no `images.remotePatterns`. Vercel's image optimizer therefore rejected every request with `400 INVALID_IMAGE_OPTIMIZE_REQUEST`, even though the underlying storage object itself was publicly reachable (raw URL returned 200). This surfaced only now with the first real post that has a cover — every earlier/demo post had a NULL `cover_bucket_path` and rendered the placeholder instead.

The fix derives the allowed host from `NEXT_PUBLIC_SUPABASE_URL`, so local (`http://127.0.0.1:54331`) and production resolve automatically, and adds an explicit `EXTRA_IMAGE_HOSTS` list: serving images from any future service requires appending one `{ protocol, hostname }` entry there, nothing else.

Inline article images (markdown `<img>`) were never affected since they bypass the optimizer; projects use local static paths, so they were unaffected too.

## Verification

- Reproduced the failing layer first: raw storage URL `200`; `/_next/image?url=<same object>` on production `400 INVALID_IMAGE_OPTIMIZE_REQUEST`
- After fix: built app served locally with prod env override — optimizer returns `200` for the exact cover URL (w=828 and w=1920)
- Negative control: unlisted host still rejected with `400` (allow-list remains enforced)
- `npm run lint`, `npm run typecheck`, `npm run build -- --webpack` — PASS

## Risks

- Config-only change; no runtime code touched. Worst case an image host is missing → same visible symptom as before (placeholder), no security regression (allow-list stays closed by default).
