### PR TITLE
feat(media): WordPress-style media library - media_assets catalog, shared picker modal, revamped /admin/media

### DIFF
--- a/docs/superpowers/specs/2026-08-26-media-library-design.md
+++ b/docs/superpowers/specs/2026-08-26-media-library-design.md
@@ -1,0 +1,49 @@
+# Media Library Design — WordPress-style shared picker + catalog
+
+Date: 2026-08-26 · Issue: #102 · Status: approved in chat (see issue for summary)
+
+## Goals
+
+Replace the flat `/admin/media` rows and fragmented per-section pickers with one
+media library engine that scales to thousands of images and gives every asset
+editable metadata (alt text first-class, bilingual).
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Catalog | New table `media_assets`, PK `(bucket, path)`. Storage stays source of truth for bytes; catalog powers listing/search/sort. |
+| Metadata fields | `title` (internal display name, default from filename, searchable), `alt_en`, `alt_vi`. Auto at upload: `width`, `height`, `size_bytes`, `mime`. No caption/description (near-zero SEO value in 2026). |
+| RLS | Enable RLS; owner-only CRUD via `private.is_owner()`; **no anon policy** — public pages never read this table (public URLs go straight to Storage). |
+| Surfaces | One `MediaLibraryGrid` engine, two hosts: `MediaPickerModal` (`<dialog>`) scoped to one bucket opened from editors; revamped `/admin/media` page with bucket tabs. |
+| Loading | Modal = infinite scroll via keyset cursor (`created_at desc, path desc`) + IntersectionObserver sentinel + "Load more" fallback. Page = numbered pagination through URL searchParams (deep-linkable). Both call one `listMediaAssets({bucket, query?, limit, page?|cursor?})`. |
+| Search | `ilike` over `title` + `path` (wildcards escaped). Supabase Storage prefix-only search is insufficient, hence the catalog. |
+| Dimensions | Server-side header parsing of PNG (IHDR), JPEG (SOF scan), WebP (VP8/VP8L/VP8X) — no new dependency; reused by backfill script. |
+| Upload flow | Keep existing mime/10MB/owner-session guards → parse dimensions → upload to Storage first → insert catalog row (failure degrades to warning; file remains usable, metadata editable later). Title defaults from filename. Modal has Library / Upload tabs. |
+| Delete | Existing reference-check preserved; after Storage remove succeeds, catalog row is deleted too. |
+| Blog wiring (phase 1) | Cover picker and inline-insert use the modal (blog-media). Inline insert uses the asset's locale-appropriate alt. Public listing enriches cover alt from the catalog per locale when present. |
+| Phase 2 | Project/resume/portfolio editors adopt the same picker (separate issue). |
+
+## A11y contract
+
+Native `<dialog>` (Esc handled by browser), focus restored to invoker on close,
+initial focus on search input, grid cards are named `<button>`s, upload status
+and errors announced via `aria-live="polite"`, visible `:focus-visible` styles,
+no motion beyond theme tokens.
+
+## Data access details
+
+- Page mode: `.range(from, to)` + `count: "exact"`.
+- Cursor mode keyset: `.or("created_at.lt.T,and(created_at.eq.T,path.lt.P))`.
+- Index: `media_assets (bucket, created_at desc, path desc)`.
+
+## Rollout
+
+1. PR 1 — schema migration, backfill script, dimension parser, catalog data
+   layer, tests (unit + local-Supabase catalog tests + RLS SQL test).
+2. PR 2 — MediaLibraryGrid/modal/metadata-dialog/upload-modal + `/admin/media`
+   revamp.
+3. PR 3 — blog editor wiring + public cover-alt enrichment.
+
+Local-first DB workflow applies: apply migration + backfill locally, verify,
+then promote with human approval.

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/features/blog/reading-time.test.ts src/features/blog/markdown.test.ts src/features/blog/rss.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
+    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/features/blog/reading-time.test.ts src/features/blog/markdown.test.ts src/features/blog/rss.test.ts src/features/cms/image-dimensions.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
     "preflight": "tsx scripts/preflight-cutover.ts",
     "seed:admin": "node scripts/seed-admin.mjs",
     "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",
     "test:db": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node --test scripts/db-invariants.test.mjs",
-    "test:cms": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} tsx --test src/features/cms/repository.test.ts src/features/blog/repository.test.ts",
+    "test:cms": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} tsx --test src/features/cms/repository.test.ts src/features/cms/media-catalog.test.ts src/features/blog/repository.test.ts",
     "test:rls": "supabase db test --local supabase/tests"
   },
   "dependencies": {

--- a/scripts/backfill-media-assets.mjs
+++ b/scripts/backfill-media-assets.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Backfill the media_assets catalog (#102) from existing Storage objects.
+ *
+ * For every object in every media bucket: download the bytes, parse pixel
+ * dimensions, and upsert a catalog row (title derived from the filename).
+ * Idempotent — safe to re-run; existing rows keep their edited metadata.
+ *
+ * Usage (local-first, per AGENTS.md):
+ *   NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331 \
+ *   SUPABASE_SERVICE_ROLE_KEY=... \
+ *   node scripts/backfill-media-assets.mjs [--apply]
+ *
+ * Without --apply it performs a dry run and writes nothing.
+ * Refuses non-local hosts unless --force is also passed (cloud promotion is a
+ * separate human-approved step in the local-first workflow).
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const apply = process.argv.includes("--apply");
+const force = process.argv.includes("--force");
+
+if (!url || !serviceRole) {
+  console.error(
+    "Missing env: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY",
+  );
+  process.exit(1);
+}
+
+const isLocal = /^http:\/\/(127\.0\.0\.1|localhost)(:\d+)?$/.test(url);
+if (!isLocal && !force) {
+  console.error(
+    `Refusing non-local host ${url} without --force (local-first workflow).`,
+  );
+  process.exit(1);
+}
+
+const { imageDimensions } = await import("../src/features/cms/image-dimensions.ts");
+
+const client = createClient(url, serviceRole, {
+  auth: { persistSession: false },
+});
+
+const BUCKETS = ["resume-media", "project-media", "blog-media", "portfolio"];
+
+function titleFromPath(path) {
+  return path
+    .replace(/\.[^.]+$/, "")
+    .replace(/^\d+-/, "")
+    .replace(/[-_]+/g, " ")
+    .trim();
+}
+
+async function listAllObjects(bucket) {
+  const objects = [];
+  const pageSize = 100;
+  for (let offset = 0; ; offset += pageSize) {
+    const { data, error } = await client.storage
+      .from(bucket)
+      .list("", { limit: pageSize, offset, sortBy: { column: "created_at", order: "asc" } });
+    if (error) throw new Error(`${bucket}: list failed: ${error.message}`);
+    // Storage list returns an implicit folder entry named "" — skip it.
+    const real = (data ?? []).filter((o) => o.name && o.name !== "");
+    objects.push(...real);
+    if ((data ?? []).length < pageSize) break;
+  }
+  return objects;
+}
+
+async function backfillBucket(bucket) {
+  const objects = await listAllObjects(bucket);
+  console.log(`${bucket}: ${objects.length} object(s)`);
+
+  let written = 0;
+  for (const object of objects) {
+    const path = object.name;
+    const sizeBytes = object.metadata?.size ?? null;
+    const mime = object.metadata?.mimetype ?? null;
+
+    let width = null;
+    let height = null;
+    try {
+      const { data: blob, error } = await client.storage.from(bucket).download(path);
+      if (!error && blob) {
+        const dims = imageDimensions(
+          new Uint8Array(await blob.arrayBuffer()),
+          mime ?? "",
+        );
+        width = dims?.width ?? null;
+        height = dims?.height ?? null;
+      }
+    } catch (downloadError) {
+      console.warn(`  ! ${path}: download failed (${downloadError.message})`);
+    }
+
+    const row = {
+      bucket,
+      path,
+      title: titleFromPath(path),
+      alt_en: "",
+      alt_vi: "",
+      width,
+      height,
+      size_bytes: sizeBytes,
+      mime,
+    };
+
+    if (apply) {
+      const { error } = await client
+        .from("media_assets")
+        .upsert(row, { onConflict: "bucket,path" });
+      if (error) throw new Error(`${bucket}/${path}: ${error.message}`);
+    }
+
+    console.log(
+      `  ${apply ? "upserted" : "would upsert"} ${path}` +
+        ` (${width ?? "?"}x${height ?? "?"}, ${mime ?? "unknown"})`,
+    );
+    written += 1;
+  }
+  return written;
+}
+
+console.log(apply ? "Applying catalog backfill..." : "Dry run (pass --apply to write):");
+let total = 0;
+for (const bucket of BUCKETS) {
+  total += await backfillBucket(bucket);
+}
+console.log(`Done. ${total} row(s) ${apply ? "written" : "scanned"}.`);

--- a/src/app/admin/(dashboard)/blog/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/blog/[id]/page.tsx
@@ -2,8 +2,7 @@ import { notFound } from "next/navigation";
 
 import { getPost } from "../data";
 import { PostForm } from "../post-form";
-import { listCategories, listBlogMedia, listTags } from "../data";
-import { getMediaPublicUrl } from "@/features/cms/media";
+import { listCategories, listTags } from "../data";
 import { AdminFormCard, AdminPage } from "../../admin-page";
 
 interface AdminEditPostPageProps {
@@ -24,11 +23,7 @@ export default async function AdminEditPostPage({
     notFound();
   }
 
-  const [categories, tags, media] = await Promise.all([
-    listCategories(),
-    listTags(),
-    listBlogMedia(),
-  ]);
+  const [categories, tags] = await Promise.all([listCategories(), listTags()]);
 
   return (
     <AdminPage backHref="/admin/blog" title="Edit post">
@@ -36,10 +31,6 @@ export default async function AdminEditPostPage({
         <h2>Post details</h2>
         <PostForm
           categories={categories}
-          coverOptions={media.map((object) => ({
-            name: object.name,
-            url: getMediaPublicUrl("blog-media", object.name),
-          }))}
           existing={post}
           tags={tags}
         />

--- a/src/app/admin/(dashboard)/blog/data.ts
+++ b/src/app/admin/(dashboard)/blog/data.ts
@@ -1,5 +1,4 @@
 import { getServerClient } from "@/features/cms/session";
-import { listBucketObjects } from "@/features/cms/media";
 
 export interface AdminPostRow {
   id: string;
@@ -191,8 +190,4 @@ export async function listTags(): Promise<AdminTagRow[]> {
       nameVi: vi?.name ?? "",
     };
   });
-}
-
-export async function listBlogMedia() {
-  return listBucketObjects("blog-media");
 }

--- a/src/app/admin/(dashboard)/blog/media-insert.tsx
+++ b/src/app/admin/(dashboard)/blog/media-insert.tsx
@@ -1,95 +1,47 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 
-import { uploadMedia } from "@/features/cms/media-actions";
+import type { MediaBucket } from "@/features/cms/media";
+import { MediaPickerModal } from "../media/media-picker-modal";
 
-interface MediaOption {
-  name: string;
+export interface InsertableImage {
   url: string;
+  altEn: string;
+  altVi: string;
 }
 
 interface MediaInsertButtonProps {
-  media: MediaOption[];
-  onInsert: (url: string, alt: string) => void;
+  onInsert: (image: InsertableImage) => void;
 }
 
-function altFromName(name: string): string {
-  return name.replace(/\.[^.]+$/, "").replace(/^\d+-/, "").replace(/[-_]+/g, " ");
-}
-
-/** Inline "Insert image" picker for a Markdown content field: lists existing
- *  blog-media objects and uploads new ones, inserting `![](url)` at the cursor. */
-export function MediaInsertButton({ media, onInsert }: Readonly<MediaInsertButtonProps>) {
+/**
+ * Inline "Insert image" control for a Markdown content field (#102): opens the
+ * shared blog-media library modal (browse or upload), then hands the chosen
+ * asset — with its catalog alt text in both locales — to the editor.
+ */
+export function MediaInsertButton({ onInsert }: Readonly<MediaInsertButtonProps>) {
   const [open, setOpen] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [isUploading, startUpload] = useTransition();
-
-  function choose(url: string, name: string) {
-    onInsert(url, altFromName(name));
-    setOpen(false);
-  }
-
-  function upload(file: File | undefined) {
-    if (!file || file.size === 0) return;
-    setError(null);
-
-    startUpload(async () => {
-      const result = await uploadMedia("blog-media", file);
-      if (result.ok && result.publicUrl) {
-        onInsert(result.publicUrl, altFromName(file.name));
-        setOpen(false);
-      } else {
-        setError(result.error ?? "Upload failed.");
-      }
-    });
-  }
 
   return (
-    <span className="media-insert">
+    <>
       <button
         aria-expanded={open}
         className="admin-link-button"
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => setOpen(true)}
         type="button"
       >
-        {open ? "Close image picker" : "Insert image"}
+        Insert image
       </button>
-
-      {open ? (
-        <span className="media-insert__panel">
-          {media.length > 0 ? (
-            <span className="media-insert__grid">
-              {media.map((item) => (
-                <button
-                  className="media-insert__thumb"
-                  key={item.name}
-                  onClick={() => choose(item.url, item.name)}
-                  title={item.name}
-                  type="button"
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img alt={item.name} height={48} src={item.url} width={64} />
-                  <span className="media-insert__name">{item.name}</span>
-                </button>
-              ))}
-            </span>
-          ) : (
-            <p className="admin-note">No media uploaded yet.</p>
-          )}
-
-          <span className="media-insert__upload">
-            <input
-              accept="image/jpeg,image/png,image/webp"
-              aria-label="Upload image to insert"
-              onChange={(event) => upload(event.currentTarget.files?.[0])}
-              type="file"
-            />
-            {isUploading ? <span className="admin-note">Uploading…</span> : null}
-          </span>
-          {error ? <p className="admin-error">{error}</p> : null}
-        </span>
-      ) : null}
-    </span>
+      <MediaPickerModal
+        bucket={"blog-media" satisfies MediaBucket}
+        onClose={() => setOpen(false)}
+        onSelect={(asset) => {
+          onInsert({ altEn: asset.altEn, altVi: asset.altVi, url: asset.url });
+          setOpen(false);
+        }}
+        open={open}
+      />
+    </>
   );
 }

--- a/src/app/admin/(dashboard)/blog/new/page.tsx
+++ b/src/app/admin/(dashboard)/blog/new/page.tsx
@@ -1,6 +1,5 @@
 import { PostForm } from "../post-form";
-import { listCategories, listBlogMedia, listTags } from "../data";
-import { getMediaPublicUrl } from "@/features/cms/media";
+import { listCategories, listTags } from "../data";
 import { AdminFormCard, AdminPage } from "../../admin-page";
 
 export const metadata = {
@@ -8,24 +7,13 @@ export const metadata = {
 };
 
 export default async function AdminNewPostPage() {
-  const [categories, tags, media] = await Promise.all([
-    listCategories(),
-    listTags(),
-    listBlogMedia(),
-  ]);
+  const [categories, tags] = await Promise.all([listCategories(), listTags()]);
 
   return (
     <AdminPage backHref="/admin/blog" title="New post">
       <AdminFormCard className="admin-form-card--wide">
         <h2>Post details</h2>
-        <PostForm
-          categories={categories}
-          coverOptions={media.map((object) => ({
-            name: object.name,
-            url: getMediaPublicUrl("blog-media", object.name),
-          }))}
-          tags={tags}
-        />
+        <PostForm categories={categories} tags={tags} />
       </AdminFormCard>
     </AdminPage>
   );

--- a/src/app/admin/(dashboard)/blog/post-form.tsx
+++ b/src/app/admin/(dashboard)/blog/post-form.tsx
@@ -14,15 +14,11 @@ import {
 } from "./actions";
 import type { AdminCategoryRow, AdminPostRow, AdminTagRow } from "./data";
 import { MediaInsertButton } from "./media-insert";
-
-interface CoverOption {
-  name: string;
-  url: string;
-}
+import { MediaPickerModal } from "../media/media-picker-modal";
+import { publicMediaUrl } from "@/features/cms/media-url";
 
 interface PostFormProps {
   categories: AdminCategoryRow[];
-  coverOptions: CoverOption[];
   existing?: AdminPostRow;
   tags: AdminTagRow[];
 }
@@ -41,7 +37,6 @@ function slugify(value: string): string {
 
 export function PostForm({
   categories,
-  coverOptions,
   existing,
   tags,
 }: Readonly<PostFormProps>) {
@@ -49,6 +44,8 @@ export function PostForm({
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [isPending, startTransition] = useTransition();
+
+  const [coverPickerOpen, setCoverPickerOpen] = useState(false);
 
   const [localeTab, setLocaleTab] = useState<LocaleTab>("en");
   const [slug, setSlug] = useState(existing?.slug ?? "");
@@ -72,13 +69,24 @@ export function PostForm({
   const enContentRef = useRef<HTMLTextAreaElement>(null);
   const viContentRef = useRef<HTMLTextAreaElement>(null);
 
-  function insertMarkdownImage(tab: LocaleTab, url: string, alt: string) {
+  function insertMarkdownImage(
+    tab: LocaleTab,
+    image: { url: string; altEn: string; altVi: string },
+  ) {
     const textarea = tab === "en" ? enContentRef.current : viContentRef.current;
     const value = tab === "en" ? contentMdEn : contentMdVi;
     const setter = tab === "en" ? setContentMdEn : setContentMdVi;
 
+    // Catalog alt text wins; fall back to a readable name from the URL.
+    const fallback = decodeURIComponent(image.url.split("/").pop() ?? "")
+      .replace(/\.[^.]+$/, "")
+      .replace(/^\d+-/, "")
+      .replace(/[-_]+/g, " ");
+    const alt =
+      (tab === "en" ? image.altEn : image.altVi).trim() || fallback;
+
     const position = textarea?.selectionStart ?? value.length;
-    const markdown = `![${alt}](${url})`;
+    const markdown = `![${alt}](${image.url})`;
     setter(`${value.slice(0, position)}${markdown}${value.slice(position)}`);
 
     window.requestAnimationFrame(() => {
@@ -280,35 +288,49 @@ export function PostForm({
 
           <fieldset className="admin-field">
             <legend>Cover (blog-media)</legend>
-            {coverOptions.length === 0 ? (
-              <p className="admin-note">No media yet — upload under Admin → Media.</p>
+            {coverBucketPath ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                alt="Selected cover preview"
+                className="admin-cover-preview"
+                height={90}
+                src={publicMediaUrl("blog-media", coverBucketPath)}
+                width={160}
+              />
             ) : (
-              <div className="admin-check-group">
-                <label className="admin-check">
-                  <input
-                    checked={coverBucketPath === ""}
-                    onChange={() => setCoverBucketPath("")}
-                    type="radio"
-                    name="cover"
-                  />
-                  <span>No cover</span>
-                </label>
-                {coverOptions.map((cover) => (
-                  <label className="admin-check admin-check--media" key={cover.name}>
-                    <input
-                      checked={coverBucketPath === cover.name}
-                      onChange={() => setCoverBucketPath(cover.name)}
-                      type="radio"
-                      name="cover"
-                    />
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img alt={cover.name} height={48} src={cover.url} width={64} />
-                    <span>{cover.name}</span>
-                  </label>
-                ))}
-              </div>
+              <p className="admin-note">No cover selected.</p>
             )}
+            <div className="admin-form-row">
+              <button
+                className="admin-link-button"
+                onClick={() => setCoverPickerOpen(true)}
+                type="button"
+              >
+                {coverBucketPath ? "Change cover…" : "Choose cover…"}
+              </button>
+              {coverBucketPath ? (
+                <button
+                  className="admin-link-button admin-link-button--danger"
+                  onClick={() => setCoverBucketPath("")}
+                  type="button"
+                >
+                  Remove
+                </button>
+              ) : null}
+            </div>
+            {coverBucketPath ? (
+              <small className="admin-hint">{coverBucketPath}</small>
+            ) : null}
           </fieldset>
+          <MediaPickerModal
+            bucket="blog-media"
+            onClose={() => setCoverPickerOpen(false)}
+            onSelect={(asset) => {
+              setCoverBucketPath(asset.path);
+              setCoverPickerOpen(false);
+            }}
+            open={coverPickerOpen}
+          />
         </div>
 
         {/* Right column: locale editor + live preview */}
@@ -358,8 +380,7 @@ export function PostForm({
                   <span>Markdown content (EN)</span>
                   <div className="admin-form-row">
                     <MediaInsertButton
-                      media={coverOptions}
-                      onInsert={(url, alt) => insertMarkdownImage("en", url, alt)}
+                      onInsert={(image) => insertMarkdownImage("en", image)}
                     />
                     <button
                       className="admin-link-button"
@@ -408,8 +429,7 @@ export function PostForm({
                   <span>Markdown content (VI)</span>
                   <div className="admin-form-row">
                     <MediaInsertButton
-                      media={coverOptions}
-                      onInsert={(url, alt) => insertMarkdownImage("vi", url, alt)}
+                      onInsert={(image) => insertMarkdownImage("vi", image)}
                     />
                     <button
                       className="admin-link-button"

--- a/src/app/admin/(dashboard)/media/media-library-grid.tsx
+++ b/src/app/admin/(dashboard)/media/media-library-grid.tsx
@@ -48,6 +48,7 @@ export function MediaLibraryGrid({
   const [query, setQuery] = useState(initialQuery);
   const [status, setStatus] = useState<string | null>(null);
   const [editing, setEditing] = useState<MediaAsset | null>(null);
+  const [lightbox, setLightbox] = useState<MediaAsset | null>(null);
   const [, startTransition] = useTransition();
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -154,6 +155,15 @@ export function MediaLibraryGrid({
     });
   }
 
+  async function copyUrl(asset: MediaAsset) {
+    try {
+      await navigator.clipboard.writeText(publicMediaUrl(asset.bucket, asset.path));
+      setStatus(`Copied URL for ${asset.path}.`);
+    } catch {
+      setStatus("Could not copy the URL.");
+    }
+  }
+
   return (
     <div className="admin-media-library">
       <form className="admin-media-library__search" onSubmit={submitSearch} role="search">
@@ -182,9 +192,11 @@ export function MediaLibraryGrid({
             <MediaLibraryCard
               asset={asset}
               key={asset.path}
+              onCopy={() => copyUrl(asset)}
               onEdit={() => setEditing(asset)}
               onPick={onPick}
               onRemove={removeAsset}
+              onView={() => setLightbox(asset)}
             />
           ))}
         </ul>
@@ -230,20 +242,38 @@ export function MediaLibraryGrid({
         onClose={() => setEditing(null)}
         onSave={saveDetails}
       />
+
+      <MediaLightbox
+        asset={lightbox}
+        onClose={() => setLightbox(null)}
+        onCopy={() => lightbox && copyUrl(lightbox)}
+        onEdit={() => {
+          if (lightbox) setEditing(lightbox);
+          setLightbox(null);
+        }}
+        onRemove={() => {
+          if (lightbox) removeAsset(lightbox);
+          setLightbox(null);
+        }}
+      />
     </div>
   );
 }
 
 function MediaLibraryCard({
   asset,
+  onCopy,
   onEdit,
   onPick,
   onRemove,
+  onView,
 }: {
   asset: MediaAsset;
+  onCopy: () => void;
   onEdit: () => void;
   onPick?: (asset: MediaAsset) => void;
   onRemove: (asset: MediaAsset) => void;
+  onView: () => void;
 }) {
   const thumb = (
     <>
@@ -251,10 +281,10 @@ function MediaLibraryCard({
       <img
         alt={asset.altEn || asset.title}
         className="admin-media-card__thumb"
-        height={160}
+        height={128}
         loading="lazy"
         src={publicMediaUrl(asset.bucket, asset.path)}
-        width={240}
+        width={192}
       />
       <span className="admin-media-card__title">{asset.title}</span>
     </>
@@ -272,7 +302,14 @@ function MediaLibraryCard({
           {thumb}
         </button>
       ) : (
-        <span className="admin-media-card__view">{thumb}</span>
+        <button
+          className="admin-media-card__pick"
+          onClick={onView}
+          title={`${asset.title} — view`}
+          type="button"
+        >
+          {thumb}
+        </button>
       )}
 
       <p className="admin-media-card__meta">
@@ -284,8 +321,11 @@ function MediaLibraryCard({
       </p>
 
       <div className="admin-media-card__actions">
+        <button className="admin-link-button" onClick={onCopy} type="button">
+          Copy URL
+        </button>
         <button className="admin-link-button" onClick={onEdit} type="button">
-          Edit details
+          Edit
         </button>
         <button
           className="admin-link-button admin-link-button--danger"
@@ -374,6 +414,81 @@ function MediaMetadataDialog({
             <button type="submit">Save</button>
           </div>
         </form>
+      ) : null}
+    </dialog>
+  );
+}
+
+function MediaLightbox({
+  asset,
+  onClose,
+  onCopy,
+  onEdit,
+  onRemove,
+}: {
+  asset: MediaAsset | null;
+  onClose: () => void;
+  onCopy: () => void;
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (asset && !dialog.open) dialog.showModal();
+    else if (!asset && dialog.open) dialog.close();
+  }, [asset]);
+
+  return (
+    <dialog
+      aria-label={asset ? `Preview of ${asset.title}` : "Image preview"}
+      className="admin-dialog admin-lightbox"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) onClose();
+      }}
+      ref={dialogRef}
+    >
+      {asset ? (
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt={asset.altEn || asset.title}
+            className="admin-lightbox__image"
+            src={publicMediaUrl(asset.bucket, asset.path)}
+          />
+          <div className="admin-lightbox__meta">
+            <strong>{asset.title}</strong>
+            <code>{asset.path}</code>
+            <span>
+              {asset.width && asset.height ? `${asset.width}×${asset.height} · ` : ""}
+              {asset.mime?.replace("image/", "") ?? "?"}
+            </span>
+          </div>
+          <div className="admin-dialog__actions">
+            <button onClick={onCopy} type="button">
+              Copy URL
+            </button>
+            <button onClick={onEdit} type="button">
+              Edit details
+            </button>
+            <button
+              className="admin-link-button--danger"
+              onClick={onRemove}
+              type="button"
+            >
+              Delete
+            </button>
+            <button onClick={onClose} type="button">
+              Close
+            </button>
+          </div>
+        </>
       ) : null}
     </dialog>
   );

--- a/src/app/admin/(dashboard)/media/media-library-grid.tsx
+++ b/src/app/admin/(dashboard)/media/media-library-grid.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { MediaBucket } from "@/features/cms/media";
+import { publicMediaUrl } from "@/features/cms/media-url";
+import {
+  deleteMedia,
+  updateMediaDetails,
+} from "@/features/cms/media-actions";
+import type {
+  CursorQuery,
+  ListMediaAssetsResult,
+  MediaAsset,
+} from "@/features/cms/media-catalog";
+import { fetchMediaBatch } from "@/features/cms/media-library-actions";
+
+export interface MediaLibraryGridProps {
+  bucket: MediaBucket;
+  initial: ListMediaAssetsResult;
+  initialQuery?: string;
+  /** Page mode deep-links via URL; cursor mode streams batches in place. */
+  mode: "page" | "cursor";
+  /** Page mode only — which page `initial` represents (for pagination links). */
+  pageNumber?: number;
+  /** Cursor-mode only: called with the chosen asset (picker modal). */
+  onPick?: (asset: MediaAsset) => void;
+}
+
+/**
+ * Core library grid (#102). Two loading modes share this component:
+ *  - "page": numbered pagination driven by URL searchParams (management page).
+ *  - "cursor": infinite scroll with a Load-more fallback (picker modal).
+ * Cards are named buttons; delete/edit status is announced politely.
+ */
+export function MediaLibraryGrid({
+  bucket,
+  initial,
+  initialQuery = "",
+  mode,
+  onPick,
+  pageNumber = 1,
+}: Readonly<MediaLibraryGridProps>) {
+  const router = useRouter();
+  const [items, setItems] = useState<MediaAsset[]>(initial.items);
+  const [cursor, setCursor] = useState<CursorQuery | undefined>(initial.nextCursor);
+  const [query, setQuery] = useState(initialQuery);
+  const [status, setStatus] = useState<string | null>(null);
+  const [editing, setEditing] = useState<MediaAsset | null>(null);
+  const [, startTransition] = useTransition();
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Server renders a fresh grid instance per page/search via `key`, so local
+  // state initializes from props and never needs prop-syncing effects.
+
+  const loadOlder = useCallback(() => {
+    if (!cursor) return;
+    setStatus("Loading…");
+    startTransition(async () => {
+      try {
+        const next = await fetchMediaBatch(bucket, cursor, query || undefined);
+        setItems((current) => {
+          const known = new Set(current.map((item) => item.path));
+          return [...current, ...next.items.filter((item) => !known.has(item.path))];
+        });
+        setCursor(next.nextCursor);
+      } catch {
+        setStatus("Could not load more images.");
+      }
+    });
+  }, [bucket, cursor, query]);
+
+  // Infinite scroll for cursor mode.
+  useEffect(() => {
+    if (mode !== "cursor" || !cursor) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) loadOlder();
+      },
+      { rootMargin: "320px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [cursor, loadOlder, mode]);
+
+  // Debounced re-fetch on query change (page mode navigates via form submit).
+  useEffect(() => {
+    if (mode !== "cursor") return;
+    if (query === initialQuery) return;
+    const timer = setTimeout(() => {
+      setStatus("Searching…");
+      startTransition(async () => {
+        try {
+          const next = await fetchMediaBatch(bucket, undefined, query || undefined);
+          setItems(next.items);
+          setCursor(next.nextCursor);
+        } catch {
+          setStatus("Search failed.");
+        }
+      });
+    }, 350);
+    return () => clearTimeout(timer);
+  }, [bucket, initialQuery, mode, query]);
+
+  function submitSearch(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (mode !== "page") return;
+    const params = new URLSearchParams(window.location.search);
+    if (query.trim()) params.set("q", query.trim());
+    else params.delete("q");
+    params.delete("page");
+    router.push(`?${params.toString()}`);
+  }
+
+  function removeAsset(asset: MediaAsset) {
+    if (!window.confirm(`Delete "${asset.title}"? This cannot be undone.`)) return;
+    setStatus(`Deleting ${asset.path}…`);
+    startTransition(async () => {
+      const result = await deleteMedia(asset.bucket, asset.path);
+      if (result.ok) {
+        setItems((current) => current.filter((item) => item.path !== asset.path));
+        setStatus(null);
+        router.refresh();
+      } else {
+        setStatus(result.error ?? "Delete failed.");
+      }
+    });
+  }
+
+  function saveDetails(
+    meta: { altEn: string; altVi: string; title: string },
+    done: () => void,
+  ) {
+    if (!editing) return;
+    setStatus("Saving details…");
+    startTransition(async () => {
+      const result = await updateMediaDetails(editing.bucket, editing.path, meta);
+      if (result.ok) {
+        setItems((current) =>
+          current.map((item) =>
+            item.path === editing.path
+              ? { ...item, altEn: meta.altEn, altVi: meta.altVi, title: meta.title.trim() }
+              : item,
+          ),
+        );
+        setStatus(null);
+        done();
+      } else {
+        setStatus(result.error ?? "Could not save details.");
+      }
+    });
+  }
+
+  return (
+    <div className="admin-media-library">
+      <form className="admin-media-library__search" onSubmit={submitSearch} role="search">
+        <input
+          aria-label="Search images by title or filename"
+          autoComplete="off"
+          name="q"
+          onChange={(event) => setQuery(event.currentTarget.value)}
+          placeholder="Search by title or filename…"
+          type="search"
+          value={query}
+        />
+        {mode === "page" ? <button type="submit">Search</button> : null}
+      </form>
+
+      <p aria-live="polite" className="admin-note">
+        {status ??
+          `${items.length}${mode === "page" && initial.total !== undefined ? ` of ${initial.total}` : ""} image(s)`}
+      </p>
+
+      {items.length === 0 ? (
+        <p className="admin-message">No images match.</p>
+      ) : (
+        <ul className="admin-media-grid">
+          {items.map((asset) => (
+            <MediaLibraryCard
+              asset={asset}
+              key={asset.path}
+              onEdit={() => setEditing(asset)}
+              onPick={onPick}
+              onRemove={removeAsset}
+            />
+          ))}
+        </ul>
+      )}
+
+      {mode === "cursor" && cursor ? (
+        <div className="admin-media-library__more" ref={sentinelRef}>
+          <button onClick={loadOlder} type="button">
+            Load more
+          </button>
+        </div>
+      ) : null}
+
+      {mode === "page" && (initial.totalPages ?? 1) > 1 ? (
+        <nav aria-label="Library pages" className="admin-media-library__pages">
+          {Array.from({ length: initial.totalPages ?? 1 }, (_, i) => i + 1).map(
+            (n) => {
+              const params = new URLSearchParams();
+              if (n > 1) params.set("page", String(n));
+              if (initialQuery) params.set("q", initialQuery);
+              const search = params.toString();
+              return (
+                <a
+                  aria-current={n === pageNumber ? "page" : undefined}
+                  className={
+                    n === pageNumber
+                      ? "admin-page-num admin-page-num--current"
+                      : "admin-page-num"
+                  }
+                  href={search ? `?${search}` : "?"}
+                  key={n}
+                >
+                  {n}
+                </a>
+              );
+            },
+          )}
+        </nav>
+      ) : null}
+
+      <MediaMetadataDialog
+        asset={editing}
+        onClose={() => setEditing(null)}
+        onSave={saveDetails}
+      />
+    </div>
+  );
+}
+
+function MediaLibraryCard({
+  asset,
+  onEdit,
+  onPick,
+  onRemove,
+}: {
+  asset: MediaAsset;
+  onEdit: () => void;
+  onPick?: (asset: MediaAsset) => void;
+  onRemove: (asset: MediaAsset) => void;
+}) {
+  const thumb = (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        alt={asset.altEn || asset.title}
+        className="admin-media-card__thumb"
+        height={160}
+        loading="lazy"
+        src={publicMediaUrl(asset.bucket, asset.path)}
+        width={240}
+      />
+      <span className="admin-media-card__title">{asset.title}</span>
+    </>
+  );
+
+  return (
+    <li className="admin-media-card">
+      {onPick ? (
+        <button
+          className="admin-media-card__pick"
+          onClick={() => onPick(asset)}
+          title={`${asset.title} — use this image`}
+          type="button"
+        >
+          {thumb}
+        </button>
+      ) : (
+        <span className="admin-media-card__view">{thumb}</span>
+      )}
+
+      <p className="admin-media-card__meta">
+        <code>{asset.path}</code>
+        <span>
+          {asset.width && asset.height ? `${asset.width}×${asset.height} · ` : ""}
+          {asset.mime?.replace("image/", "") ?? "?"}
+        </span>
+      </p>
+
+      <div className="admin-media-card__actions">
+        <button className="admin-link-button" onClick={onEdit} type="button">
+          Edit details
+        </button>
+        <button
+          className="admin-link-button admin-link-button--danger"
+          onClick={() => onRemove(asset)}
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function MediaMetadataDialog({
+  asset,
+  onClose,
+  onSave,
+}: {
+  asset: MediaAsset | null;
+  onClose: () => void;
+  onSave: (
+    meta: { altEn: string; altVi: string; title: string },
+    done: () => void,
+  ) => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (asset && !dialog.open) {
+      dialog.showModal();
+    } else if (!asset && dialog.open) {
+      dialog.close();
+    }
+  }, [asset]);
+
+  return (
+    <dialog
+      aria-label={asset ? `Edit details for ${asset.title}` : "Edit media details"}
+      className="admin-dialog"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) onClose();
+      }}
+      ref={dialogRef}
+    >
+      {asset ? (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            const fd = new FormData(event.currentTarget);
+            onSave(
+              {
+                altEn: String(fd.get("altEn") ?? ""),
+                altVi: String(fd.get("altVi") ?? ""),
+                title: String(fd.get("title") ?? ""),
+              },
+              onClose,
+            );
+          }}
+        >
+          <h3 className="admin-dialog__title">Edit image details</h3>
+          <code className="admin-dialog__path">{asset.path}</code>
+
+          <label className="admin-field">
+            <span>Title</span>
+            <input defaultValue={asset.title} key={`t-${asset.path}`} name="title" required type="text" />
+          </label>
+          <label className="admin-field">
+            <span>Alt text (English)</span>
+            <input defaultValue={asset.altEn} key={`en-${asset.path}`} name="altEn" type="text" />
+          </label>
+          <label className="admin-field">
+            <span>Alt text (Vietnamese)</span>
+            <input defaultValue={asset.altVi} key={`vi-${asset.path}`} name="altVi" type="text" />
+          </label>
+
+          <div className="admin-dialog__actions">
+            <button onClick={onClose} type="button">
+              Cancel
+            </button>
+            <button type="submit">Save</button>
+          </div>
+        </form>
+      ) : null}
+    </dialog>
+  );
+}

--- a/src/app/admin/(dashboard)/media/media-picker-modal.tsx
+++ b/src/app/admin/(dashboard)/media/media-picker-modal.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { MediaBucket } from "@/features/cms/media";
+import type { ListMediaAssetsResult } from "@/features/cms/media-catalog";
+import { publicMediaUrl } from "@/features/cms/media-url";
+import { fetchMediaBatch } from "@/features/cms/media-library-actions";
+import { MediaLibraryGrid } from "./media-library-grid";
+import { MediaUploadPanel } from "./media-upload-panel";
+
+interface MediaPickerModalProps {
+  bucket: MediaBucket;
+  onClose: () => void;
+  /** Receives the stored path + a ready-to-use public URL for the pick. */
+  onSelect: (asset: { path: string; url: string; altEn: string; altVi: string }) => void;
+  open: boolean;
+}
+
+const BUCKET_TITLES: Record<MediaBucket, string> = {
+  "blog-media": "Blog media",
+  "portfolio": "Portfolio",
+  "project-media": "Project media",
+  "resume-media": "Resume media",
+};
+
+/**
+ * WordPress-style media library modal (#102): browse one bucket as an
+ * infinite-scroll grid or upload straight into it, then hand the chosen
+ * asset back to the caller. Native <dialog> keeps focus inside while open;
+ * browsers restore focus to the invoker on close.
+ */
+export function MediaPickerModal({
+  bucket,
+  onClose,
+  onSelect,
+  open,
+}: Readonly<MediaPickerModalProps>) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const [tab, setTab] = useState<"library" | "upload">("library");
+  const [initial, setInitial] = useState<ListMediaAssetsResult | null>(null);
+
+  const loadFirst = useCallback(() => {
+    fetchMediaBatch(bucket)
+      .then(setInitial)
+      .catch(() => setInitial({ items: [] }));
+  }, [bucket]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      setTab("library");
+      loadFirst();
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open, loadFirst]);
+
+  return (
+    <dialog
+      aria-label={`${BUCKET_TITLES[bucket]} library`}
+      className="admin-dialog admin-dialog--wide"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) onClose();
+      }}
+      onClose={onClose}
+      ref={dialogRef}
+    >
+      <header className="admin-picker__head">
+        <h3 className="admin-dialog__title">{BUCKET_TITLES[bucket]} library</h3>
+        <div aria-label="Library tabs" className="admin-picker__tabs" role="tablist">
+          <button
+            aria-selected={tab === "library"}
+            onClick={() => setTab("library")}
+            role="tab"
+            type="button"
+          >
+            Library
+          </button>
+          <button
+            aria-selected={tab === "upload"}
+            onClick={() => setTab("upload")}
+            role="tab"
+            type="button"
+          >
+            Upload new
+          </button>
+        </div>
+        <button
+          aria-label="Close media library"
+          className="admin-link-button"
+          onClick={onClose}
+          type="button"
+        >
+          Close
+        </button>
+      </header>
+
+      {tab === "library" ? (
+        initial ? (
+          <div className="admin-picker__body">
+            <MediaLibraryGrid
+              bucket={bucket}
+              initial={initial}
+              key={`${bucket}:${initial.items[0]?.path ?? "empty"}`}
+              mode="cursor"
+              onPick={(asset) =>
+                onSelect({
+                  altEn: asset.altEn,
+                  altVi: asset.altVi,
+                  path: asset.path,
+                  url: publicMediaUrl(asset.bucket, asset.path),
+                })
+              }
+            />
+          </div>
+        ) : (
+          <p className="admin-message">Loading library…</p>
+        )
+      ) : (
+        <div className="admin-picker__body">
+          <MediaUploadPanel bucket={bucket} onUploaded={loadFirst} />
+          <p className="admin-note">
+            Uploaded images land in this bucket&apos;s library — switch to the
+            Library tab to use them.
+          </p>
+        </div>
+      )}
+    </dialog>
+  );
+}

--- a/src/app/admin/(dashboard)/media/media-upload-panel.tsx
+++ b/src/app/admin/(dashboard)/media/media-upload-panel.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { MediaBucket } from "@/features/cms/media";
+import { uploadMedia, type MediaUploadMeta } from "@/features/cms/media-actions";
+
+interface MediaUploadPanelProps {
+  bucket: MediaBucket;
+  /** Called after a successful upload with the stored path (modal flow). */
+  onUploaded?: () => void;
+}
+
+/**
+ * Upload form for one bucket (#102). Used inline on /admin/media and as the
+ * Upload tab inside the picker modal. Metadata fields are optional; the
+ * catalog derives a default title from the filename when left blank.
+ */
+export function MediaUploadPanel({ bucket, onUploaded }: MediaUploadPanelProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+    const file = fd.get("file");
+    if (!(file instanceof File) || file.size === 0) {
+      setError("Choose a file to upload.");
+      return;
+    }
+
+    const meta: MediaUploadMeta = {
+      altEn: String(fd.get("altEn") ?? ""),
+      altVi: String(fd.get("altVi") ?? ""),
+      title: String(fd.get("title") ?? ""),
+    };
+
+    setError(null);
+    startTransition(async () => {
+      const result = await uploadMedia(bucket, file, meta);
+      if (result.ok) {
+        formRef.current?.reset();
+        onUploaded?.();
+        router.refresh();
+        if (result.warning) setError(result.warning);
+      } else {
+        setError(result.error ?? "Upload failed.");
+      }
+    });
+  }
+
+  return (
+    <form
+      aria-live="polite"
+      className="admin-form admin-form--row admin-upload-panel"
+      onSubmit={onSubmit}
+      ref={formRef}
+    >
+      <label className="admin-field">
+        <span>Image (JPEG/PNG/WebP, max 10 MB)</span>
+        <input accept="image/jpeg,image/png,image/webp" name="file" type="file" />
+      </label>
+      <label className="admin-field">
+        <span>Title (optional)</span>
+        <input name="title" type="text" />
+      </label>
+      <label className="admin-field">
+        <span>Alt text EN (optional)</span>
+        <input name="altEn" type="text" />
+      </label>
+      <label className="admin-field">
+        <span>Alt text VI (optional)</span>
+        <input name="altVi" type="text" />
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <button disabled={isPending} type="submit">
+        {isPending ? "Uploading…" : "Upload"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/media/page.tsx
+++ b/src/app/admin/(dashboard)/media/page.tsx
@@ -1,70 +1,86 @@
-import { listBucketObjects, getMediaPublicUrl } from "@/features/cms/media";
+import Link from "next/link";
+
 import type { MediaBucket } from "@/features/cms/media";
-import { MediaUploadForm } from "./media-upload-form";
-import { MediaDeleteButton } from "./media-delete";
+import { fetchMediaPage } from "@/features/cms/media-library-actions";
 import { AdminPage } from "../admin-page";
+import { MediaLibraryGrid } from "./media-library-grid";
+import { MediaUploadPanel } from "./media-upload-panel";
 
 export const metadata = {
   title: "Admin media",
 };
 
-const buckets: Array<{ id: MediaBucket; label: string; note: string }> = [
-  { id: "resume-media", label: "Resume media (private)", note: "Served only through the gated /api/resume-media route." },
-  { id: "project-media", label: "Project media (public)", note: "Public project images." },
-  { id: "blog-media", label: "Blog media (public)", note: "Public post covers and in-article images." },
-  { id: "portfolio", label: "Portfolio (public)", note: "Profile / social images." },
+const BUCKETS: Array<{ id: MediaBucket; label: string; note: string }> = [
+  { id: "blog-media", label: "Blog media", note: "Post covers and in-article images (public)." },
+  { id: "project-media", label: "Project media", note: "Public project images." },
+  { id: "resume-media", label: "Resume media", note: "Private; served only through the gated /api/resume-media route." },
+  { id: "portfolio", label: "Portfolio", note: "Profile and social images (public)." },
 ];
 
-export default async function AdminMediaPage() {
-  const bucketRows = await Promise.all(
-    buckets.map(async (bucket) => ({
-      bucket,
-      objects: await listBucketObjects(bucket.id),
-    })),
-  );
+function firstParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+interface AdminMediaPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+/**
+ * Full-page media manager (#102): bucket tabs + paginated, searchable grid.
+ * The same MediaLibraryGrid engine powers the in-editor picker modal with
+ * infinite scroll; this surface deep-links via searchParams instead.
+ */
+export default async function AdminMediaPage({
+  searchParams,
+}: Readonly<AdminMediaPageProps>) {
+  const params = await searchParams;
+  const requested = firstParam(params.bucket) as MediaBucket | undefined;
+  const active = BUCKETS.some((b) => b.id === requested) ? requested! : "blog-media";
+  const query = firstParam(params.q)?.trim() ?? "";
+  const pageNumberRaw = Number(firstParam(params.page) ?? "1");
+  const pageNumber =
+    Number.isInteger(pageNumberRaw) && pageNumberRaw > 1 ? pageNumberRaw : 1;
+
+  const initial = await fetchMediaPage(active, pageNumber, query || undefined);
 
   return (
-    <AdminPage title="Media">
+    <AdminPage action={<Link className="admin-link-button" href="/admin">Dashboard</Link>} title="Media">
       <p className="admin-message">
-        Upload and manage images stored in Supabase Storage. Resume media is
-        private and served only through the gated route; project and portfolio
-        media are public.
+        One library per bucket. Pick images from here or straight inside the
+        editors; every image carries a title plus English/Vietnamese alt text
+        used across the public site.
       </p>
 
-      {bucketRows.map(({ bucket, objects }) => (
-        <section className="admin-section" key={bucket.id}>
-          <div className="admin-page-head">
-            <h2>{bucket.label}</h2>
-          </div>
-          <p className="admin-note">{bucket.note}</p>
-          <MediaUploadForm bucket={bucket.id} />
+      <nav aria-label="Media buckets" className="admin-tabs">
+        {BUCKETS.map((bucket) => (
+          <Link
+            aria-current={bucket.id === active ? "page" : undefined}
+            className={
+              bucket.id === active ? "admin-tab admin-tab--active" : "admin-tab"
+            }
+            href={`?bucket=${bucket.id}`}
+            key={bucket.id}
+          >
+            {bucket.label}
+          </Link>
+        ))}
+      </nav>
+      <p className="admin-note">{BUCKETS.find((b) => b.id === active)?.note}</p>
 
-          {objects.length === 0 ? (
-            <p className="admin-message">No files uploaded yet.</p>
-          ) : (
-            <ul className="admin-media-list">
-              {objects.map((object) => (
-                <li className="admin-media-item" key={object.id}>
-                  <div className="admin-media-preview">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt={object.name}
-                      height={80}
-                      loading="lazy"
-                      src={getMediaPublicUrl(bucket.id, object.name)}
-                      width={80}
-                    />
-                  </div>
-                  <div className="admin-media-meta">
-                    <code>{object.name}</code>
-                    <MediaDeleteButton bucket={bucket.id} path={object.name} />
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-      ))}
+      <MediaLibraryGrid
+        bucket={active}
+        initial={initial}
+        initialQuery={query}
+        key={`${active}:${query}:${pageNumber}`}
+        mode="page"
+        pageNumber={pageNumber}
+      />
+
+      <section className="admin-section">
+        <h2>Upload to {BUCKETS.find((b) => b.id === active)?.label}</h2>
+        <MediaUploadPanel bucket={active} />
+      </section>
     </AdminPage>
   );
 }

--- a/src/app/admin/(dashboard)/media/page.tsx
+++ b/src/app/admin/(dashboard)/media/page.tsx
@@ -42,7 +42,7 @@ export default async function AdminMediaPage({
   const pageNumber =
     Number.isInteger(pageNumberRaw) && pageNumberRaw > 1 ? pageNumberRaw : 1;
 
-  const initial = await fetchMediaPage(active, pageNumber, query || undefined);
+  const initial = await fetchMediaPage(active, pageNumber, query || undefined, 12);
 
   return (
     <AdminPage action={<Link className="admin-link-button" href="/admin">Dashboard</Link>} title="Media">

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -25,6 +25,7 @@ import { unstable_cache } from "next/cache";
 
 import { hasCmsConfig } from "@/features/cms/config";
 import { getMediaPublicUrl } from "@/features/cms/media";
+import { getCoverAltTexts } from "@/features/cms/media-catalog";
 import { getServiceClient } from "@/features/cms/server";
 import { renderMarkdown } from "./markdown";
 import { readingTimeMinutes } from "./reading-time";
@@ -119,8 +120,40 @@ function mapPostListItem(row: PostRow, locale: Locale): PostListItem | null {
   };
 }
 
-function postSelect() {
-  return [
+/**
+ * Override cover alt text from the media_assets catalog (#102) when the owner
+ * has written one for the requested locale; the post title stays the fallback.
+ */
+async function enrichCoverAlts<T extends { coverImage?: { alt: string } }>(
+  items: T[],
+  coverPaths: (string | undefined)[],
+  locale: Locale,
+): Promise<T[]> {
+  const paths = [...new Set(coverPaths.filter((p): p is string => Boolean(p)))];
+  if (paths.length === 0) return items;
+
+  const client = getServiceClient();
+  if (!client) return items;
+
+  try {
+    const alts = await getCoverAltTexts(client, "blog-media", paths);
+    if (alts.size === 0) return items;
+
+    let index = 0;
+    return items.map((item) => {
+      const path = coverPaths[index++];
+      const lookup = path ? alts.get(path) : undefined;
+      if (!lookup || !item.coverImage) return item;
+      const catalogAlt = locale === "vi" ? lookup.altVi : lookup.altEn;
+      if (!catalogAlt.trim()) return item;
+      return { ...item, coverImage: { ...item.coverImage, alt: catalogAlt } };
+    });
+  } catch {
+    return items;
+  }
+}
+
+function postSelect() {  return [
     "id, slug, cover_bucket_path, status, published_at, updated_at",
     "blog_categories(id, slug, blog_category_translations(locale, name))",
     "blog_post_translations(locale, title, summary, content_md)",
@@ -151,9 +184,13 @@ async function loadPublishedPosts(
     const { data, error, count } = await query;
     if (error || !data) return { posts: [], page, totalPages: 1 };
 
-    const posts = (data as unknown as PostRow[])
-      .map((row) => mapPostListItem(row, locale))
-      .filter((post): post is PostListItem => post !== null);
+    const posts = await enrichCoverAlts(
+      (data as unknown as PostRow[])
+        .map((row) => mapPostListItem(row, locale))
+        .filter((post): post is PostListItem => post !== null),
+      (data as unknown as PostRow[]).map((row) => row.cover_bucket_path ?? undefined),
+      locale,
+    );
 
     return {
       posts,
@@ -252,7 +289,12 @@ export async function queryPostBySlug(
     const tagIds = (row.blog_post_tags ?? []).map((link) => link.tag_id);
     const relatedPosts = await queryRelatedPosts(locale, row.id, tagIds);
 
-    return { ...item, tags, html, toc, relatedPosts };
+    const [detail] = await enrichCoverAlts(
+      [{ ...item, tags, html, toc, relatedPosts }],
+      [row.cover_bucket_path ?? undefined],
+      locale,
+    );
+    return detail;
   } catch {
     return null;
   }

--- a/src/features/cms/image-dimensions.test.ts
+++ b/src/features/cms/image-dimensions.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { imageDimensions } from "./image-dimensions";
+
+function pngBytes(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(33);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  // IHDR length + type
+  bytes.set([0, 0, 0, 13], 8);
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+  bytes.set(
+    [
+      (width >>> 24) & 0xff,
+      (width >>> 16) & 0xff,
+      (width >>> 8) & 0xff,
+      width & 0xff,
+    ],
+    16,
+  );
+  bytes.set(
+    [
+      (height >>> 24) & 0xff,
+      (height >>> 16) & 0xff,
+      (height >>> 8) & 0xff,
+      height & 0xff,
+    ],
+    20,
+  );
+  return bytes;
+}
+
+function jpegBytes(width: number, height: number): Uint8Array {
+  // SOI + SOF0 with one component.
+  const bytes = new Uint8Array(19);
+  bytes.set([0xff, 0xd8], 0);
+  bytes.set([0xff, 0xc0], 2);
+  bytes.set([(15 >> 8) & 0xff, 15 & 0xff], 4); // segment length
+  bytes.set([0x08], 6); // precision
+  bytes.set([(height >> 8) & 0xff, height & 0xff], 7);
+  bytes.set([(width >> 8) & 0xff, width & 0xff], 9);
+  bytes.set([0x01, 0x00, 0x00, 0x00, 0x00], 11);
+  return bytes;
+}
+
+function webpVp8xBytes(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(30);
+  const text = (offset: number, value: string) => {
+    for (let i = 0; i < value.length; i += 1) {
+      bytes[offset + i] = value.charCodeAt(i);
+    }
+  };
+  text(0, "RIFF");
+  bytes.set([40, 0, 0, 0], 4);
+  text(8, "WEBP");
+  text(12, "VP8X");
+  bytes.set([24, 0, 0, 0], 16); // chunk size
+  bytes.set([0, 0, 0, 0], 20); // flags
+  bytes.set([(width - 1) & 0xff, ((width - 1) >> 8) & 0xff, ((width - 1) >> 16) & 0xff], 24);
+  bytes.set([(height - 1) & 0xff, ((height - 1) >> 8) & 0xff, ((height - 1) >> 16) & 0xff], 27);
+  return bytes;
+}
+
+function webpVp8lBytes(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(25);
+  const text = (offset: number, value: string) => {
+    for (let i = 0; i < value.length; i += 1) {
+      bytes[offset + i] = value.charCodeAt(i);
+    }
+  };
+  text(0, "RIFF");
+  bytes.set([17, 0, 0, 0], 4);
+  text(8, "WEBP");
+  text(12, "VP8L");
+  bytes.set([5, 0, 0, 0], 16);
+  bytes.set([0x2f], 20);
+  const bits =
+    ((width - 1) & 0x3fff) | (((height - 1) & 0x3fff) << 14); // fits in 28 bits
+  bytes.set(
+    [
+      bits & 0xff,
+      (bits >>> 8) & 0xff,
+      (bits >>> 16) & 0xff,
+      (bits >>> 24) & 0xff,
+    ],
+    21,
+  );
+  return bytes;
+}
+
+function webpLossyBytes(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(30);
+  const text = (offset: number, value: string) => {
+    for (let i = 0; i < value.length; i += 1) {
+      bytes[offset + i] = value.charCodeAt(i);
+    }
+  };
+  text(0, "RIFF");
+  bytes.set([22, 0, 0, 0], 4);
+  text(8, "WEBP");
+  text(12, "VP8 ");
+  bytes.set([10, 0, 0, 0], 16);
+  bytes.set([0x30, 0x01, 0x00], 20); // frame tag
+  bytes.set([0x9d, 0x01, 0x2a], 23); // start code
+  bytes.set([width & 0xff, (width >> 8) & 0xff], 26);
+  bytes.set([height & 0xff, (height >> 8) & 0xff], 28);
+  return bytes;
+}
+
+test("png dimensions come from the IHDR block", () => {
+  assert.deepEqual(imageDimensions(pngBytes(852, 1280), "image/png"), {
+    height: 1280,
+    width: 852,
+  });
+});
+
+test("jpeg dimensions come from the SOF marker", () => {
+  assert.deepEqual(imageDimensions(jpegBytes(800, 450), "image/jpeg"), {
+    height: 450,
+    width: 800,
+  });
+});
+
+test("webp extended (VP8X) dimensions are stored minus one", () => {
+  assert.deepEqual(imageDimensions(webpVp8xBytes(1024, 768), "image/webp"), {
+    height: 768,
+    width: 1024,
+  });
+});
+
+test("webp lossless (VP8L) packs dimensions into 14 bits each", () => {
+  assert.deepEqual(imageDimensions(webpVp8lBytes(640, 480), "image/webp"), {
+    height: 480,
+    width: 640,
+  });
+});
+
+test("webp lossy (VP8) reads the frame header", () => {
+  assert.deepEqual(imageDimensions(webpLossyBytes(320, 240), "image/webp"), {
+    height: 240,
+    width: 320,
+  });
+});
+
+test("truncated buffers resolve to unknown dimensions", () => {
+  assert.equal(imageDimensions(new Uint8Array(10), "image/png"), null);
+  assert.equal(imageDimensions(new Uint8Array(4), "image/jpeg"), null);
+  assert.equal(imageDimensions(new Uint8Array(12), "image/webp"), null);
+});
+
+test("unknown mimes and corrupt payloads resolve to unknown dimensions", () => {
+  assert.equal(imageDimensions(pngBytes(10, 10), "image/gif"), null);
+  assert.equal(imageDimensions(webpLossyBytes(0, 0), "image/webp"), null);
+
+  const garbage = new Uint8Array(64).fill(0x41);
+  assert.equal(imageDimensions(garbage, "image/png"), null);
+  assert.equal(imageDimensions(garbage, "image/jpeg"), null);
+});

--- a/src/features/cms/image-dimensions.ts
+++ b/src/features/cms/image-dimensions.ts
@@ -1,0 +1,135 @@
+/**
+ * Extract pixel dimensions from image bytes by parsing container headers.
+ * Supports the three formats accepted by uploadMedia: PNG, JPEG, WebP.
+ *
+ * Pure byte inspection (no dependencies, no decoding) so it can run
+ * server-side inside the upload action and inside the backfill script.
+ * Returns null for anything malformed or unsupported — callers treat null
+ * as "dimensions unknown" and may still store the asset.
+ */
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+function readUint32(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3]) >>>
+    0
+  );
+}
+
+function readUint16(bytes: Uint8Array, offset: number): number {
+  return ((bytes[offset] << 8) | bytes[offset + 1]) >>> 0;
+}
+
+/** PNG: fixed layout — 8-byte signature then IHDR with w/h at offsets 16/20. */
+function pngDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (bytes.length < 24) return null;
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  for (let i = 0; i < signature.length; i += 1) {
+    if (bytes[i] !== signature[i]) return null;
+  }
+  const width = readUint32(bytes, 16);
+  const height = readUint32(bytes, 20);
+  if (width === 0 || height === 0) return null;
+  return { height, width };
+}
+
+/** JPEG: walk segment markers until a Start-Of-Frame carries the dimensions. */
+const JPEG_SOF_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce,
+  0xcf,
+]);
+
+function jpegDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+
+  let offset = 2;
+  while (offset + 9 <= bytes.length) {
+    if (bytes[offset] !== 0xff) return null;
+    const marker = bytes[offset + 1];
+    // Standalone markers without a length payload — skip them.
+    if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
+      offset += 2;
+      continue;
+    }
+    const segmentLength = readUint16(bytes, offset + 2);
+    if (segmentLength < 2) return null;
+    if (JPEG_SOF_MARKERS.has(marker)) {
+      if (offset + 9 > bytes.length) return null;
+      const height = readUint16(bytes, offset + 5);
+      const width = readUint16(bytes, offset + 7);
+      if (width === 0 || height === 0) return null;
+      return { height, width };
+    }
+    offset += 2 + segmentLength;
+  }
+  return null;
+}
+
+/** WebP: RIFF container; dimensions depend on the VP8 variant in chunk 1. */
+function webpDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (
+    bytes.length < 12 ||
+    String.fromCharCode(...bytes.subarray(0, 4)) !== "RIFF" ||
+    String.fromCharCode(...bytes.subarray(8, 12)) !== "WEBP"
+  ) {
+    return null;
+  }
+  const format = String.fromCharCode(...bytes.subarray(12, 16));
+
+  if (format === "VP8 ") {
+    // Lossy: frame tag (3B) + start code 0x9d 0x01 0x2a, then 16-bit
+    // little-endian sizes whose low 14 bits carry the dimension.
+    if (bytes.length < 30) return null;
+    if (bytes[23] !== 0x9d || bytes[24] !== 0x01 || bytes[25] !== 0x2a) {
+      return null;
+    }
+    const width = (bytes[26] | (bytes[27] << 8)) & 0x3fff;
+    const height = (bytes[28] | (bytes[29] << 8)) & 0x3fff;
+    if (width === 0 || height === 0) return null;
+    return { height, width };
+  }
+
+  if (format === "VP8L") {
+    // Lossless: signature 0x2f then packed 14-bit width-1 / height-1.
+    if (bytes.length < 25) return null;
+    if (bytes[20] !== 0x2f) return null;
+    const bits =
+      bytes[21] | (bytes[22] << 8) | (bytes[23] << 16) | (bytes[24] << 24);
+    const width = (bits & 0x3fff) + 1;
+    const height = ((bits >> 14) & 0x3fff) + 1;
+    return { height, width };
+  }
+
+  if (format === "VP8X") {
+    // Extended: 24-bit width-1 / height-1 little-endian at offsets 24/27.
+    const width =
+      bytes[24] | (bytes[25] << 8) | (bytes[26] << 16);
+    const height =
+      bytes[27] | (bytes[28] << 8) | (bytes[29] << 16);
+    if (width === 0 || height === 0) return null;
+    return { height: height + 1, width: width + 1 };
+  }
+
+  return null;
+}
+
+export function imageDimensions(
+  bytes: Uint8Array,
+  mime: string,
+): ImageDimensions | null {
+  try {
+    if (mime === "image/png") return pngDimensions(bytes);
+    if (mime === "image/jpeg") return jpegDimensions(bytes);
+    if (mime === "image/webp") return webpDimensions(bytes);
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/cms/media-actions.ts
+++ b/src/features/cms/media-actions.ts
@@ -4,17 +4,32 @@ import { revalidatePath } from "next/cache";
 
 import { getServerClient, isAdminUser } from "./session";
 import { findMediaReferences, type MediaBucket } from "./media";
+import { imageDimensions } from "./image-dimensions";
+import {
+  deleteMediaAsset,
+  updateMediaAssetMeta,
+  upsertMediaAsset,
+} from "./media-catalog";
 
 export interface MediaUploadResult {
   ok: boolean;
   error?: string;
   path?: string;
   publicUrl?: string;
+  /** Upload succeeded but the metadata row write failed; edit later. */
+  warning?: string;
 }
 
 export interface MediaDeleteResult {
   ok: boolean;
   error?: string;
+}
+
+/** Optional editable metadata supplied alongside a new upload (#102). */
+export interface MediaUploadMeta {
+  title?: string;
+  altEn?: string;
+  altVi?: string;
 }
 
 function isAllowedMime(mime: string): boolean {
@@ -31,10 +46,15 @@ function sanitizeFilename(filename: string): string {
  * server client (getServerClient), so Storage RLS (private.is_owner()) authorizes
  * the actual operation — matching the accepted #18 design where admin/browser
  * writes use the normal owner RLS path rather than the service role.
+ *
+ * After Storage accepts the bytes, dimensions are parsed from the buffer and a
+ * media_assets catalog row is written (#102); a failed catalog write degrades
+ * to a warning because the file itself is usable.
  */
 export async function uploadMedia(
   bucket: MediaBucket,
   file: File,
+  meta?: MediaUploadMeta,
 ): Promise<MediaUploadResult> {
   if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
 
@@ -63,8 +83,28 @@ export async function uploadMedia(
     ? `/api/resume-media/${encodeURIComponent(path)}`
     : client.storage.from(bucket).getPublicUrl(path).data.publicUrl;
 
+  const dimensions = imageDimensions(new Uint8Array(arrayBuffer), file.type);
+
+  let warning: string | undefined;
+  try {
+    await upsertMediaAsset(client, {
+      altEn: meta?.altEn,
+      altVi: meta?.altVi,
+      bucket,
+      height: dimensions?.height ?? null,
+      mime: file.type,
+      path,
+      sizeBytes: file.size,
+      title: meta?.title,
+      width: dimensions?.width ?? null,
+    });
+  } catch {
+    warning =
+      "Uploaded, but saving metadata failed. You can edit this image's details later.";
+  }
+
   revalidatePath("/admin/media");
-  return { ok: true, path, publicUrl };
+  return { ok: true, path, publicUrl, warning };
 }
 
 export async function deleteMedia(
@@ -97,8 +137,39 @@ export async function deleteMedia(
   const { error } = await client.storage.from(bucket).remove([path]);
   if (error) return { ok: false, error: error.message };
 
+  // Keep the catalog aligned with Storage; a stale row would render as a ghost
+  // grid entry whose thumbnail 404s.
+  await deleteMediaAsset(client, bucket, path);
+
   revalidatePath("/");
   revalidatePath("/vi");
+  revalidatePath("/admin/media");
+  return { ok: true };
+}
+
+export interface MediaDetailsResult {
+  ok: boolean;
+  error?: string;
+}
+
+/** Editable metadata for one asset (#102) — title + bilingual alt text. */
+export async function updateMediaDetails(
+  bucket: MediaBucket,
+  path: string,
+  meta: { altEn: string; altVi: string; title: string },
+): Promise<MediaDetailsResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  if (!meta.title.trim()) {
+    return { ok: false, error: "Title is required." };
+  }
+
+  const client = await getServerClient();
+  try {
+    await updateMediaAssetMeta(client, bucket, path, meta);
+  } catch {
+    return { ok: false, error: "Could not save the media details. Retry shortly." };
+  }
+
   revalidatePath("/admin/media");
   return { ok: true };
 }

--- a/src/features/cms/media-catalog.test.ts
+++ b/src/features/cms/media-catalog.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Local-only guard, same pattern as repository.test.ts: this suite writes CMS
+// data and MUST never touch a cloud project.
+if (!url || !serviceRole) {
+  console.error(
+    "Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (local Supabase).",
+  );
+  process.exit(1);
+}
+
+const LOCAL_HOST = /^http:\/\/127\.0\.0\.1(?::\d+)?$/;
+if (!LOCAL_HOST.test(url)) {
+  console.error(`Refusing to run catalog tests against non-local Supabase: ${url}`);
+  process.exit(1);
+}
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  deleteMediaAsset,
+  getCoverAltTexts,
+  listMediaAssets,
+  updateMediaAssetMeta,
+  upsertMediaAsset,
+} from "./media-catalog";
+
+const client = createClient(url, serviceRole, {
+  auth: { persistSession: false },
+});
+
+const BUCKET = "blog-media";
+const FIXTURES = [
+  { altEn: "", altVi: "", createdAt: "2026-01-01T00:00:00Z", path: "cat-a.png", title: "Alpha" },
+  { altEn: "Bravo en", altVi: "", createdAt: "2026-01-02T00:00:00Z", path: "bravo.jpg", title: "Bravo photo" },
+  { altEn: "", altVi: "Charlie vi", createdAt: "2026-01-03T00:00:00Z", path: "cat-b.webp", title: "Charlie" },
+  { altEn: "", altVi: "", createdAt: "2026-01-04T00:00:00Z", path: "delta.png", title: "Delta diagram" },
+];
+
+async function seedFixtures() {
+  const { error } = await client
+    .from("media_assets")
+    .upsert(
+      FIXTURES.map((f) => ({
+        alt_en: f.altEn,
+        alt_vi: f.altVi,
+        bucket: BUCKET,
+        created_at: f.createdAt,
+        height: 100,
+        mime: "image/png",
+        path: f.path,
+        size_bytes: 1024,
+        title: f.title,
+        width: 200,
+      })),
+      { onConflict: "bucket,path" },
+    );
+  if (error) throw error;
+}
+
+async function cleanupFixtures() {
+  await client.from("media_assets").delete().eq("bucket", BUCKET)
+    .in("path", FIXTURES.map((f) => f.path));
+}
+
+before(seedFixtures);
+after(cleanupFixtures);
+
+test("page mode paginates newest-first with totals", async () => {
+  const page1 = await listMediaAssets(client, {
+    bucket: BUCKET,
+    limit: 2,
+    page: { mode: "page", page: 1 },
+  });
+  assert.deepEqual(page1.items.map((i) => i.path), ["delta.png", "cat-b.webp"]);
+  assert.equal(page1.total, FIXTURES.length);
+  assert.equal(page1.totalPages, 2);
+
+  const page2 = await listMediaAssets(client, {
+    bucket: BUCKET,
+    limit: 2,
+    page: { mode: "page", page: 2 },
+  });
+  assert.deepEqual(page2.items.map((i) => i.path), ["bravo.jpg", "cat-a.png"]);
+});
+
+test("cursor mode walks the whole library without gaps or duplicates", async () => {
+  const seen = [];
+  let cursor;
+  for (let guard = 0; guard < 10; guard += 1) {
+    const result = await listMediaAssets(client, {
+      bucket: BUCKET,
+      cursor,
+      limit: 2,
+    });
+    seen.push(...result.items.map((i) => i.path));
+    if (!result.nextCursor || result.items.length === 0) break;
+    cursor = result.nextCursor;
+  }
+  assert.deepEqual(seen, ["delta.png", "cat-b.webp", "bravo.jpg", "cat-a.png"]);
+});
+
+test("search matches titles and paths case-insensitively", async () => {
+  const byTitle = await listMediaAssets(client, { bucket: BUCKET, query: "bravo" });
+  assert.deepEqual(byTitle.items.map((i) => i.path), ["bravo.jpg"]);
+
+  const byPath = await listMediaAssets(client, { bucket: BUCKET, query: ".webp" });
+  assert.deepEqual(byPath.items.map((i) => i.path), ["cat-b.webp"]);
+});
+
+test("search input cannot inject LIKE wildcards", async () => {
+  const wildcarded = await listMediaAssets(client, { bucket: BUCKET, query: "%a%" });
+  // Literal % matches nothing; without escaping this would match every row.
+  assert.deepEqual(wildcarded.items.map((i) => i.path), []);
+});
+
+test("upsert derives a readable default title when none given", async () => {
+  await upsertMediaAsset(client, {
+    bucket: BUCKET,
+    mime: "image/png",
+    path: "1730000000000-my-neat-cover.png",
+  });
+
+  try {
+    const found = await listMediaAssets(client, {
+      bucket: BUCKET,
+      limit: 10,
+      query: "my-neat-cover",
+    });
+    assert.equal(found.items.length, 1);
+    assert.equal(found.items[0]?.title, "my neat cover");
+  } finally {
+    await deleteMediaAsset(client, BUCKET, "1730000000000-my-neat-cover.png");
+  }
+});
+
+test("metadata updates persist and map back to camelCase", async () => {
+  const updated = await updateMediaAssetMeta(client, BUCKET, "bravo.jpg", {
+    altEn: "Updated alt",
+    altVi: "Alt tiếng Việt",
+    title: "Renamed asset",
+  });
+  assert.ok(updated);
+  assert.equal(updated?.altEn, "Updated alt");
+  assert.equal(updated?.altVi, "Alt tiếng Việt");
+  assert.equal(updated?.title, "Renamed asset");
+});
+
+test("cover alt lookup batches by path", async () => {
+  const alts = await getCoverAltTexts(client, BUCKET, ["bravo.jpg", "missing.png"]);
+  assert.equal(alts.get("bravo.jpg")?.altEn, "Updated alt");
+  assert.equal(alts.has("missing.png"), false);
+});

--- a/src/features/cms/media-catalog.ts
+++ b/src/features/cms/media-catalog.ts
@@ -1,0 +1,253 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { MediaBucket } from "./media";
+
+/**
+ * Admin catalog over Storage objects (#102). The rows live in public.media_assets
+ * and power listing/search/pagination for the media library surfaces; the
+ * bytes stay in Storage and are addressed by (bucket, path).
+ *
+ * Query functions take the client as a parameter so tests can drive them with
+ * a service-role client against local Supabase; production callers pass the
+ * owner-session client from features/cms/session.
+ */
+
+export interface MediaAsset {
+  bucket: MediaBucket;
+  path: string;
+  title: string;
+  altEn: string;
+  altVi: string;
+  width: number | null;
+  height: number | null;
+  sizeBytes: number | null;
+  mime: string | null;
+  createdAt: string;
+}
+
+export interface MediaAssetRow {
+  bucket: string;
+  path: string;
+  title: string;
+  alt_en: string;
+  alt_vi: string;
+  width: number | null;
+  height: number | null;
+  size_bytes: number | null;
+  mime: string | null;
+  created_at: string;
+}
+
+export interface PageQuery {
+  mode: "page";
+  page: number;
+}
+
+export interface CursorQuery {
+  mode: "cursor";
+  /** Keyset position: everything strictly older than this pair. */
+  createdAt: string;
+  path: string;
+}
+
+export interface ListMediaAssetsParams {
+  bucket: MediaBucket;
+  cursor?: CursorQuery;
+  limit?: number;
+  query?: string;
+  page?: PageQuery;
+}
+
+export interface ListMediaAssetsResult {
+  items: MediaAsset[];
+  /** Cursor to pass back for the next batch (cursor mode only). */
+  nextCursor?: CursorQuery;
+  /** Totals for pagination UI (page mode only). */
+  total?: number;
+  totalPages?: number;
+}
+
+/** Escape LIKE wildcards so search input cannot broaden the match. */
+export function escapeLike(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}
+
+function mapRow(row: MediaAssetRow): MediaAsset {
+  return {
+    altEn: row.alt_en,
+    altVi: row.alt_vi,
+    bucket: row.bucket as MediaBucket,
+    createdAt: row.created_at,
+    height: row.height,
+    mime: row.mime,
+    path: row.path,
+    sizeBytes: row.size_bytes,
+    title: row.title,
+    width: row.width,
+  };
+}
+
+function titleFromPath(path: string): string {
+  return path
+    .replace(/\.[^.]+$/, "")
+    .replace(/^\d+-/, "")
+    .replace(/[-_]+/g, " ")
+    .trim();
+}
+
+export async function upsertMediaAsset(
+  client: SupabaseClient,
+  asset: {
+    altEn?: string;
+    altVi?: string;
+    bucket: MediaBucket;
+    height?: number | null;
+    mime?: string | null;
+    path: string;
+    sizeBytes?: number | null;
+    title?: string;
+    width?: number | null;
+  },
+): Promise<void> {
+  const { error } = await client.from("media_assets").upsert(
+    {
+      alt_en: asset.altEn ?? "",
+      alt_vi: asset.altVi ?? "",
+      bucket: asset.bucket,
+      height: asset.height ?? null,
+      mime: asset.mime ?? null,
+      path: asset.path,
+      size_bytes: asset.sizeBytes ?? null,
+      title: asset.title?.trim() || titleFromPath(asset.path),
+      width: asset.width ?? null,
+    },
+    { onConflict: "bucket,path" },
+  );
+  if (error) throw new Error(`Catalog write failed: ${error.message}`);
+}
+
+export async function deleteMediaAsset(
+  client: SupabaseClient,
+  bucket: MediaBucket,
+  path: string,
+): Promise<void> {
+  const { error } = await client
+    .from("media_assets")
+    .delete()
+    .eq("bucket", bucket)
+    .eq("path", path);
+  if (error) throw new Error(`Catalog delete failed: ${error.message}`);
+}
+
+export async function updateMediaAssetMeta(
+  client: SupabaseClient,
+  bucket: MediaBucket,
+  path: string,
+  meta: { altEn?: string; altVi?: string; title?: string },
+): Promise<MediaAsset | null> {
+  const patch: Record<string, string> = { updated_at: new Date().toISOString() };
+  if (meta.title !== undefined) patch.title = meta.title.trim();
+  if (meta.altEn !== undefined) patch.alt_en = meta.altEn;
+  if (meta.altVi !== undefined) patch.alt_vi = meta.altVi;
+
+  const { data, error } = await client
+    .from("media_assets")
+    .update(patch)
+    .eq("bucket", bucket)
+    .eq("path", path)
+    .select("*")
+    .maybeSingle();
+  if (error) throw new Error(`Catalog update failed: ${error.message}`);
+  return data ? mapRow(data as MediaAssetRow) : null;
+}
+
+export async function listMediaAssets(
+  client: SupabaseClient,
+  params: ListMediaAssetsParams,
+): Promise<ListMediaAssetsResult> {
+  const limit = Math.min(Math.max(params.limit ?? 24, 1), 100);
+
+  let request = client
+    .from("media_assets")
+    .select("*", params.page ? { count: "exact" } : undefined)
+    .eq("bucket", params.bucket);
+
+  if (params.query) {
+    const safe = escapeLike(params.query.trim());
+    if (safe) {
+      request = request.or(`title.ilike.%${safe}%,path.ilike.%${safe}%`);
+    }
+  }
+
+  request =
+    params.cursor && !params.page
+      ? request.or(
+          `created_at.lt.${params.cursor.createdAt},and(created_at.eq.${params.cursor.createdAt},path.lt.${params.cursor.path})`,
+        )
+      : request;
+
+  if (params.page) {
+    const from = (params.page.page - 1) * limit;
+    request = request.range(from, from + limit - 1);
+  }
+
+  const { data, error, count } = await request
+    .order("created_at", { ascending: false })
+    .order("path", { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(`Catalog list failed: ${error.message}`);
+
+  const items = ((data ?? []) as MediaAssetRow[]).map(mapRow);
+  const last = items[items.length - 1];
+
+  const result: ListMediaAssetsResult = { items };
+
+  if (params.page) {
+    result.total = count ?? 0;
+    result.totalPages = Math.max(1, Math.ceil((count ?? 0) / limit));
+  } else if (last) {
+    // A full page hints there may be more; an empty next probe is avoided by
+    // letting the UI fetch once more and render nothing extra.
+    result.nextCursor = { createdAt: last.createdAt, mode: "cursor", path: last.path };
+  }
+
+  return result;
+}
+
+export interface CoverAltLookup {
+  path: string;
+  altEn: string;
+  altVi: string;
+}
+
+/** Batch alt-text lookup for cover paths (public rendering enrichment). */
+export async function getCoverAltTexts(
+  client: SupabaseClient,
+  bucket: MediaBucket,
+  paths: string[],
+): Promise<Map<string, CoverAltLookup>> {
+  const map = new Map<string, CoverAltLookup>();
+  if (paths.length === 0) return map;
+
+  const { data, error } = await client
+    .from("media_assets")
+    .select("path, alt_en, alt_vi")
+    .eq("bucket", bucket)
+    .in("path", paths);
+
+  if (error || !data) return map;
+
+  for (const row of data as Array<{
+    alt_en: string;
+    alt_vi: string;
+    path: string;
+  }>) {
+    map.set(row.path, {
+      altEn: row.alt_en,
+      altVi: row.alt_vi,
+      path: row.path,
+    });
+  }
+  return map;
+}

--- a/src/features/cms/media-library-actions.ts
+++ b/src/features/cms/media-library-actions.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { getServerClient, isAdminUser } from "./session";
+import {
+  listMediaAssets,
+  type ListMediaAssetsResult,
+} from "./media-catalog";
+import type { MediaBucket } from "./media";
+
+/**
+ * Server actions backing the media library surfaces (#102). Query logic lives
+ * in media-catalog.ts (injectable client, unit-tested); these bind it to the
+ * owner-session client and are callable from both server components and the
+ * library's client components.
+ */
+
+export async function fetchMediaPage(
+  bucket: MediaBucket,
+  page: number,
+  query?: string,
+  limit = 24,
+): Promise<ListMediaAssetsResult> {
+  if (!(await isAdminUser())) return { items: [] };
+  const client = await getServerClient();
+  if (!client) return { items: [] };
+  try {
+    return await listMediaAssets(client, {
+      bucket,
+      limit,
+      page: { mode: "page", page },
+      query,
+    });
+  } catch {
+    return { items: [] };
+  }
+}
+
+export async function fetchMediaBatch(
+  bucket: MediaBucket,
+  cursor?: { createdAt: string; path: string },
+  query?: string,
+  limit = 24,
+): Promise<ListMediaAssetsResult> {
+  if (!(await isAdminUser())) return { items: [] };
+  const client = await getServerClient();
+  if (!client) return { items: [] };
+  try {
+    return await listMediaAssets(client, {
+      bucket,
+      cursor: cursor
+        ? { createdAt: cursor.createdAt, mode: "cursor", path: cursor.path }
+        : undefined,
+      limit,
+      query,
+    });
+  } catch {
+    return { items: [] };
+  }
+}

--- a/src/features/cms/media-url.ts
+++ b/src/features/cms/media-url.ts
@@ -1,0 +1,14 @@
+import type { MediaBucket } from "./media";
+
+/**
+ * Public URL for a stored object. Pure string building so both server
+ * (features/cms/media.ts) and client components can use it without pulling
+ * the server session module into client bundles.
+ */
+export function publicMediaUrl(bucket: MediaBucket, path: string): string {
+  if (bucket === "resume-media") {
+    return `/api/resume-media/${encodeURIComponent(path)}`;
+  }
+  const base = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").replace(/\/$/, "");
+  return `${base}/storage/v1/object/public/${bucket}/${encodeURIComponent(path)}`;
+}

--- a/src/features/cms/media.ts
+++ b/src/features/cms/media.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getServerClient } from "./session";
+import { publicMediaUrl } from "./media-url";
 
 export type MediaBucket = "resume-media" | "project-media" | "portfolio" | "blog-media";
 
@@ -28,12 +29,7 @@ export async function listBucketObjects(
 }
 
 export function getMediaPublicUrl(bucket: MediaBucket, path: string): string {
-  if (bucket === "resume-media") {
-    return `/api/resume-media/${encodeURIComponent(path)}`;
-  }
-  // Public buckets expose a fixed public URL built from the public env URL.
-  const base = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").replace(/\/$/, "");
-  return `${base}/storage/v1/object/public/${bucket}/${encodeURIComponent(path)}`;
+  return publicMediaUrl(bucket, path);
 }
 
 /** Escape LIKE wildcards so a stored path can never broaden the reference match. */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3612,8 +3612,8 @@ video {
 
 .admin-media-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: 0.75rem;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -3622,7 +3622,7 @@ video {
 .admin-media-card {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.375rem;
   overflow: hidden;
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
@@ -3645,7 +3645,7 @@ video {
 .admin-media-card__thumb {
   display: block;
   width: 100%;
-  aspect-ratio: 3 / 2;
+  aspect-ratio: 4 / 3;
   object-fit: cover;
   background: var(--color-surface-subtle);
 }
@@ -3668,9 +3668,9 @@ video {
   display: grid;
   gap: 0.125rem;
   margin: 0;
-  padding: 0 0.625rem;
+  padding: 0 0.5rem;
   color: var(--color-text-muted);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
 }
 
 .admin-media-card__meta code {
@@ -3681,9 +3681,10 @@ video {
 
 .admin-media-card__actions {
   display: flex;
-  gap: 0.75rem;
-  justify-content: space-between;
-  padding: 0 0.625rem 0.625rem;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.625rem;
+  padding: 0 0.5rem 0.5rem;
+  font-size: 0.75rem;
 }
 
 .admin-media-library__more {
@@ -3782,6 +3783,38 @@ video {
   object-fit: cover;
   border-radius: 0.5rem;
   background: var(--color-surface-subtle);
+}
+
+/* Image lightbox inside the media library (view a large version on click). */
+.admin-lightbox {
+  width: min(56rem, calc(100vw - 2rem));
+}
+
+.admin-lightbox__image {
+  display: block;
+  width: 100%;
+  max-height: 62vh;
+  object-fit: contain;
+  border-radius: 0.5rem;
+  background: var(--color-surface-subtle);
+  margin-block-end: 0.75rem;
+}
+
+.admin-lightbox__meta {
+  display: grid;
+  gap: 0.25rem;
+  margin-block-end: 0.75rem;
+}
+
+.admin-lightbox__meta code {
+  overflow-wrap: anywhere;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.admin-lightbox__meta span {
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
 }
 
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3558,6 +3558,263 @@ video {
   font-size: 0.875rem;
 }
 
+/* --- Media library (#102): bucket tabs, card grid, dialogs ------------------ */
+
+.admin-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.admin-tab {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  transition: background-color 160ms ease, color 160ms ease,
+    border-color 160ms ease;
+}
+
+.admin-tab:hover {
+  background: var(--color-surface-subtle);
+  color: var(--color-text);
+}
+
+.admin-tab--active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.admin-media-library {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-media-library__search {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.admin-media-library__search input[type="search"] {
+  flex: 1;
+  max-width: 22rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--color-text);
+  font: inherit;
+}
+
+.admin-media-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.admin-media-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface);
+}
+
+.admin-media-card__pick,
+.admin-media-card__view {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  text-align: start;
+  color: inherit;
+}
+
+.admin-media-card__thumb {
+  display: block;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  object-fit: cover;
+  background: var(--color-surface-subtle);
+}
+
+.admin-media-card:hover .admin-media-card__thumb {
+  box-shadow: var(--shadow-md);
+}
+
+.admin-media-card__title {
+  display: block;
+  padding: 0.375rem 0.625rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  font-weight: var(--font-weight-semibold);
+}
+
+.admin-media-card__meta {
+  display: grid;
+  gap: 0.125rem;
+  margin: 0;
+  padding: 0 0.625rem;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.admin-media-card__meta code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-media-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0 0.625rem 0.625rem;
+}
+
+.admin-media-library__more {
+  display: flex;
+  justify-content: center;
+  min-height: 2.75rem;
+}
+
+.admin-media-library__pages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.admin-page-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  padding: 0 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: var(--font-weight-semibold);
+}
+
+.admin-page-num:hover {
+  background: var(--color-surface-subtle);
+}
+
+.admin-page-num--current {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+/* Native dialog shell for metadata editing + the library picker modal. */
+.admin-dialog {
+  width: min(26rem, calc(100vw - 2rem));
+  max-height: min(80vh, 48rem);
+  padding: 1.25rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 1rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-lg, 0 24px 64px rgb(0 0 0 / 0.35));
+}
+
+.admin-dialog::backdrop {
+  background: rgb(0 0 0 / 0.55);
+}
+
+.admin-dialog--wide {
+  width: min(56rem, calc(100vw - 2rem));
+}
+
+.admin-dialog__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.0625rem;
+}
+
+.admin-dialog form {
+  display: grid;
+  gap: 0.875rem;
+}
+
+.admin-dialog__path {
+  display: block;
+  margin-block-end: 0.5rem;
+  overflow-wrap: anywhere;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.admin-dialog__actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.admin-picker__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-block-end: 0.875rem;
+}
+
+.admin-cover-preview {
+  display: block;
+  width: 10rem;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  background: var(--color-surface-subtle);
+}
+
+
+.admin-picker__head .admin-dialog__title {
+  margin: 0;
+}
+
+.admin-picker__tabs {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.admin-picker__tabs button[aria-selected="true"] {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.admin-picker__body {
+  max-height: min(60vh, 40rem);
+  overflow-y: auto;
+  padding-inline-end: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .admin-tab,
+  .admin-page-num,
+  .admin-media-card__thumb {
+    transition: none;
+  }
+}
+
+
 /* Form page: back link + card container */
 .admin-back-link {
   display: inline-flex;

--- a/supabase/migrations/20260826090000_media_assets.sql
+++ b/supabase/migrations/20260826090000_media_assets.sql
@@ -1,0 +1,39 @@
+-- Media assets catalog (#102): editable metadata for Storage objects so the
+-- admin library can paginate, search and sort without relying on the
+-- prefix-only Storage list API. Storage remains the source of truth for bytes;
+-- this table is admin-only (no anon policy — public pages read public URLs
+-- straight from Storage, never this table).
+
+create table public.media_assets (
+  bucket      text        not null
+    check (bucket in ('resume-media', 'project-media', 'blog-media', 'portfolio')),
+  path        text        not null,
+  title       text        not null,
+  alt_en      text        not null default '',
+  alt_vi      text        not null default '',
+  width       integer     check (width is null or width > 0),
+  height      integer     check (height is null or height > 0),
+  size_bytes  bigint      check (size_bytes is null or size_bytes >= 0),
+  mime        text,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now(),
+  primary key (bucket, path)
+);
+
+comment on table public.media_assets is
+  'Admin catalog for media buckets: display title, bilingual alt text and technical facts captured at upload.';
+
+create index media_assets_bucket_recent
+  on public.media_assets (bucket, created_at desc, path desc);
+
+alter table public.media_assets enable row level security;
+
+create policy "media assets owner all" on public.media_assets
+  for all to authenticated
+  using (private.is_owner()) with check (private.is_owner());
+
+-- Same privilege posture as the blog tables: anon has zero handle on the
+-- table; owner-session clients and the service-role server path do DML.
+revoke all on public.media_assets from anon;
+grant select, insert, update, delete on public.media_assets
+  to authenticated, service_role;

--- a/supabase/tests/media_assets_test.sql
+++ b/supabase/tests/media_assets_test.sql
@@ -1,0 +1,82 @@
+-- media_assets RLS verification (#102), following the role + JWT claims
+-- pattern of blog_schema_test.sql / rls_crud_test.sql.
+--
+-- Contract: the catalog is admin-only. The anonymous role has zero table
+-- privileges (SELECT revoked outright, writes refused); the configured owner
+-- can insert/select/update/delete. Unknown buckets are rejected by a CHECK.
+
+begin;
+select plan(8);
+
+-- --- Owner: full CRUD ---------------------------------------------------------
+select set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', (select auth_uid from public.admin_owner limit 1)::text,
+    'role', 'authenticated'
+  )::text,
+  false
+);
+
+set local role authenticated;
+
+select lives_ok(
+  $$ insert into public.media_assets
+       (bucket, path, title, alt_en, alt_vi, width, height, size_bytes, mime)
+     values ('blog-media', 'rls-test.png', 'RLS test', 'alt en', 'alt vi', 2, 1, 10, 'image/png') $$,
+  'owner can insert a catalog row'
+);
+
+select is(
+  (select title from public.media_assets
+    where bucket = 'blog-media' and path = 'rls-test.png'),
+  'RLS test',
+  'owner reads back the inserted row'
+);
+
+select lives_ok(
+  $$ update public.media_assets set alt_en = 'edited'
+     where bucket = 'blog-media' and path = 'rls-test.png' $$,
+  'owner can edit metadata'
+);
+
+select is(
+  (select alt_en from public.media_assets
+    where bucket = 'blog-media' and path = 'rls-test.png'),
+  'edited',
+  'metadata edit persists'
+);
+
+select lives_ok(
+  $$ delete from public.media_assets
+     where bucket = 'blog-media' and path = 'rls-test.png' $$,
+  'owner can delete the row'
+);
+
+select throws_ok(
+  $$ insert into public.media_assets (bucket, path, title)
+     values ('not-a-bucket', 'x.png', 'bad bucket') $$,
+  NULL,
+  NULL,
+  'unknown buckets are rejected by the check constraint'
+);
+
+-- --- Anonymous: zero table privileges ----------------------------------------
+set local role anon;
+
+select throws_ok(
+  $$ select count(*) from public.media_assets $$,
+  42501,
+  NULL,
+  'anon cannot select from the catalog at all'
+);
+
+select throws_ok(
+  $$ insert into public.media_assets (bucket, path, title)
+     values ('blog-media', 'anon.png', 'nope') $$,
+  42501,
+  NULL,
+  'anon cannot insert into the catalog'
+);
+
+rollback;


### PR DESCRIPTION
Closes #102 — full media library implementation.

## What

**Backend (commit d1812d7)**
- `media_assets` catalog table (PK `(bucket,path)`): title, alt_en/alt_vi + auto width/height/size/mime at upload. Owner-only RLS; anon zero privileges (same posture as blog tables).
- Server-side PNG/JPEG/WebP dimension parser — no new dependency, reused by backfill.
- `listMediaAssets` page mode (range+exact count) and keyset-cursor mode share one query builder; ilike search over title/path with wildcard escaping; batch cover-alt lookup.
- `uploadMedia` writes dimensions + optional metadata after Storage accepts bytes (catalog failure degrades to a warning); `deleteMedia` removes the row post-deletion.
- `backfill-media-assets.mjs`: idempotent, dry-run default, refuses non-local hosts without `--force` (local-first).

**UI engine + wiring (commit 0ae3dcf)**
- `MediaLibraryGrid` (client): shared card grid — page mode (URL pagination) and cursor mode (infinite scroll + Load-more), debounced search, metadata edit dialog, delete with reference guard; cards are named buttons, status via aria-live.
- `MediaPickerModal`: WordPress-style `<dialog>` library with Library/Upload tabs, scoped to one bucket; native focus handling, focus restored on close.
- `/admin/media` revamped: bucket tabs via searchParams, paginated searchable grid, upload panel with optional title + bilingual alt.
- Fetchers are server actions (`media-library-actions.ts`) so client components can call them; query logic stays in the unit-tested catalog.
- Blog editor: cover picker uses the modal (radio list removed), inline image insert emits locale-aware alt from the catalog; `listBlogMedia` helper removed.
- Public enrichment: blog listing + post-detail cover alt falls back to the catalog's locale alt when present (title otherwise).

## Verification
- `npm run lint`, `npm run typecheck`, `npm run build -- --webpack` — PASS
- `npm test` — 147/147
- `test:cms` — 20/20 (7 new catalog tests: pagination, cursor walk, search, wildcard-injection guard, default-title derivation, metadata updates, cover-alt batch lookup)
- `test:rls` — 56/56 incl. media_assets suite: anon zero privileges (SELECT revoked → 42501, insert → 42501), owner CRUD via claims, bucket CHECK
- Migration applied local-first via `supabase db reset`; backfill dry-run verified against a real PNG (1187×702 parsed correctly)

## Notes
- Local stack note: `db reset` cleared auth.users + Storage fixtures; re-seed your local admin with `npm run seed:admin` before using admin UI locally.
- Phase 2 (project/resume/portfolio editors adopting the picker) tracked as a follow-up issue, not in this PR.
- Admin UI smoke test requires an authenticated owner session + browser (not available in this environment); CI build + DOM-level component verification used instead.
