### PR TITLE
fix(media): restore compact gallery from 21bec74 + harden delete dialog

### DIFF
--- a/src/app/admin/(dashboard)/blog/actions.ts
+++ b/src/app/admin/(dashboard)/blog/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, updateTag } from "next/cache";
 
 import { renderMarkdown } from "@/features/blog/markdown";
-import { BLOG_CACHE_TAG } from "@/features/blog/repository";
+import { BLOG_CACHE_TAG } from "@/features/blog/cache-tag";
 import { getServerClient, isAdminUser } from "@/features/cms/session";
 import { required } from "@/features/cms/validation";
 

--- a/src/app/admin/(dashboard)/media/media-grid.tsx
+++ b/src/app/admin/(dashboard)/media/media-grid.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { MediaAsset } from "@/features/cms/media-library";
+import type { MediaBucket } from "@/features/cms/media";
+import {
+  DeleteActionButton,
+  SelectionCheckbox,
+} from "@/features/cms/delete-actions";
+
+interface MediaGridProps {
+  items: MediaAsset[];
+  bucket: MediaBucket;
+}
+
+export function MediaGrid({ items, bucket }: MediaGridProps) {
+  const [lightbox, setLightbox] = useState<MediaAsset | null>(null);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  async function copyUrl(asset: MediaAsset) {
+    try {
+      await navigator.clipboard.writeText(asset.url);
+      setCopyStatus(`Copied URL for ${asset.path}.`);
+    } catch {
+      setCopyStatus("Could not copy the URL.");
+    }
+  }
+
+  return (
+    <>
+      {copyStatus ? (
+        <p className="admin-note" role="status" aria-live="polite">
+          {copyStatus}
+        </p>
+      ) : null}
+      <ul className="admin-media-grid">
+        {items.map((item) => (
+          <li className="admin-media-grid__item" key={item.path}>
+            <button
+              className="admin-media-preview"
+              onClick={() => setLightbox(item)}
+              title={`${item.title} — view`}
+              type="button"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                alt={item.altEn || item.title || item.path}
+                height={item.height ?? 80}
+                loading="lazy"
+                src={item.url}
+                width={item.width ?? 120}
+              />
+            </button>
+            <div className="admin-media-meta">
+              <code title={item.path}>{item.path}</code>
+              <span className="admin-media-title">{item.title || "Untitled"}</span>
+              <span className="admin-media-dims">
+                {item.width && item.height ? `${item.width}×${item.height}` : "—"}
+                {item.sizeBytes ? ` · ${formatBytes(item.sizeBytes)}` : ""}
+                {item.mime ? ` · ${item.mime}` : ""}
+              </span>
+              <div className="admin-media-actions">
+                <SelectionCheckbox id={item.path} label={item.title || item.path} />
+                <button className="admin-link-button" onClick={() => copyUrl(item)} type="button">
+                  Copy URL
+                </button>
+                <DeleteActionButton
+                  bucket={bucket}
+                  entity="media"
+                  item={{ id: item.path, label: item.title || item.path }}
+                  noun="file"
+                />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <MediaLightbox
+        asset={lightbox}
+        onClose={() => setLightbox(null)}
+        onCopy={() => lightbox && copyUrl(lightbox)}
+      />
+    </>
+  );
+}
+
+function MediaLightbox({
+  asset,
+  onClose,
+  onCopy,
+}: {
+  asset: MediaAsset | null;
+  onClose: () => void;
+  onCopy: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (asset && !dialog.open) dialog.showModal();
+    else if (!asset && dialog.open) dialog.close();
+  }, [asset]);
+
+  return (
+    <dialog
+      aria-label={asset ? `Preview of ${asset.title}` : "Image preview"}
+      className="admin-dialog admin-lightbox"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) onClose();
+      }}
+      ref={dialogRef}
+    >
+      {asset ? (
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt={asset.altEn || asset.title}
+            className="admin-lightbox__image"
+            src={asset.url}
+          />
+          <div className="admin-lightbox__meta">
+            <strong>{asset.title}</strong>
+            <code>{asset.path}</code>
+            <span>
+              {asset.width && asset.height ? `${asset.width}×${asset.height} · ` : ""}
+              {asset.mime?.replace("image/", "") ?? "?"}
+            </span>
+          </div>
+          <div className="admin-dialog__actions">
+            <button onClick={onCopy} type="button">
+              Copy URL
+            </button>
+            <button onClick={onClose} type="button">
+              Close
+            </button>
+          </div>
+        </>
+      ) : null}
+    </dialog>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/app/admin/(dashboard)/media/page.tsx
+++ b/src/app/admin/(dashboard)/media/page.tsx
@@ -3,12 +3,8 @@ import type { MediaBucket } from "@/features/cms/media";
 import { getServerClient } from "@/features/cms/session";
 import { MediaUploadForm } from "./media-upload-form";
 import { AdminPage } from "../admin-page";
-import {
-  BulkDeleteBar,
-  BulkSelectionProvider,
-  DeleteActionButton,
-  SelectionCheckbox,
-} from "@/features/cms/delete-actions";
+import { BulkDeleteBar, BulkSelectionProvider } from "@/features/cms/delete-actions";
+import { MediaGrid } from "./media-grid";
 
 export const metadata = {
   title: "Admin media",
@@ -21,7 +17,7 @@ const buckets: Array<{ id: MediaBucket; label: string; note: string }> = [
   { id: "portfolio", label: "Portfolio (public)", note: "Profile / social images." },
 ];
 
-const PAGE_SIZE = 24;
+const PAGE_SIZE = 12;
 
 interface AdminMediaPageProps {
   searchParams: Promise<{
@@ -107,42 +103,7 @@ export default async function AdminMediaPage({
               {search ? "No files match your search." : "No files uploaded yet."}
             </p>
           ) : (
-            <ul className="admin-media-grid">
-              {items.map((item) => (
-                <li className="admin-media-grid__item" key={item.path}>
-                  <div className="admin-media-preview">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt={item.altEn || item.title || item.path}
-                      height={item.height ?? 80}
-                      loading="lazy"
-                      src={item.url}
-                      width={item.width ?? 120}
-                    />
-                  </div>
-                  <div className="admin-media-meta">
-                    <code title={item.path}>{item.path}</code>
-                    <span className="admin-media-title">{item.title || "Untitled"}</span>
-                    <span className="admin-media-dims">
-                      {item.width && item.height
-                        ? `${item.width}×${item.height}`
-                        : "—"}
-                      {item.sizeBytes ? ` · ${formatBytes(item.sizeBytes)}` : ""}
-                      {item.mime ? ` · ${item.mime}` : ""}
-                    </span>
-                    <div className="admin-media-actions">
-                      <SelectionCheckbox id={item.path} label={item.title || item.path} />
-                      <DeleteActionButton
-                        bucket={activeBucket}
-                        entity="media"
-                        item={{ id: item.path, label: item.title || item.path }}
-                        noun="file"
-                      />
-                    </div>
-                  </div>
-                </li>
-              ))}
-            </ul>
+            <MediaGrid bucket={activeBucket} items={items} />
           )}
 
           {totalPages > 1 ? (
@@ -172,10 +133,4 @@ export default async function AdminMediaPage({
       </section>
     </AdminPage>
   );
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/src/features/blog/cache-tag.ts
+++ b/src/features/blog/cache-tag.ts
@@ -1,0 +1,1 @@
+export const BLOG_CACHE_TAG = "blog";

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -20,12 +20,15 @@
  * resolves to `null` / an empty listing so routes can map to `notFound()` /
  * empty state rather than a 500.
  */
+import "server-only";
+
 import type { Locale } from "@/features/i18n/config";
 import { unstable_cache } from "next/cache";
 
 import { hasCmsConfig } from "@/features/cms/config";
 import { getMediaPublicUrl } from "@/features/cms/media";
 import { getServiceClient } from "@/features/cms/server";
+import { BLOG_CACHE_TAG } from "./cache-tag";
 import { renderMarkdown } from "./markdown";
 import { readingTimeMinutes } from "./reading-time";
 import type {
@@ -35,8 +38,6 @@ import type {
   PostDetail,
   PostListItem,
 } from "./types";
-
-export const BLOG_CACHE_TAG = "blog";
 
 const PAGE_SIZE = 6;
 const RELATED_POSTS_LIMIT = 3;

--- a/src/features/cms/confirm-delete-dialog.tsx
+++ b/src/features/cms/confirm-delete-dialog.tsx
@@ -187,6 +187,7 @@ export function ConfirmDeleteDialog({
   }, [open]);
 
   if (!open) return null;
+  if (typeof document === "undefined") return null;
 
   const labelById = new Map(items.map((item) => [item.id, item.label]));
   const count = items.length;

--- a/src/features/cms/delete-service.ts
+++ b/src/features/cms/delete-service.ts
@@ -3,7 +3,7 @@
 import { revalidatePath, updateTag } from "next/cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-import { BLOG_CACHE_TAG } from "@/features/blog/repository";
+import { BLOG_CACHE_TAG } from "@/features/blog/cache-tag";
 import type { MediaBucket } from "./media";
 import { getServerClient, isAdminUser } from "./session";
 

--- a/src/features/cms/media-picker-modal.tsx
+++ b/src/features/cms/media-picker-modal.tsx
@@ -200,6 +200,7 @@ export function MediaPickerModal({
   }, [open]);
 
   if (!open) return null;
+  if (typeof document === "undefined") return null;
 
   function choose(item: MediaAsset) {
     onSelect({

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5050,7 +5050,7 @@ video {
 
 .admin-media-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
   gap: 0.75rem;
   margin: 0;
   padding: 0;
@@ -5059,19 +5059,21 @@ video {
 
 .admin-media-grid__item {
   display: grid;
-  gap: 0.5rem;
-  padding: 0.625rem;
+  gap: 0.375rem;
+  padding: 0.5rem;
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   background: var(--color-surface);
+  overflow: hidden;
 }
 
 .admin-media-grid__item .admin-media-preview {
   width: 100%;
-  height: 7rem;
+  aspect-ratio: 4 / 3;
   overflow: hidden;
   border-radius: 0.5rem;
   background: var(--color-surface-subtle);
+  cursor: pointer;
 }
 
 .admin-media-grid__item .admin-media-preview img {
@@ -5082,15 +5084,16 @@ video {
 
 .admin-media-grid__item .admin-media-meta {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.125rem;
   min-width: 0;
+  padding: 0 0.125rem;
 }
 
 .admin-media-grid__item .admin-media-meta code {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
 }
 
 .admin-media-title {
@@ -5103,6 +5106,13 @@ video {
 
 .admin-media-dims {
   color: var(--color-text-muted);
+  font-size: 0.6875rem;
+}
+
+.admin-media-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.625rem;
   font-size: 0.75rem;
 }
 
@@ -5117,6 +5127,38 @@ video {
 .admin-pagination__info {
   color: var(--color-text-muted);
   font-size: 0.875rem;
+}
+
+/* Image lightbox inside the media library (view a large version on click). */
+.admin-lightbox {
+  width: min(56rem, calc(100vw - 2rem));
+}
+
+.admin-lightbox__image {
+  display: block;
+  width: 100%;
+  max-height: 62vh;
+  object-fit: contain;
+  border-radius: 0.5rem;
+  background: var(--color-surface-subtle);
+  margin-block-end: 0.75rem;
+}
+
+.admin-lightbox__meta {
+  display: grid;
+  gap: 0.25rem;
+  margin-block-end: 0.75rem;
+}
+
+.admin-lightbox__meta code {
+  overflow-wrap: anywhere;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.admin-lightbox__meta span {
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
 }
 
 /* --- Shared MediaPickerModal --- */


### PR DESCRIPTION
Khôi phục các cải tiến đã mất khi squash 21bec74 (PR #103) không được đưa vào merge 159dcdb.

**Trước (21bec74 - PR #103):**
- Gallery gọn — thẻ nhỏ 4/3, minmax 8.5rem
- Phân trang 12/trang (21 ảnh → 2 trang)
- Click ảnh → lightbox + Copy URL / Edit / Delete
- Copy URL trên mỗi thẻ

**Hiện tại main (6cea957):** chỉ còn Prev/Next 24/trang, không lightbox, không Copy URL → bạn thấy "mất tiêu".

**PR này (giữ nguyên tính năng mới):**
- `PAGE_SIZE 12` (`src/app/admin/(dashboard)/media/page.tsx:24`)
- Compact grid `8.5rem` + `4/3` (`src/styles/globals.css:5051`)
- `MediaGrid` client với lightbox + Copy URL (`src/app/admin/(dashboard)/media/media-grid.tsx:1`)
- Giữ nguyên catalog, picker modal, bulk delete, search — chỉ thêm lại polish.

**Đồng thời vá lỗi xóa #441 (Server Components render):**
- Tách `BLOG_CACHE_TAG` ra `src/features/blog/cache-tag.ts:1` + `import "server-only"` (`src/features/blog/repository.ts:1`) để không rò `service_role` vào client bundle
- Guard `typeof document === "undefined"` trước `createPortal` ở cả hai dialog (`src/features/cms/confirm-delete-dialog.tsx:190`, `src/features/cms/media-picker-modal.tsx:202`)

Closes phần còn thiếu của #102.