### PR TITLE
fix(blog): single H1 per article - renderer strips a leading h1 from the markdown body

### DIFF
--- a/src/app/admin/(dashboard)/blog/post-form.tsx
+++ b/src/app/admin/(dashboard)/blog/post-form.tsx
@@ -377,6 +377,10 @@ export function PostForm({
                     rows={16}
                     value={contentMdEn}
                   />
+                  <small className="admin-hint">
+                    Start the body with `##` headings — the title above is the single H1 of the
+                    page, and a leading `#` line is dropped when rendering.
+                  </small>
                 </label>
               </>
             ) : (
@@ -423,6 +427,10 @@ export function PostForm({
                     rows={16}
                     value={contentMdVi}
                   />
+                  <small className="admin-hint">
+                    Start the body with `##` headings — the title above is the single H1 of the
+                    page, and a leading `#` line is dropped when rendering.
+                  </small>
                 </label>
               </>
             )}

--- a/src/features/blog/markdown.test.ts
+++ b/src/features/blog/markdown.test.ts
@@ -69,3 +69,33 @@ test("duplicate headings get distinct slug ids in the toc", async () => {
   assert.equal(toc[0]?.id, "repeat");
   assert.equal(toc[1]?.id, "repeat-1");
 });
+
+test("a leading h1 is stripped (the page template owns the article H1)", async () => {
+  const { html, toc, headingCount } = await renderMarkdown(
+    ["# Post Title", "", "Intro paragraph.", "", "## Section one"].join("\n"),
+  );
+
+  assert.ok(!html.includes("<h1"), "no h1 in rendered body");
+  assert.ok(
+    html.trimStart().startsWith("<p>Intro paragraph.</p>"),
+    "body starts at first paragraph",
+  );
+  assert.deepEqual(toc, [{ id: "section-one", text: "Section one", depth: 2 }]);
+  assert.equal(headingCount, 1);
+});
+
+test("an h1 after other content is kept untouched", async () => {
+  const { html } = await renderMarkdown(
+    ["## Section one", "", "Text.", "", "# Mid-document heading"].join("\n"),
+  );
+
+  assert.ok(html.includes("<h1"), "mid-document h1 survives");
+});
+
+test("content without a leading h1 renders unchanged", async () => {
+  const markdown = ["## Section one", "", "Paragraph."].join("\n");
+  const { html } = await renderMarkdown(markdown);
+
+  assert.ok(!html.includes("<h1"));
+  assert.ok(html.includes("<h2 id=\"section-one\">"));
+});

--- a/src/features/blog/markdown.ts
+++ b/src/features/blog/markdown.ts
@@ -5,6 +5,7 @@
  * admin Preview:
  *   - GFM (tables, task lists, strikethrough, autolinks)
  *   - heading slugs restricted to h2/h3 for TOC extraction
+ *   - a leading `h1` is removed (the page template owns the article's single H1)
  *   - syntax highlighting for fenced code blocks (token classes; the per-theme
  *     palettes are a CSS concern applied in the UI slice)
  *   - raw HTML passthrough is disabled by construction (remark-rehype without
@@ -30,6 +31,19 @@ export interface MarkdownResult {
   html: string;
   toc: TocEntry[];
   headingCount: number;
+}
+
+/**
+ * Drop a leading `h1` element. The article template owns the page's single
+ * `<h1>` (post title), so an author opening the body with `# …` would produce
+ * two H1s per article. Only the very first block is removed — `h1`s appearing
+ * after other content are kept untouched.
+ */
+function stripLeadingHeading(tree: import("hast").Root): void {
+  const first = tree.children[0];
+  if (first?.type === "element" && first.tagName === "h1") {
+    tree.children.shift();
+  }
 }
 
 /** Rehype transformer: collect h2/h3 headings (after `rehype-slug` assigns ids). */
@@ -60,6 +74,7 @@ const processor = unified()
 export async function renderMarkdown(markdown: string): Promise<MarkdownResult> {
   const tree = processor.runSync(processor.parse(markdown));
 
+  stripLeadingHeading(tree);
   const toc = collectToc(tree);
   const html = processor.stringify(tree);
   return { html, toc, headingCount: toc.length };


### PR DESCRIPTION
## Summary

Article pages currently render **two `<h1>` elements** when a post's markdown body starts with `# …` (the template already renders the post title as the page H1). This makes the article body own exactly one H1 — the template's — regardless of how authors write their content:

- **`renderMarkdown`** (`src/features/blog/markdown.ts`): after parsing, if the first block of the document is an `h1` element it is removed. `h1`s appearing anywhere after other content are kept untouched; documents without a leading `h1` are unchanged. The admin Preview shares this pipeline verbatim, so preview and public page stay consistent.
- **Editor hint** (`post-form.tsx`): both Markdown content fields (EN/VI) now carry a hint: start the body with `##` headings — the title above is the single H1 of the page, and a leading `#` line is dropped when rendering.
- No data migration and no CMS mutation: existing posts that open with `# …` render correctly immediately.

## Acceptance criteria

- [x] Article body never renders more than one `h1`
- [x] Leading `# Title` in stored markdown is dropped at render time
- [x] Mid-document `h1` and h1-free documents are untouched
- [x] Admin preview matches public rendering (shared pipeline)

## Verification

- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm test` — 140/140 PASS (3 new renderer tests: strip-leading-h1 / keep mid-document h1 / keep h1-free docs)
- `npm run build -- --webpack` — PASS
- GitNexus `detect_changes` on the branch worktree — risk LOW, 3 files, no unexpected affected flows

Developed in an isolated git worktree (`/tmp/opencode/qvak-single-h1`) so the concurrently active image-fix session keeps its checkout.

## Known limitations

- The JSON-LD `image` double-URL bug (`getAbsoluteUrl` prefixing an absolute Supabase URL in `blogPostingJsonLd`) is intentionally out of scope here — handled separately.
- Sitemap/listing caches refresh via the existing blog tag revalidation (any admin save); not affected by this PR.
