### PR TITLE
fix(media): exact demo/21bec74 interface on top of full newest features

### DIFF
--- a/docs/superpowers/specs/2026-08-26-media-library-design.md
+++ b/docs/superpowers/specs/2026-08-26-media-library-design.md
@@ -1,0 +1,49 @@
+# Media Library Design — WordPress-style shared picker + catalog
+
+Date: 2026-08-26 · Issue: #102 · Status: approved in chat (see issue for summary)
+
+## Goals
+
+Replace the flat `/admin/media` rows and fragmented per-section pickers with one
+media library engine that scales to thousands of images and gives every asset
+editable metadata (alt text first-class, bilingual).
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Catalog | New table `media_assets`, PK `(bucket, path)`. Storage stays source of truth for bytes; catalog powers listing/search/sort. |
+| Metadata fields | `title` (internal display name, default from filename, searchable), `alt_en`, `alt_vi`. Auto at upload: `width`, `height`, `size_bytes`, `mime`. No caption/description (near-zero SEO value in 2026). |
+| RLS | Enable RLS; owner-only CRUD via `private.is_owner()`; **no anon policy** — public pages never read this table (public URLs go straight to Storage). |
+| Surfaces | One `MediaLibraryGrid` engine, two hosts: `MediaPickerModal` (`<dialog>`) scoped to one bucket opened from editors; revamped `/admin/media` page with bucket tabs. |
+| Loading | Modal = infinite scroll via keyset cursor (`created_at desc, path desc`) + IntersectionObserver sentinel + "Load more" fallback. Page = numbered pagination through URL searchParams (deep-linkable). Both call one `listMediaAssets({bucket, query?, limit, page?|cursor?})`. |
+| Search | `ilike` over `title` + `path` (wildcards escaped). Supabase Storage prefix-only search is insufficient, hence the catalog. |
+| Dimensions | Server-side header parsing of PNG (IHDR), JPEG (SOF scan), WebP (VP8/VP8L/VP8X) — no new dependency; reused by backfill script. |
+| Upload flow | Keep existing mime/10MB/owner-session guards → parse dimensions → upload to Storage first → insert catalog row (failure degrades to warning; file remains usable, metadata editable later). Title defaults from filename. Modal has Library / Upload tabs. |
+| Delete | Existing reference-check preserved; after Storage remove succeeds, catalog row is deleted too. |
+| Blog wiring (phase 1) | Cover picker and inline-insert use the modal (blog-media). Inline insert uses the asset's locale-appropriate alt. Public listing enriches cover alt from the catalog per locale when present. |
+| Phase 2 | Project/resume/portfolio editors adopt the same picker (separate issue). |
+
+## A11y contract
+
+Native `<dialog>` (Esc handled by browser), focus restored to invoker on close,
+initial focus on search input, grid cards are named `<button>`s, upload status
+and errors announced via `aria-live="polite"`, visible `:focus-visible` styles,
+no motion beyond theme tokens.
+
+## Data access details
+
+- Page mode: `.range(from, to)` + `count: "exact"`.
+- Cursor mode keyset: `.or("created_at.lt.T,and(created_at.eq.T,path.lt.P))`.
+- Index: `media_assets (bucket, created_at desc, path desc)`.
+
+## Rollout
+
+1. PR 1 — schema migration, backfill script, dimension parser, catalog data
+   layer, tests (unit + local-Supabase catalog tests + RLS SQL test).
+2. PR 2 — MediaLibraryGrid/modal/metadata-dialog/upload-modal + `/admin/media`
+   revamp.
+3. PR 3 — blog editor wiring + public cover-alt enrichment.
+
+Local-first DB workflow applies: apply migration + backfill locally, verify,
+then promote with human approval.

--- a/src/app/admin/(dashboard)/blog/media-insert.tsx
+++ b/src/app/admin/(dashboard)/blog/media-insert.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+import type { MediaBucket } from "@/features/cms/media";
+import { MediaPickerModal } from "../media/media-picker-modal";
+
+export interface InsertableImage {
+  url: string;
+  altEn: string;
+  altVi: string;
+}
+
+interface MediaInsertButtonProps {
+  onInsert: (image: InsertableImage) => void;
+}
+
+/**
+ * Inline "Insert image" control for a Markdown content field (#102): opens the
+ * shared blog-media library modal (browse or upload), then hands the chosen
+ * asset — with its catalog alt text in both locales — to the editor.
+ */
+export function MediaInsertButton({ onInsert }: Readonly<MediaInsertButtonProps>) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        aria-expanded={open}
+        className="admin-link-button"
+        onClick={() => setOpen(true)}
+        type="button"
+      >
+        Insert image
+      </button>
+      <MediaPickerModal
+        bucket={"blog-media" satisfies MediaBucket}
+        onClose={() => setOpen(false)}
+        onSelect={(asset) => {
+          onInsert({ altEn: asset.altEn, altVi: asset.altVi, url: asset.url });
+          setOpen(false);
+        }}
+        open={open}
+      />
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/media/media-library-grid.tsx
+++ b/src/app/admin/(dashboard)/media/media-library-grid.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { MediaBucket } from "@/features/cms/media";
+import { publicMediaUrl } from "@/features/cms/media-url";
+import {
+  deleteMedia,
+  updateMediaDetails,
+} from "@/features/cms/media-actions";
+import type {
+  CursorQuery,
+  ListMediaAssetsResult,
+  MediaAsset,
+} from "@/features/cms/media-catalog";
+import { fetchMediaBatch } from "@/features/cms/media-library-actions";
+
+export interface MediaLibraryGridProps {
+  bucket: MediaBucket;
+  initial: ListMediaAssetsResult;
+  initialQuery?: string;
+  /** Page mode deep-links via URL; cursor mode streams batches in place. */
+  mode: "page" | "cursor";
+  /** Page mode only — which page `initial` represents (for pagination links). */
+  pageNumber?: number;
+  /** Cursor-mode only: called with the chosen asset (picker modal). */
+  onPick?: (asset: MediaAsset) => void;
+}
+
+/**
+ * Core library grid (#102). Two loading modes share this component:
+ *  - "page": numbered pagination driven by URL searchParams (management page).
+ *  - "cursor": infinite scroll with a Load-more fallback (picker modal).
+ * Cards are named buttons; delete/edit status is announced politely.
+ */
+export function MediaLibraryGrid({
+  bucket,
+  initial,
+  initialQuery = "",
+  mode,
+  onPick,
+  pageNumber = 1,
+}: Readonly<MediaLibraryGridProps>) {
+  const router = useRouter();
+  const [items, setItems] = useState<MediaAsset[]>(initial.items);
+  const [cursor, setCursor] = useState<CursorQuery | undefined>(initial.nextCursor);
+  const [query, setQuery] = useState(initialQuery);
+  const [status, setStatus] = useState<string | null>(null);
+  const [editing, setEditing] = useState<MediaAsset | null>(null);
+  const [lightbox, setLightbox] = useState<MediaAsset | null>(null);
+  const [, startTransition] = useTransition();
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Server renders a fresh grid instance per page/search via `key`, so local
+  // state initializes from props and never needs prop-syncing effects.
+
+  const loadOlder = useCallback(() => {
+    if (!cursor) return;
+    setStatus("Loading…");
+    startTransition(async () => {
+      try {
+        const next = await fetchMediaBatch(bucket, cursor, query || undefined);
+        setItems((current) => {
+          const known = new Set(current.map((item) => item.path));
+          return [...current, ...next.items.filter((item) => !known.has(item.path))];
+        });
+        setCursor(next.nextCursor);
+      } catch {
+        setStatus("Could not load more images.");
+      }
+    });
+  }, [bucket, cursor, query]);
+
+  // Infinite scroll for cursor mode.
+  useEffect(() => {
+    if (mode !== "cursor" || !cursor) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) loadOlder();
+      },
+      { rootMargin: "320px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [cursor, loadOlder, mode]);
+
+  // Debounced re-fetch on query change (page mode navigates via form submit).
+  useEffect(() => {
+    if (mode !== "cursor") return;
+    if (query === initialQuery) return;
+    const timer = setTimeout(() => {
+      setStatus("Searching…");
+      startTransition(async () => {
+        try {
+          const next = await fetchMediaBatch(bucket, undefined, query || undefined);
+          setItems(next.items);
+          setCursor(next.nextCursor);
+        } catch {
+          setStatus("Search failed.");
+        }
+      });
+    }, 350);
+    return () => clearTimeout(timer);
+  }, [bucket, initialQuery, mode, query]);
+
+  function submitSearch(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (mode !== "page") return;
+    const params = new URLSearchParams(window.location.search);
+    if (query.trim()) params.set("q", query.trim());
+    else params.delete("q");
+    params.delete("page");
+    router.push(`?${params.toString()}`);
+  }
+
+  function removeAsset(asset: MediaAsset) {
+    if (!window.confirm(`Delete "${asset.title}"? This cannot be undone.`)) return;
+    setStatus(`Deleting ${asset.path}…`);
+    startTransition(async () => {
+      const result = await deleteMedia(asset.bucket, asset.path);
+      if (result.ok) {
+        setItems((current) => current.filter((item) => item.path !== asset.path));
+        setStatus(null);
+        router.refresh();
+      } else {
+        setStatus(result.error ?? "Delete failed.");
+      }
+    });
+  }
+
+  function saveDetails(
+    meta: { altEn: string; altVi: string; title: string },
+    done: () => void,
+  ) {
+    if (!editing) return;
+    setStatus("Saving details…");
+    startTransition(async () => {
+      const result = await updateMediaDetails(editing.bucket, editing.path, meta);
+      if (result.ok) {
+        setItems((current) =>
+          current.map((item) =>
+            item.path === editing.path
+              ? { ...item, altEn: meta.altEn, altVi: meta.altVi, title: meta.title.trim() }
+              : item,
+          ),
+        );
+        setStatus(null);
+        done();
+      } else {
+        setStatus(result.error ?? "Could not save details.");
+      }
+    });
+  }
+
+  async function copyUrl(asset: MediaAsset) {
+    try {
+      await navigator.clipboard.writeText(publicMediaUrl(asset.bucket, asset.path));
+      setStatus(`Copied URL for ${asset.path}.`);
+    } catch {
+      setStatus("Could not copy the URL.");
+    }
+  }
+
+  return (
+    <div className="admin-media-library">
+      <form className="admin-media-library__search" onSubmit={submitSearch} role="search">
+        <input
+          aria-label="Search images by title or filename"
+          autoComplete="off"
+          name="q"
+          onChange={(event) => setQuery(event.currentTarget.value)}
+          placeholder="Search by title or filename…"
+          type="search"
+          value={query}
+        />
+        {mode === "page" ? <button type="submit">Search</button> : null}
+      </form>
+
+      <p aria-live="polite" className="admin-note">
+        {status ??
+          `${items.length}${mode === "page" && initial.total !== undefined ? ` of ${initial.total}` : ""} image(s)`}
+      </p>
+
+      {items.length === 0 ? (
+        <p className="admin-message">No images match.</p>
+      ) : (
+        <ul className="admin-media-grid">
+          {items.map((asset) => (
+            <MediaLibraryCard
+              asset={asset}
+              key={asset.path}
+              onCopy={() => copyUrl(asset)}
+              onEdit={() => setEditing(asset)}
+              onPick={onPick}
+              onRemove={removeAsset}
+              onView={() => setLightbox(asset)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {mode === "cursor" && cursor ? (
+        <div className="admin-media-library__more" ref={sentinelRef}>
+          <button onClick={loadOlder} type="button">
+            Load more
+          </button>
+        </div>
+      ) : null}
+
+      {mode === "page" && (initial.totalPages ?? 1) > 1 ? (
+        <nav aria-label="Library pages" className="admin-media-library__pages">
+          {Array.from({ length: initial.totalPages ?? 1 }, (_, i) => i + 1).map(
+            (n) => {
+              const params = new URLSearchParams();
+              if (n > 1) params.set("page", String(n));
+              if (initialQuery) params.set("q", initialQuery);
+              const search = params.toString();
+              return (
+                <a
+                  aria-current={n === pageNumber ? "page" : undefined}
+                  className={
+                    n === pageNumber
+                      ? "admin-page-num admin-page-num--current"
+                      : "admin-page-num"
+                  }
+                  href={search ? `?${search}` : "?"}
+                  key={n}
+                >
+                  {n}
+                </a>
+              );
+            },
+          )}
+        </nav>
+      ) : null}
+
+      <MediaMetadataDialog
+        asset={editing}
+        onClose={() => setEditing(null)}
+        onSave={saveDetails}
+      />
+
+      <MediaLightbox
+        asset={lightbox}
+        onClose={() => setLightbox(null)}
+        onCopy={() => lightbox && copyUrl(lightbox)}
+        onEdit={() => {
+          if (lightbox) setEditing(lightbox);
+          setLightbox(null);
+        }}
+        onRemove={() => {
+          if (lightbox) removeAsset(lightbox);
+          setLightbox(null);
+        }}
+      />
+    </div>
+  );
+}
+
+function MediaLibraryCard({
+  asset,
+  onCopy,
+  onEdit,
+  onPick,
+  onRemove,
+  onView,
+}: {
+  asset: MediaAsset;
+  onCopy: () => void;
+  onEdit: () => void;
+  onPick?: (asset: MediaAsset) => void;
+  onRemove: (asset: MediaAsset) => void;
+  onView: () => void;
+}) {
+  const thumb = (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        alt={asset.altEn || asset.title}
+        className="admin-media-card__thumb"
+        height={128}
+        loading="lazy"
+        src={publicMediaUrl(asset.bucket, asset.path)}
+        width={192}
+      />
+      <span className="admin-media-card__title">{asset.title}</span>
+    </>
+  );
+
+  return (
+    <li className="admin-media-card">
+      {onPick ? (
+        <button
+          className="admin-media-card__pick"
+          onClick={() => onPick(asset)}
+          title={`${asset.title} — use this image`}
+          type="button"
+        >
+          {thumb}
+        </button>
+      ) : (
+        <button
+          className="admin-media-card__pick"
+          onClick={onView}
+          title={`${asset.title} — view`}
+          type="button"
+        >
+          {thumb}
+        </button>
+      )}
+
+      <p className="admin-media-card__meta">
+        <code>{asset.path}</code>
+        <span>
+          {asset.width && asset.height ? `${asset.width}×${asset.height} · ` : ""}
+          {asset.mime?.replace("image/", "") ?? "?"}
+        </span>
+      </p>
+
+      <div className="admin-media-card__actions">
+        <button className="admin-link-button" onClick={onCopy} type="button">
+          Copy URL
+        </button>
+        <button className="admin-link-button" onClick={onEdit} type="button">
+          Edit
+        </button>
+        <button
+          className="admin-link-button admin-link-button--danger"
+          onClick={() => onRemove(asset)}
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function MediaMetadataDialog({
+  asset,
+  onClose,
+  onSave,
+}: {
+  asset: MediaAsset | null;
+  onClose: () => void;
+  onSave: (
+    meta: { altEn: string; altVi: string; title: string },
+    done: () => void,
+  ) => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (asset && !dialog.open) {
+      dialog.showModal();
+    } else if (!asset && dialog.open) {
+      dialog.close();
+    }
+  }, [asset]);
+
+  return (
+    <dialog
+      aria-label={asset ? `Edit details for ${asset.title}` : "Edit media details"}
+      className="admin-dialog"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) onClose();
+      }}
+      ref={dialogRef}
+    >
+      {asset ? (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            const fd = new FormData(event.currentTarget);
+            onSave(
+              {
+                altEn: String(fd.get("altEn") ?? ""),
+                altVi: String(fd.get("altVi") ?? ""),
+                title: String(fd.get("title") ?? ""),
+              },
+              onClose,
+            );
+          }}
+        >
+          <h3 className="admin-dialog__title">Edit image details</h3>
+          <code className="admin-dialog__path">{asset.path}</code>
+
+          <label className="admin-field">
+            <span>Title</span>
+            <input defaultValue={asset.title} key={`t-${asset.path}`} name="title" required type="text" />
+          </label>
+          <label className="admin-field">
+            <span>Alt text (English)</span>
+            <input defaultValue={asset.altEn} key={`en-${asset.path}`} name="altEn" type="text" />
+          </label>
+          <label className="admin-field">
+            <span>Alt text (Vietnamese)</span>
+            <input defaultValue={asset.altVi} key={`vi-${asset.path}`} name="altVi" type="text" />
+          </label>
+
+          <div className="admin-dialog__actions">
+            <button onClick={onClose} type="button">
+              Cancel
+            </button>
+            <button type="submit">Save</button>
+          </div>
+        </form>
+      ) : null}
+    </dialog>
+  );
+}
+
+function MediaLightbox({
+  asset,
+  onClose,
+  onCopy,
+  onEdit,
+  onRemove,
+}: {
+  asset: MediaAsset | null;
+  onClose: () => void;
+  onCopy: () => void;
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (asset && !dialog.open) dialog.showModal();
+    else if (!asset && dialog.open) dialog.close();
+  }, [asset]);
+
+  return (
+    <dialog
+      aria-label={asset ? `Preview of ${asset.title}` : "Image preview"}
+      className="admin-dialog admin-lightbox"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) onClose();
+      }}
+      ref={dialogRef}
+    >
+      {asset ? (
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt={asset.altEn || asset.title}
+            className="admin-lightbox__image"
+            src={publicMediaUrl(asset.bucket, asset.path)}
+          />
+          <div className="admin-lightbox__meta">
+            <strong>{asset.title}</strong>
+            <code>{asset.path}</code>
+            <span>
+              {asset.width && asset.height ? `${asset.width}×${asset.height} · ` : ""}
+              {asset.mime?.replace("image/", "") ?? "?"}
+            </span>
+          </div>
+          <div className="admin-dialog__actions">
+            <button onClick={onCopy} type="button">
+              Copy URL
+            </button>
+            <button onClick={onEdit} type="button">
+              Edit details
+            </button>
+            <button
+              className="admin-link-button--danger"
+              onClick={onRemove}
+              type="button"
+            >
+              Delete
+            </button>
+            <button onClick={onClose} type="button">
+              Close
+            </button>
+          </div>
+        </>
+      ) : null}
+    </dialog>
+  );
+}

--- a/src/app/admin/(dashboard)/media/media-picker-modal.tsx
+++ b/src/app/admin/(dashboard)/media/media-picker-modal.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { MediaBucket } from "@/features/cms/media";
+import type { ListMediaAssetsResult } from "@/features/cms/media-catalog";
+import { publicMediaUrl } from "@/features/cms/media-url";
+import { fetchMediaBatch } from "@/features/cms/media-library-actions";
+import { MediaLibraryGrid } from "./media-library-grid";
+import { MediaUploadPanel } from "./media-upload-panel";
+
+interface MediaPickerModalProps {
+  bucket: MediaBucket;
+  onClose: () => void;
+  /** Receives the stored path + a ready-to-use public URL for the pick. */
+  onSelect: (asset: { path: string; url: string; altEn: string; altVi: string }) => void;
+  open: boolean;
+}
+
+const BUCKET_TITLES: Record<MediaBucket, string> = {
+  "blog-media": "Blog media",
+  "portfolio": "Portfolio",
+  "project-media": "Project media",
+  "resume-media": "Resume media",
+};
+
+/**
+ * WordPress-style media library modal (#102): browse one bucket as an
+ * infinite-scroll grid or upload straight into it, then hand the chosen
+ * asset back to the caller. Native <dialog> keeps focus inside while open;
+ * browsers restore focus to the invoker on close.
+ */
+export function MediaPickerModal({
+  bucket,
+  onClose,
+  onSelect,
+  open,
+}: Readonly<MediaPickerModalProps>) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const [tab, setTab] = useState<"library" | "upload">("library");
+  const [initial, setInitial] = useState<ListMediaAssetsResult | null>(null);
+
+  const loadFirst = useCallback(() => {
+    fetchMediaBatch(bucket)
+      .then(setInitial)
+      .catch(() => setInitial({ items: [] }));
+  }, [bucket]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      setTab("library");
+      loadFirst();
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open, loadFirst]);
+
+  return (
+    <dialog
+      aria-label={`${BUCKET_TITLES[bucket]} library`}
+      className="admin-dialog admin-dialog--wide"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) onClose();
+      }}
+      onClose={onClose}
+      ref={dialogRef}
+    >
+      <header className="admin-picker__head">
+        <h3 className="admin-dialog__title">{BUCKET_TITLES[bucket]} library</h3>
+        <div aria-label="Library tabs" className="admin-picker__tabs" role="tablist">
+          <button
+            aria-selected={tab === "library"}
+            onClick={() => setTab("library")}
+            role="tab"
+            type="button"
+          >
+            Library
+          </button>
+          <button
+            aria-selected={tab === "upload"}
+            onClick={() => setTab("upload")}
+            role="tab"
+            type="button"
+          >
+            Upload new
+          </button>
+        </div>
+        <button
+          aria-label="Close media library"
+          className="admin-link-button"
+          onClick={onClose}
+          type="button"
+        >
+          Close
+        </button>
+      </header>
+
+      {tab === "library" ? (
+        initial ? (
+          <div className="admin-picker__body">
+            <MediaLibraryGrid
+              bucket={bucket}
+              initial={initial}
+              key={`${bucket}:${initial.items[0]?.path ?? "empty"}`}
+              mode="cursor"
+              onPick={(asset) =>
+                onSelect({
+                  altEn: asset.altEn,
+                  altVi: asset.altVi,
+                  path: asset.path,
+                  url: publicMediaUrl(asset.bucket, asset.path),
+                })
+              }
+            />
+          </div>
+        ) : (
+          <p className="admin-message">Loading library…</p>
+        )
+      ) : (
+        <div className="admin-picker__body">
+          <MediaUploadPanel bucket={bucket} onUploaded={loadFirst} />
+          <p className="admin-note">
+            Uploaded images land in this bucket&apos;s library — switch to the
+            Library tab to use them.
+          </p>
+        </div>
+      )}
+    </dialog>
+  );
+}

--- a/src/app/admin/(dashboard)/media/media-upload-panel.tsx
+++ b/src/app/admin/(dashboard)/media/media-upload-panel.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { MediaBucket } from "@/features/cms/media";
+import { uploadMedia, type MediaUploadMeta } from "@/features/cms/media-actions";
+
+interface MediaUploadPanelProps {
+  bucket: MediaBucket;
+  /** Called after a successful upload with the stored path (modal flow). */
+  onUploaded?: () => void;
+}
+
+/**
+ * Upload form for one bucket (#102). Used inline on /admin/media and as the
+ * Upload tab inside the picker modal. Metadata fields are optional; the
+ * catalog derives a default title from the filename when left blank.
+ */
+export function MediaUploadPanel({ bucket, onUploaded }: MediaUploadPanelProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fd = new FormData(event.currentTarget);
+    const file = fd.get("file");
+    if (!(file instanceof File) || file.size === 0) {
+      setError("Choose a file to upload.");
+      return;
+    }
+
+    const meta: MediaUploadMeta = {
+      altEn: String(fd.get("altEn") ?? ""),
+      altVi: String(fd.get("altVi") ?? ""),
+      title: String(fd.get("title") ?? ""),
+    };
+
+    setError(null);
+    startTransition(async () => {
+      const result = await uploadMedia(bucket, file, meta);
+      if (result.ok) {
+        formRef.current?.reset();
+        onUploaded?.();
+        router.refresh();
+        if (result.warning) setError(result.warning);
+      } else {
+        setError(result.error ?? "Upload failed.");
+      }
+    });
+  }
+
+  return (
+    <form
+      aria-live="polite"
+      className="admin-form admin-form--row admin-upload-panel"
+      onSubmit={onSubmit}
+      ref={formRef}
+    >
+      <label className="admin-field">
+        <span>Image (JPEG/PNG/WebP, max 10 MB)</span>
+        <input accept="image/jpeg,image/png,image/webp" name="file" type="file" />
+      </label>
+      <label className="admin-field">
+        <span>Title (optional)</span>
+        <input name="title" type="text" />
+      </label>
+      <label className="admin-field">
+        <span>Alt text EN (optional)</span>
+        <input name="altEn" type="text" />
+      </label>
+      <label className="admin-field">
+        <span>Alt text VI (optional)</span>
+        <input name="altVi" type="text" />
+      </label>
+
+      {error ? (
+        <p className="admin-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <button disabled={isPending} type="submit">
+        {isPending ? "Uploading…" : "Upload"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/media/page.tsx
+++ b/src/app/admin/(dashboard)/media/page.tsx
@@ -1,135 +1,85 @@
-import { listMediaAssetsCore } from "@/features/cms/media-library";
+import Link from "next/link";
+
 import type { MediaBucket } from "@/features/cms/media";
-import { getServerClient } from "@/features/cms/session";
-import { MediaUploadForm } from "./media-upload-form";
+import { fetchMediaPage } from "@/features/cms/media-library-actions";
 import { AdminPage } from "../admin-page";
-import { BulkDeleteBar, BulkSelectionProvider } from "@/features/cms/delete-actions";
-import { MediaGrid } from "./media-grid";
+import { MediaLibraryGrid } from "./media-library-grid";
+import { MediaUploadPanel } from "./media-upload-panel";
 
 export const metadata = {
   title: "Admin media",
 };
 
-const buckets: Array<{ id: MediaBucket; label: string; note: string }> = [
-  { id: "resume-media", label: "Resume media (private)", note: "Served only through the gated /api/resume-media route." },
-  { id: "project-media", label: "Project media (public)", note: "Public project images." },
-  { id: "blog-media", label: "Blog media (public)", note: "Public post covers and in-article images." },
-  { id: "portfolio", label: "Portfolio (public)", note: "Profile / social images." },
+const BUCKETS: Array<{ id: MediaBucket; label: string; note: string }> = [
+  { id: "blog-media", label: "Blog media", note: "Post covers and in-article images (public)." },
+  { id: "project-media", label: "Project media", note: "Public project images." },
+  { id: "resume-media", label: "Resume media", note: "Private; served only through the gated /api/resume-media route." },
+  { id: "portfolio", label: "Portfolio", note: "Profile and social images (public)." },
 ];
 
-const PAGE_SIZE = 12;
-
-interface AdminMediaPageProps {
-  searchParams: Promise<{
-    bucket?: string;
-    page?: string;
-    q?: string;
-  }>;
+function firstParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
 }
 
+interface AdminMediaPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+/**
+ * Full-page media manager (#102): bucket tabs + paginated, searchable grid.
+ * The same MediaLibraryGrid engine powers the in-editor picker modal with
+ * infinite scroll; this surface deep-links via searchParams instead.
+ */
 export default async function AdminMediaPage({
   searchParams,
 }: Readonly<AdminMediaPageProps>) {
   const params = await searchParams;
-  const activeBucket = (buckets.find((b) => b.id === params.bucket) ?? buckets[0]!).id;
-  const page = Math.max(1, Number(params.page) || 1);
-  const search = params.q?.trim() ?? "";
+  const requested = firstParam(params.bucket) as MediaBucket | undefined;
+  const active = BUCKETS.some((b) => b.id === requested) ? requested! : "blog-media";
+  const query = firstParam(params.q)?.trim() ?? "";
+  const pageNumberRaw = Number(firstParam(params.page) ?? "1");
+  const pageNumber =
+    Number.isInteger(pageNumberRaw) && pageNumberRaw > 1 ? pageNumberRaw : 1;
 
-  const client = await getServerClient();
-  const result = await listMediaAssetsCore(client, {
-    mode: "page",
-    bucket: activeBucket,
-    search: search || undefined,
-    page,
-    pageSize: PAGE_SIZE,
-  });
-  const { items } = result;
-  const total = result.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const pageItems = items.map((item) => ({ id: item.path, label: item.title || item.path }));
+  const initial = await fetchMediaPage(active, pageNumber, query || undefined, 12);
 
   return (
-    <AdminPage title="Media">
+    <AdminPage action={<Link className="admin-link-button" href="/admin">Dashboard</Link>} title="Media">
       <p className="admin-message">
-        Upload and manage images stored in Supabase Storage. Resume media is
-        private and served only through the gated route; project and portfolio
-        media are public.
+        One library per bucket. Pick images from here or straight inside the
+        editors; every image carries a title plus English/Vietnamese alt text
+        used across the public site.
       </p>
 
-      <div className="admin-tabs" role="tablist" aria-label="Media bucket">
-        {buckets.map((bucket) => {
-          const active = bucket.id === activeBucket;
-          return (
-            <a
-              aria-selected={active}
-              className={active ? "admin-tab admin-tab--active" : "admin-tab"}
-              href={`/admin/media?bucket=${bucket.id}`}
-              key={bucket.id}
-              role="tab"
-            >
-              {bucket.label}
-            </a>
-          );
-        })}
-      </div>
+      <nav aria-label="Media buckets" className="admin-tabs">
+        {BUCKETS.map((bucket) => (
+          <Link
+            aria-current={bucket.id === active ? "page" : undefined}
+            className={
+              bucket.id === active ? "admin-tab admin-tab--active" : "admin-tab"
+            }
+            href={`?bucket=${bucket.id}`}
+            key={bucket.id}
+          >
+            {bucket.label}
+          </Link>
+        ))}
+      </nav>
+      <p className="admin-note">{BUCKETS.find((b) => b.id === active)?.note}</p>
+
+      <MediaLibraryGrid
+        bucket={active}
+        initial={initial}
+        initialQuery={query}
+        key={`${active}:${query}:${pageNumber}`}
+        mode="page"
+        pageNumber={pageNumber}
+      />
 
       <section className="admin-section">
-        <div className="admin-page-head">
-          <h2>{buckets.find((b) => b.id === activeBucket)?.label}</h2>
-        </div>
-        <p className="admin-note">{buckets.find((b) => b.id === activeBucket)?.note}</p>
-
-        <MediaUploadForm bucket={activeBucket} />
-
-        <form className="admin-form admin-form--row" method="get" action="/admin/media">
-          <input
-            aria-label="Search media"
-            defaultValue={search}
-            name="q"
-            placeholder="Search by filename or title…"
-            type="search"
-          />
-          <input name="bucket" type="hidden" value={activeBucket} />
-          <button className="admin-button-secondary" type="submit">
-            Search
-          </button>
-        </form>
-
-        <BulkSelectionProvider>
-          <BulkDeleteBar bucket={activeBucket} entity="media" items={pageItems} noun="file" />
-
-          {items.length === 0 ? (
-            <p className="admin-message">
-              {search ? "No files match your search." : "No files uploaded yet."}
-            </p>
-          ) : (
-            <MediaGrid bucket={activeBucket} items={items} />
-          )}
-
-          {totalPages > 1 ? (
-            <nav className="admin-pagination" aria-label="Media pages">
-              {page > 1 ? (
-                <a
-                  className="admin-button-secondary"
-                  href={`/admin/media?bucket=${activeBucket}&page=${page - 1}${search ? `&q=${encodeURIComponent(search)}` : ""}`}
-                >
-                  ← Previous
-                </a>
-              ) : null}
-              <span className="admin-pagination__info">
-                Page {page} of {totalPages}
-              </span>
-              {page < totalPages ? (
-                <a
-                  className="admin-button-secondary"
-                  href={`/admin/media?bucket=${activeBucket}&page=${page + 1}${search ? `&q=${encodeURIComponent(search)}` : ""}`}
-                >
-                  Next →
-                </a>
-              ) : null}
-            </nav>
-          ) : null}
-        </BulkSelectionProvider>
+        <h2>Upload to {BUCKETS.find((b) => b.id === active)?.label}</h2>
+        <MediaUploadPanel bucket={active} />
       </section>
     </AdminPage>
   );

--- a/src/features/cms/media-actions.ts
+++ b/src/features/cms/media-actions.ts
@@ -11,6 +11,7 @@ import type { MediaBucket } from "./media";
 export interface MediaUploadResult {
   ok: boolean;
   error?: string;
+  warning?: string;
   path?: string;
   publicUrl?: string;
 }
@@ -62,10 +63,28 @@ function titleFromFilename(filename: string): string {
  * #18 design where admin/browser writes use the owner RLS path. Dimensions are
  * parsed from the file header (PNG/JPEG/WebP) so the catalog carries real
  * width/height for layout without layout shift.
+ *
+ * Supports both the new object signature `uploadMedia({bucket,file,title,altEn,altVi})`
+ * and the legacy `uploadMedia(bucket,file,meta)` used by demo/21bec74's
+ * MediaLibraryGrid/MediaUploadPanel for backwards compatibility.
  */
 export async function uploadMedia(
-  input: MediaUploadInput,
+  bucketOrInput: MediaBucket | MediaUploadInput,
+  file?: File,
+  meta?: MediaUploadMeta,
 ): Promise<MediaUploadResult> {
+  const input: MediaUploadInput =
+    typeof bucketOrInput === "string"
+      ? {
+          bucket: bucketOrInput as MediaBucket,
+          file: file as File,
+          title: meta?.title,
+          altEn: meta?.altEn,
+          altVi: meta?.altVi,
+        }
+      : (bucketOrInput as MediaUploadInput);
+
+  if (!input.file) return { ok: false, error: "No file provided." };
   if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
 
   if (!isAllowedMime(input.file.type)) {
@@ -188,6 +207,38 @@ export async function getMediaAsset(
     updatedAt: row.updated_at,
     url: getMediaUrl(row.bucket, row.path),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility for demo/21bec74's MediaLibraryGrid (old API) — keep while
+// both the new MediaPickerModal (new API) and the demo grid (old API) coexist.
+// ---------------------------------------------------------------------------
+
+export interface MediaUploadMeta {
+  title: string;
+  altEn: string;
+  altVi: string;
+}
+
+export async function deleteMedia(
+  bucket: MediaBucket,
+  path: string,
+): Promise<MediaUpdateResult> {
+  if (!(await isAdminUser())) return { ok: false, error: "Unauthorized." };
+  const client = await getServerClient();
+  const { error } = await client.storage.from(bucket).remove([path]);
+  if (error) return { ok: false, error: error.message };
+  await client.from("media_assets").delete().eq("bucket", bucket).eq("path", path);
+  revalidatePath("/admin/media");
+  return { ok: true };
+}
+
+export async function updateMediaDetails(
+  bucket: MediaBucket,
+  path: string,
+  meta: MediaUploadMeta,
+): Promise<MediaUpdateResult> {
+  return updateMediaAsset({ bucket, path, title: meta.title, altEn: meta.altEn, altVi: meta.altVi });
 }
 
 /**

--- a/src/features/cms/media-catalog.test.ts
+++ b/src/features/cms/media-catalog.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Local-only guard, same pattern as repository.test.ts: this suite writes CMS
+// data and MUST never touch a cloud project.
+if (!url || !serviceRole) {
+  console.error(
+    "Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (local Supabase).",
+  );
+  process.exit(1);
+}
+
+const LOCAL_HOST = /^http:\/\/127\.0\.0\.1(?::\d+)?$/;
+if (!LOCAL_HOST.test(url)) {
+  console.error(`Refusing to run catalog tests against non-local Supabase: ${url}`);
+  process.exit(1);
+}
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  deleteMediaAsset,
+  getCoverAltTexts,
+  listMediaAssets,
+  updateMediaAssetMeta,
+  upsertMediaAsset,
+} from "./media-catalog";
+
+const client = createClient(url, serviceRole, {
+  auth: { persistSession: false },
+});
+
+const BUCKET = "blog-media";
+const FIXTURES = [
+  { altEn: "", altVi: "", createdAt: "2026-01-01T00:00:00Z", path: "cat-a.png", title: "Alpha" },
+  { altEn: "Bravo en", altVi: "", createdAt: "2026-01-02T00:00:00Z", path: "bravo.jpg", title: "Bravo photo" },
+  { altEn: "", altVi: "Charlie vi", createdAt: "2026-01-03T00:00:00Z", path: "cat-b.webp", title: "Charlie" },
+  { altEn: "", altVi: "", createdAt: "2026-01-04T00:00:00Z", path: "delta.png", title: "Delta diagram" },
+];
+
+async function seedFixtures() {
+  const { error } = await client
+    .from("media_assets")
+    .upsert(
+      FIXTURES.map((f) => ({
+        alt_en: f.altEn,
+        alt_vi: f.altVi,
+        bucket: BUCKET,
+        created_at: f.createdAt,
+        height: 100,
+        mime: "image/png",
+        path: f.path,
+        size_bytes: 1024,
+        title: f.title,
+        width: 200,
+      })),
+      { onConflict: "bucket,path" },
+    );
+  if (error) throw error;
+}
+
+async function cleanupFixtures() {
+  await client.from("media_assets").delete().eq("bucket", BUCKET)
+    .in("path", FIXTURES.map((f) => f.path));
+}
+
+before(seedFixtures);
+after(cleanupFixtures);
+
+test("page mode paginates newest-first with totals", async () => {
+  const page1 = await listMediaAssets(client, {
+    bucket: BUCKET,
+    limit: 2,
+    page: { mode: "page", page: 1 },
+  });
+  assert.deepEqual(page1.items.map((i) => i.path), ["delta.png", "cat-b.webp"]);
+  assert.equal(page1.total, FIXTURES.length);
+  assert.equal(page1.totalPages, 2);
+
+  const page2 = await listMediaAssets(client, {
+    bucket: BUCKET,
+    limit: 2,
+    page: { mode: "page", page: 2 },
+  });
+  assert.deepEqual(page2.items.map((i) => i.path), ["bravo.jpg", "cat-a.png"]);
+});
+
+test("cursor mode walks the whole library without gaps or duplicates", async () => {
+  const seen = [];
+  let cursor;
+  for (let guard = 0; guard < 10; guard += 1) {
+    const result = await listMediaAssets(client, {
+      bucket: BUCKET,
+      cursor,
+      limit: 2,
+    });
+    seen.push(...result.items.map((i) => i.path));
+    if (!result.nextCursor || result.items.length === 0) break;
+    cursor = result.nextCursor;
+  }
+  assert.deepEqual(seen, ["delta.png", "cat-b.webp", "bravo.jpg", "cat-a.png"]);
+});
+
+test("search matches titles and paths case-insensitively", async () => {
+  const byTitle = await listMediaAssets(client, { bucket: BUCKET, query: "bravo" });
+  assert.deepEqual(byTitle.items.map((i) => i.path), ["bravo.jpg"]);
+
+  const byPath = await listMediaAssets(client, { bucket: BUCKET, query: ".webp" });
+  assert.deepEqual(byPath.items.map((i) => i.path), ["cat-b.webp"]);
+});
+
+test("search input cannot inject LIKE wildcards", async () => {
+  const wildcarded = await listMediaAssets(client, { bucket: BUCKET, query: "%a%" });
+  // Literal % matches nothing; without escaping this would match every row.
+  assert.deepEqual(wildcarded.items.map((i) => i.path), []);
+});
+
+test("upsert derives a readable default title when none given", async () => {
+  await upsertMediaAsset(client, {
+    bucket: BUCKET,
+    mime: "image/png",
+    path: "1730000000000-my-neat-cover.png",
+  });
+
+  try {
+    const found = await listMediaAssets(client, {
+      bucket: BUCKET,
+      limit: 10,
+      query: "my-neat-cover",
+    });
+    assert.equal(found.items.length, 1);
+    assert.equal(found.items[0]?.title, "my neat cover");
+  } finally {
+    await deleteMediaAsset(client, BUCKET, "1730000000000-my-neat-cover.png");
+  }
+});
+
+test("metadata updates persist and map back to camelCase", async () => {
+  const updated = await updateMediaAssetMeta(client, BUCKET, "bravo.jpg", {
+    altEn: "Updated alt",
+    altVi: "Alt tiếng Việt",
+    title: "Renamed asset",
+  });
+  assert.ok(updated);
+  assert.equal(updated?.altEn, "Updated alt");
+  assert.equal(updated?.altVi, "Alt tiếng Việt");
+  assert.equal(updated?.title, "Renamed asset");
+});
+
+test("cover alt lookup batches by path", async () => {
+  const alts = await getCoverAltTexts(client, BUCKET, ["bravo.jpg", "missing.png"]);
+  assert.equal(alts.get("bravo.jpg")?.altEn, "Updated alt");
+  assert.equal(alts.has("missing.png"), false);
+});

--- a/src/features/cms/media-catalog.ts
+++ b/src/features/cms/media-catalog.ts
@@ -1,0 +1,253 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { MediaBucket } from "./media";
+
+/**
+ * Admin catalog over Storage objects (#102). The rows live in public.media_assets
+ * and power listing/search/pagination for the media library surfaces; the
+ * bytes stay in Storage and are addressed by (bucket, path).
+ *
+ * Query functions take the client as a parameter so tests can drive them with
+ * a service-role client against local Supabase; production callers pass the
+ * owner-session client from features/cms/session.
+ */
+
+export interface MediaAsset {
+  bucket: MediaBucket;
+  path: string;
+  title: string;
+  altEn: string;
+  altVi: string;
+  width: number | null;
+  height: number | null;
+  sizeBytes: number | null;
+  mime: string | null;
+  createdAt: string;
+}
+
+export interface MediaAssetRow {
+  bucket: string;
+  path: string;
+  title: string;
+  alt_en: string;
+  alt_vi: string;
+  width: number | null;
+  height: number | null;
+  size_bytes: number | null;
+  mime: string | null;
+  created_at: string;
+}
+
+export interface PageQuery {
+  mode: "page";
+  page: number;
+}
+
+export interface CursorQuery {
+  mode: "cursor";
+  /** Keyset position: everything strictly older than this pair. */
+  createdAt: string;
+  path: string;
+}
+
+export interface ListMediaAssetsParams {
+  bucket: MediaBucket;
+  cursor?: CursorQuery;
+  limit?: number;
+  query?: string;
+  page?: PageQuery;
+}
+
+export interface ListMediaAssetsResult {
+  items: MediaAsset[];
+  /** Cursor to pass back for the next batch (cursor mode only). */
+  nextCursor?: CursorQuery;
+  /** Totals for pagination UI (page mode only). */
+  total?: number;
+  totalPages?: number;
+}
+
+/** Escape LIKE wildcards so search input cannot broaden the match. */
+export function escapeLike(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}
+
+function mapRow(row: MediaAssetRow): MediaAsset {
+  return {
+    altEn: row.alt_en,
+    altVi: row.alt_vi,
+    bucket: row.bucket as MediaBucket,
+    createdAt: row.created_at,
+    height: row.height,
+    mime: row.mime,
+    path: row.path,
+    sizeBytes: row.size_bytes,
+    title: row.title,
+    width: row.width,
+  };
+}
+
+function titleFromPath(path: string): string {
+  return path
+    .replace(/\.[^.]+$/, "")
+    .replace(/^\d+-/, "")
+    .replace(/[-_]+/g, " ")
+    .trim();
+}
+
+export async function upsertMediaAsset(
+  client: SupabaseClient,
+  asset: {
+    altEn?: string;
+    altVi?: string;
+    bucket: MediaBucket;
+    height?: number | null;
+    mime?: string | null;
+    path: string;
+    sizeBytes?: number | null;
+    title?: string;
+    width?: number | null;
+  },
+): Promise<void> {
+  const { error } = await client.from("media_assets").upsert(
+    {
+      alt_en: asset.altEn ?? "",
+      alt_vi: asset.altVi ?? "",
+      bucket: asset.bucket,
+      height: asset.height ?? null,
+      mime: asset.mime ?? null,
+      path: asset.path,
+      size_bytes: asset.sizeBytes ?? null,
+      title: asset.title?.trim() || titleFromPath(asset.path),
+      width: asset.width ?? null,
+    },
+    { onConflict: "bucket,path" },
+  );
+  if (error) throw new Error(`Catalog write failed: ${error.message}`);
+}
+
+export async function deleteMediaAsset(
+  client: SupabaseClient,
+  bucket: MediaBucket,
+  path: string,
+): Promise<void> {
+  const { error } = await client
+    .from("media_assets")
+    .delete()
+    .eq("bucket", bucket)
+    .eq("path", path);
+  if (error) throw new Error(`Catalog delete failed: ${error.message}`);
+}
+
+export async function updateMediaAssetMeta(
+  client: SupabaseClient,
+  bucket: MediaBucket,
+  path: string,
+  meta: { altEn?: string; altVi?: string; title?: string },
+): Promise<MediaAsset | null> {
+  const patch: Record<string, string> = { updated_at: new Date().toISOString() };
+  if (meta.title !== undefined) patch.title = meta.title.trim();
+  if (meta.altEn !== undefined) patch.alt_en = meta.altEn;
+  if (meta.altVi !== undefined) patch.alt_vi = meta.altVi;
+
+  const { data, error } = await client
+    .from("media_assets")
+    .update(patch)
+    .eq("bucket", bucket)
+    .eq("path", path)
+    .select("*")
+    .maybeSingle();
+  if (error) throw new Error(`Catalog update failed: ${error.message}`);
+  return data ? mapRow(data as MediaAssetRow) : null;
+}
+
+export async function listMediaAssets(
+  client: SupabaseClient,
+  params: ListMediaAssetsParams,
+): Promise<ListMediaAssetsResult> {
+  const limit = Math.min(Math.max(params.limit ?? 24, 1), 100);
+
+  let request = client
+    .from("media_assets")
+    .select("*", params.page ? { count: "exact" } : undefined)
+    .eq("bucket", params.bucket);
+
+  if (params.query) {
+    const safe = escapeLike(params.query.trim());
+    if (safe) {
+      request = request.or(`title.ilike.%${safe}%,path.ilike.%${safe}%`);
+    }
+  }
+
+  request =
+    params.cursor && !params.page
+      ? request.or(
+          `created_at.lt.${params.cursor.createdAt},and(created_at.eq.${params.cursor.createdAt},path.lt.${params.cursor.path})`,
+        )
+      : request;
+
+  if (params.page) {
+    const from = (params.page.page - 1) * limit;
+    request = request.range(from, from + limit - 1);
+  }
+
+  const { data, error, count } = await request
+    .order("created_at", { ascending: false })
+    .order("path", { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(`Catalog list failed: ${error.message}`);
+
+  const items = ((data ?? []) as MediaAssetRow[]).map(mapRow);
+  const last = items[items.length - 1];
+
+  const result: ListMediaAssetsResult = { items };
+
+  if (params.page) {
+    result.total = count ?? 0;
+    result.totalPages = Math.max(1, Math.ceil((count ?? 0) / limit));
+  } else if (last) {
+    // A full page hints there may be more; an empty next probe is avoided by
+    // letting the UI fetch once more and render nothing extra.
+    result.nextCursor = { createdAt: last.createdAt, mode: "cursor", path: last.path };
+  }
+
+  return result;
+}
+
+export interface CoverAltLookup {
+  path: string;
+  altEn: string;
+  altVi: string;
+}
+
+/** Batch alt-text lookup for cover paths (public rendering enrichment). */
+export async function getCoverAltTexts(
+  client: SupabaseClient,
+  bucket: MediaBucket,
+  paths: string[],
+): Promise<Map<string, CoverAltLookup>> {
+  const map = new Map<string, CoverAltLookup>();
+  if (paths.length === 0) return map;
+
+  const { data, error } = await client
+    .from("media_assets")
+    .select("path, alt_en, alt_vi")
+    .eq("bucket", bucket)
+    .in("path", paths);
+
+  if (error || !data) return map;
+
+  for (const row of data as Array<{
+    alt_en: string;
+    alt_vi: string;
+    path: string;
+  }>) {
+    map.set(row.path, {
+      altEn: row.alt_en,
+      altVi: row.alt_vi,
+      path: row.path,
+    });
+  }
+  return map;
+}

--- a/src/features/cms/media-library-actions.ts
+++ b/src/features/cms/media-library-actions.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { getServerClient, isAdminUser } from "./session";
+import {
+  listMediaAssets,
+  type ListMediaAssetsResult,
+} from "./media-catalog";
+import type { MediaBucket } from "./media";
+
+/**
+ * Server actions backing the media library surfaces (#102). Query logic lives
+ * in media-catalog.ts (injectable client, unit-tested); these bind it to the
+ * owner-session client and are callable from both server components and the
+ * library's client components.
+ */
+
+export async function fetchMediaPage(
+  bucket: MediaBucket,
+  page: number,
+  query?: string,
+  limit = 24,
+): Promise<ListMediaAssetsResult> {
+  if (!(await isAdminUser())) return { items: [] };
+  const client = await getServerClient();
+  if (!client) return { items: [] };
+  try {
+    return await listMediaAssets(client, {
+      bucket,
+      limit,
+      page: { mode: "page", page },
+      query,
+    });
+  } catch {
+    return { items: [] };
+  }
+}
+
+export async function fetchMediaBatch(
+  bucket: MediaBucket,
+  cursor?: { createdAt: string; path: string },
+  query?: string,
+  limit = 24,
+): Promise<ListMediaAssetsResult> {
+  if (!(await isAdminUser())) return { items: [] };
+  const client = await getServerClient();
+  if (!client) return { items: [] };
+  try {
+    return await listMediaAssets(client, {
+      bucket,
+      cursor: cursor
+        ? { createdAt: cursor.createdAt, mode: "cursor", path: cursor.path }
+        : undefined,
+      limit,
+      query,
+    });
+  } catch {
+    return { items: [] };
+  }
+}

--- a/src/features/cms/media-url.ts
+++ b/src/features/cms/media-url.ts
@@ -1,0 +1,14 @@
+import type { MediaBucket } from "./media";
+
+/**
+ * Public URL for a stored object. Pure string building so both server
+ * (features/cms/media.ts) and client components can use it without pulling
+ * the server session module into client bundles.
+ */
+export function publicMediaUrl(bucket: MediaBucket, path: string): string {
+  if (bucket === "resume-media") {
+    return `/api/resume-media/${encodeURIComponent(path)}`;
+  }
+  const base = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").replace(/\/$/, "");
+  return `${base}/storage/v1/object/public/${bucket}/${encodeURIComponent(path)}`;
+}


### PR DESCRIPTION
Như bạn yêu cầu lần cuối: giữ **full mới nhất** (hard delete #104, social links #83, single H1, media catalog) và **giao diện media y hệt demo/21bec74-as-was** (PR #103).

- Checkout y hệt 10 files demo: `MediaLibraryGrid` (495 dòng, 12/page, lightbox, Copy URL), `media-catalog.ts`, `media-library-actions.ts`, `media-url.ts`, `media-picker-modal.tsx` (app), `media-upload-panel.tsx`, `media-insert.tsx`, `page.tsx`
- `media-actions.ts` hỗ trợ cả 2 API (mới + demo) để picker mới/cũ đều chạy
- Build: typecheck/lint pass, `npm run build -- --webpack` pass

Thay thế PR #111 (bản adapt trước đó) — bản này là **y hệt** demo, không làm mới.

Closes demo exact restore as requested.