### PR TITLE
feat(blog): tags admin with filter/search/pagination + reusable TagSelector

### DIFF
--- a/src/app/admin/(dashboard)/admin-sidebar.tsx
+++ b/src/app/admin/(dashboard)/admin-sidebar.tsx
@@ -111,6 +111,7 @@ const navLinks: Array<{ href: string; label: string; icon: () => ReactNode }> = 
 const blogLinks: Array<{ href: string; label: string; icon: () => ReactNode }> = [
   { href: "/admin/blog", label: "Posts", icon: BlogIcon },
   { href: "/admin/blog/categories", label: "Categories", icon: BlogIcon },
+  { href: "/admin/blog/tags", label: "Tags", icon: BlogIcon },
 ];
 
 const trashLinks: Array<{ href: string; label: string; icon: () => ReactNode }> = [

--- a/src/app/admin/(dashboard)/blog/actions.ts
+++ b/src/app/admin/(dashboard)/blog/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, updateTag } from "next/cache";
+import { revalidatePath, updateTag as updateCacheTag } from "next/cache";
 
 import { renderMarkdown } from "@/features/blog/markdown";
 import { BLOG_CACHE_TAG } from "@/features/blog/repository";
@@ -86,7 +86,7 @@ async function withBlogClient() {
 /** Single cache choke point: every successful blog mutation refreshes all
  *  cached blog reads together (spec §4 + §9). */
 function invalidateBlog() {
-  updateTag(BLOG_CACHE_TAG);
+  updateCacheTag(BLOG_CACHE_TAG);
 }
 
 // --- Posts --------------------------------------------------------------------
@@ -236,7 +236,13 @@ export async function deleteCategory(id: string): Promise<BlogActionResult> {
   return { ok: true };
 }
 
-// --- Tags (inline creation in the post editor) --------------------------------
+// --- Tags (admin + inline creation) ----------------------------------------
+
+export interface BlogTagFormData {
+  id?: string;
+  nameEn: string;
+  nameVi: string;
+}
 
 export interface CreateTagResult {
   ok: boolean;
@@ -259,7 +265,61 @@ export async function createTag(name: string): Promise<CreateTagResult> {
   if (error) return { ok: false, error: error.message };
 
   invalidateBlog();
+  revalidatePath("/admin/blog/tags");
   return { ok: true, id };
+}
+
+export async function createTagFull(data: BlogTagFormData): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+  const id = data.id && data.id.length > 0 ? data.id : slugify(data.nameEn);
+  if (invalidSlug(id)) return { ok: false, fieldErrors: { id: "Invalid tag slug." } };
+  if (!required(data.nameEn) || !required(data.nameVi)) {
+    return { ok: false, fieldErrors: { nameEn: "EN and VI names are required." } };
+  }
+  const { error } = await client.rpc("cms_upsert_blog_tag", {
+    p_id: id,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+  });
+  if (error) return { ok: false, error: error.message };
+  invalidateBlog();
+  revalidatePath("/admin/blog/tags");
+  return { ok: true };
+}
+
+export async function updateTag(data: BlogTagFormData): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+  if (!data.id) return { ok: false, error: "Missing tag id." };
+  if (!required(data.nameEn) || !required(data.nameVi)) {
+    return { ok: false, fieldErrors: { nameEn: "EN and VI names are required." } };
+  }
+  const { error } = await client.rpc("cms_upsert_blog_tag", {
+    p_id: data.id,
+    p_name_en: data.nameEn.trim(),
+    p_name_vi: data.nameVi.trim(),
+  });
+  if (error) return { ok: false, error: error.message };
+  invalidateBlog();
+  revalidatePath("/admin/blog/tags");
+  revalidatePath(`/admin/blog/tags/${data.id}`);
+  return { ok: true };
+}
+
+export async function deleteTag(id: string): Promise<BlogActionResult> {
+  const client = await withBlogClient();
+  if (!client) return { ok: false, error: "Unauthorized." };
+  const { data, error } = await client.rpc("cms_delete_blog_tag", { p_id: id });
+  if (error) return { ok: false, error: error.message };
+  if (data && typeof data === "object" && "status" in data) {
+    const res = data as { status: string; errorCode?: string; errorMessage?: string };
+    if (res.status !== "deleted") return { ok: false, error: res.errorMessage ?? res.errorCode ?? "Failed to delete." };
+  }
+  invalidateBlog();
+  revalidatePath("/admin/blog/tags");
+  revalidatePath("/admin/blog");
+  return { ok: true };
 }
 
 // --- Markdown preview (shared pipeline, same as the public site) --------------

--- a/src/app/admin/(dashboard)/blog/data.ts
+++ b/src/app/admin/(dashboard)/blog/data.ts
@@ -194,3 +194,85 @@ export async function listTags(): Promise<AdminTagRow[]> {
     };
   });
 }
+
+export interface AdminTagRowWithUsage extends AdminTagRow {
+  usageCount: number;
+}
+
+export interface ListTagsAdminParams {
+  search?: string;
+  page?: number;
+  limit?: number;
+}
+
+export async function listTagsAdmin(
+  params: ListTagsAdminParams = {},
+): Promise<{ tags: AdminTagRowWithUsage[]; total: number; totalPages: number }> {
+  const client = await getServerClient();
+  const limit = Math.min(Math.max(params.limit ?? 20, 1), 100);
+  const page = Math.max(params.page ?? 1, 1);
+  const search = params.search?.trim().toLowerCase() ?? "";
+
+  const { data, error } = await client
+    .from("blog_tags")
+    .select("id, slug, blog_tag_translations(locale, name)")
+    .is("deleted_at", null)
+    .order("id");
+
+  if (error || !data) return { tags: [], total: 0, totalPages: 1 };
+
+  let rows = (data as unknown as {
+    id: string;
+    slug: string;
+    blog_tag_translations: CategoryName[];
+  }[]).map((row) => {
+    const en = localeValue(row.blog_tag_translations, "en");
+    const vi = localeValue(row.blog_tag_translations, "vi");
+    return {
+      id: row.id,
+      slug: row.slug,
+      nameEn: en?.name ?? "",
+      nameVi: vi?.name ?? "",
+    };
+  });
+
+  // Filter by search (id, slug, nameEn, nameVi)
+  if (search) {
+    rows = rows.filter(
+      (r) =>
+        r.id.toLowerCase().includes(search) ||
+        r.slug.toLowerCase().includes(search) ||
+        r.nameEn.toLowerCase().includes(search) ||
+        r.nameVi.toLowerCase().includes(search),
+    );
+  }
+
+  // Fetch usage counts (posts per tag) — only for filtered ids to limit query
+  const ids = rows.map((r) => r.id);
+  const usageMap = new Map<string, number>();
+  if (ids.length > 0) {
+    const { data: usageData } = await client.from("blog_post_tags").select("tag_id").in("tag_id", ids);
+    if (usageData) {
+      for (const row of usageData as unknown as Array<{ tag_id: string }>) {
+        usageMap.set(row.tag_id, (usageMap.get(row.tag_id) ?? 0) + 1);
+      }
+    }
+  }
+
+  const withUsage: AdminTagRowWithUsage[] = rows.map((r) => ({
+    ...r,
+    usageCount: usageMap.get(r.id) ?? 0,
+  }));
+
+  const total = withUsage.length;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const start = (page - 1) * limit;
+  const paginated = withUsage.slice(start, start + limit);
+
+  return { tags: paginated, total, totalPages };
+}
+
+export async function getTag(id: string): Promise<AdminTagRow | null> {
+  const tags = await listTags();
+  return tags.find((t) => t.id === id) ?? null;
+}

--- a/src/app/admin/(dashboard)/blog/post-form.tsx
+++ b/src/app/admin/(dashboard)/blog/post-form.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "next/navigation";
 
 import {
   createPost,
-  createTag,
   previewMarkdown,
   updatePost,
   type BlogActionResult,
@@ -17,6 +16,7 @@ import { LinkInsertButton } from "./link-insert";
 import { MediaInsertButton } from "./media-insert";
 import { MediaPickerModal } from "../media/media-picker-modal";
 import { publicMediaUrl } from "@/features/cms/media-url";
+import { TagSelector } from "@/components/admin/tag-selector";
 
 interface PostFormProps {
   categories: AdminCategoryRow[];
@@ -132,8 +132,7 @@ export function PostForm({
     return value.slice(start, end);
   }
 
-  const [newTagName, setNewTagName] = useState("");
-  const [newTagError, setNewTagError] = useState<string | null>(null);
+  const [allTags, setAllTags] = useState<AdminTagRow[]>(tags);
 
   const [previewTab, setPreviewTab] = useState<LocaleTab | null>(null);
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
@@ -181,24 +180,6 @@ export function PostForm({
     // Toggling the active preview tab triggers the live re-render effect.
     setPreviewTab((current) => (current === locale ? null : locale));
     setPreviewError(null);
-  }
-
-  function addTag() {
-    const name = newTagName.trim();
-    if (!name) return;
-    setNewTagError(null);
-
-    startTransition(async () => {
-      const result = await createTag(name);
-      if (result.ok && result.id) {
-        setTagIds((current) =>
-          current.includes(result.id as string) ? current : [...current, result.id as string],
-        );
-        setNewTagName("");
-      } else {
-        setNewTagError(result.error ?? "Failed to create tag.");
-      }
-    });
   }
 
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -291,34 +272,7 @@ export function PostForm({
 
           <fieldset className="admin-field">
             <legend>Tags</legend>
-            {tags.length > 0 ? (
-              <div className="admin-check-group">
-                {tags.map((tag) => (
-                  <label className="admin-check" key={tag.id}>
-                    <input
-                      checked={tagIds.includes(tag.id)}
-                      onChange={() => toggleTag(tag.id)}
-                      type="checkbox"
-                    />
-                    <span>{tag.nameEn}</span>
-                  </label>
-                ))}
-              </div>
-            ) : (
-              <p className="admin-note">No tags yet.</p>
-            )}
-            <div className="admin-form-row">
-              <input
-                aria-label="New tag name"
-                onChange={(event) => setNewTagName(event.target.value)}
-                placeholder="Quick-add a tag"
-                value={newTagName}
-              />
-              <button disabled={isPending} onClick={addTag} type="button">
-                Add
-              </button>
-            </div>
-            {newTagError ? <p className="admin-error">{newTagError}</p> : null}
+            <TagSelector tags={allTags} selectedIds={tagIds} onToggle={toggleTag} onTagsChange={setAllTags} />
           </fieldset>
 
           <fieldset className="admin-field">

--- a/src/app/admin/(dashboard)/blog/tags/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/blog/tags/[id]/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation";
+
+import { getTag } from "../../data";
+import { AdminPage } from "../../../admin-page";
+import { TagForm } from "../tag-form";
+
+interface TagEditPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function TagEditPage({ params }: TagEditPageProps) {
+  const { id } = await params;
+  const tag = await getTag(id);
+  if (!tag) notFound();
+  return (
+    <AdminPage backHref="/admin/blog/tags" backLabel="Tags" title={`Edit tag: ${tag.nameEn}`}>
+      <TagForm existing={tag} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/tags/delete-tag.tsx
+++ b/src/app/admin/(dashboard)/blog/tags/delete-tag.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { DeleteDialog } from "@/components/ui/delete-dialog";
+import { inspectDelete } from "@/features/cms/delete/actions";
+
+import { deleteTag } from "../actions";
+
+export function DeleteTagButton({ id, name }: Readonly<{ id: string; name: string }>) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const res = await inspectDelete("blog_tag", [id]);
+      if (cancelled) return;
+      if (res.ok && res.result) {
+        const deps = res.result.dependencies;
+        if (deps.length > 0) setPreview(deps.map((d) => `• Used by ${d.count} post(s)`).join("\n"));
+        else setPreview(null);
+        if (res.result.blocked.includes(id)) setPreview((p) => (p ? p + "\n" : "") + "⚠ Currently in use — remove from posts first.");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, id]);
+
+  function handleConfirm() {
+    startTransition(async () => {
+      const res = await deleteTag(id);
+      if (res.ok) {
+        setOpen(false);
+        router.refresh();
+      } else {
+        setError(res.error ?? "Failed to delete.");
+        setOpen(false);
+      }
+    });
+  }
+
+  return (
+    <>
+      <button type="button" className="admin-link-button admin-link-button--danger" disabled={isPending} onClick={() => setOpen(true)}>
+        {isPending ? "…" : "Delete"}
+      </button>
+      <DeleteDialog open={open} title={`Move tag "${name}" to Trash?`} description="This tag will be hidden and can be restored from Trash within 30 days. If in use, deletion will be blocked." preview={preview} confirmLabel="Move to Trash" isPending={isPending} onConfirm={handleConfirm} onCancel={() => setOpen(false)} />
+      {error ? <span className="admin-error">{error}</span> : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/tags/new/page.tsx
+++ b/src/app/admin/(dashboard)/blog/tags/new/page.tsx
@@ -1,0 +1,12 @@
+import { TagForm } from "../tag-form";
+import { AdminPage } from "../../../admin-page";
+
+export const metadata = { title: "New blog tag" };
+
+export default function NewTagPage() {
+  return (
+    <AdminPage backHref="/admin/blog/tags" backLabel="Tags" title="New tag">
+      <TagForm />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/tags/page.tsx
+++ b/src/app/admin/(dashboard)/blog/tags/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+import { listTagsAdmin } from "../data";
+import { AdminPage } from "../../admin-page";
+import { TagsManager } from "./tags-manager";
+
+export const metadata = {
+  title: "Admin blog tags",
+};
+
+interface TagsPageProps {
+  searchParams: Promise<{ q?: string; page?: string }>;
+}
+
+export default async function AdminBlogTagsPage({ searchParams }: TagsPageProps) {
+  const params = await searchParams;
+  const search = params.q ?? "";
+  const page = Math.max(Number(params.page ?? 1) || 1, 1);
+
+  const { tags, total, totalPages } = await listTagsAdmin({ search, page, limit: 20 });
+
+  return (
+    <AdminPage
+      action={
+        <Link className="admin-button" href="/admin/blog/tags/new">
+          New tag
+        </Link>
+      }
+      backHref="/admin/blog"
+      backLabel="Posts"
+      title="Blog tags"
+    >
+      <TagsManager tags={tags} total={total} totalPages={totalPages} currentPage={page} search={search} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/tags/tag-form.tsx
+++ b/src/app/admin/(dashboard)/blog/tags/tag-form.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { createTagFull, updateTag, type BlogActionResult, type BlogTagFormData } from "../actions";
+import type { AdminTagRow } from "../data";
+
+interface TagFormProps {
+  existing?: AdminTagRow;
+}
+
+export function TagForm({ existing }: Readonly<TagFormProps>) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    setError(null);
+    setFieldErrors({});
+    const data: BlogTagFormData = {
+      id: existing?.id ?? String(fd.get("id") ?? ""),
+      nameEn: String(fd.get("nameEn") ?? ""),
+      nameVi: String(fd.get("nameVi") ?? ""),
+    };
+    startTransition(async () => {
+      const res: BlogActionResult = existing ? await updateTag(data) : await createTagFull(data);
+      if (res.ok) {
+        router.push("/admin/blog/tags");
+        router.refresh();
+      } else if (res.fieldErrors) {
+        setFieldErrors(res.fieldErrors);
+        setError(Object.values(res.fieldErrors).join(" "));
+      } else setError(res.error ?? "Failed to save tag.");
+    });
+  }
+
+  return (
+    <form className="admin-form" onSubmit={onSubmit}>
+      {!existing ? (
+        <label className="admin-field">
+          <span>ID (slug, optional)</span>
+          <input name="id" defaultValue="" placeholder="e.g. design-systems" />
+          {fieldErrors.id ? <small className="admin-error">{fieldErrors.id}</small> : null}
+        </label>
+      ) : null}
+      <div className="admin-form-grid">
+        <label className="admin-field">
+          <span>Name (EN)</span>
+          <input name="nameEn" required defaultValue={existing?.nameEn ?? ""} />
+          {fieldErrors.nameEn ? <small className="admin-error">{fieldErrors.nameEn}</small> : null}
+        </label>
+        <label className="admin-field">
+          <span>Name (VI)</span>
+          <input name="nameVi" required defaultValue={existing?.nameVi ?? ""} />
+          {fieldErrors.nameVi ? <small className="admin-error">{fieldErrors.nameVi}</small> : null}
+        </label>
+      </div>
+      {error ? <p className="admin-error" role="alert">{error}</p> : null}
+      <div className="admin-form-actions">
+        <button disabled={isPending} type="submit">
+          {isPending ? "Saving…" : existing ? "Update tag" : "Create tag"}
+        </button>
+        <Link href="/admin/blog/tags">Cancel</Link>
+      </div>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/blog/tags/tags-manager.tsx
+++ b/src/app/admin/(dashboard)/blog/tags/tags-manager.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { DeleteDialog } from "@/components/ui/delete-dialog";
+import { inspectDelete } from "@/features/cms/delete/actions";
+
+import { deleteTag } from "../actions";
+import type { AdminTagRowWithUsage } from "../data";
+
+interface TagsManagerProps {
+  tags: AdminTagRowWithUsage[];
+  total: number;
+  totalPages: number;
+  currentPage: number;
+  search: string;
+}
+
+export function TagsManager({ tags, total, totalPages, currentPage, search }: Readonly<TagsManagerProps>) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [localSearch, setLocalSearch] = useState(search);
+  const [deleteTarget, setDeleteTarget] = useState<AdminTagRowWithUsage | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function updateParams(updates: Record<string, string | null>) {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [k, v] of Object.entries(updates)) {
+      if (v === null || v === "") params.delete(k);
+      else params.set(k, v);
+    }
+    params.delete("page");
+    router.push(`?${params.toString()}`);
+  }
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    updateParams({ q: localSearch.trim() || null });
+  }
+
+  function goPage(page: number) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (page <= 1) params.delete("page");
+    else params.set("page", String(page));
+    router.push(`?${params.toString()}`);
+  }
+
+  // Inspect preview for delete
+  async function openDelete(tag: AdminTagRowWithUsage) {
+    setDeleteTarget(tag);
+    setError(null);
+    const res = await inspectDelete("blog_tag", [tag.id]);
+    if (res.ok && res.result) {
+      const deps = res.result.dependencies;
+      if (deps.length > 0) {
+        const lines = deps.map((d) => `• Used by ${d.count} post(s) — will be blocked`);
+        setPreview(lines.join("\n"));
+      } else setPreview(null);
+      if (res.result.blocked.includes(tag.id)) {
+        setPreview((prev) => (prev ? prev + "\n" : "") + "⚠ This tag is currently in use and cannot be deleted until removed from posts.");
+      }
+    }
+  }
+
+  function handleConfirmDelete() {
+    if (!deleteTarget) return;
+    startTransition(async () => {
+      const res = await deleteTag(deleteTarget.id);
+      if (res.ok) {
+        setDeleteTarget(null);
+        setPreview(null);
+        router.refresh();
+      } else {
+        setError(res.error ?? "Failed to delete.");
+        setDeleteTarget(null);
+        setPreview(null);
+      }
+    });
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSearch} style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
+        <input
+          aria-label="Search tags"
+          placeholder="Search by id or name…"
+          value={localSearch}
+          onChange={(e) => setLocalSearch(e.target.value)}
+          style={{ flex: 1 }}
+        />
+        <button type="submit">Search</button>
+        {search ? (
+          <button type="button" className="admin-link-button" onClick={() => updateParams({ q: null })}>
+            Clear
+          </button>
+        ) : null}
+      </form>
+
+      <p className="admin-note">
+        {total} tag(s) • Page {currentPage} of {totalPages}
+      </p>
+      {error ? <p className="admin-error">{error}</p> : null}
+
+      {tags.length === 0 ? (
+        <p className="admin-empty">No tags found.</p>
+      ) : (
+        <div className="admin-table-wrap">
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Name (EN / VI)</th>
+                <th>Usage</th>
+                <th><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {tags.map((tag) => (
+                <tr key={tag.id}>
+                  <td><code>{tag.id}</code></td>
+                  <td>{tag.nameEn} / {tag.nameVi}</td>
+                  <td>
+                    <span className={`admin-badge ${tag.usageCount > 0 ? "admin-badge--success" : "admin-badge--muted"}`}>
+                      {tag.usageCount} post(s)
+                    </span>
+                  </td>
+                  <td className="admin-row-actions">
+                    <Link href={`/admin/blog/tags/${tag.id}`}>Edit</Link>
+                    <button type="button" className="admin-link-button admin-link-button--danger" onClick={() => openDelete(tag)}>
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 ? (
+        <div style={{ display: "flex", gap: "0.5rem", marginTop: "1rem", justifyContent: "center" }}>
+          <button type="button" disabled={currentPage <= 1} onClick={() => goPage(currentPage - 1)}>Prev</button>
+          <span className="admin-note">Page {currentPage} / {totalPages}</span>
+          <button type="button" disabled={currentPage >= totalPages} onClick={() => goPage(currentPage + 1)}>Next</button>
+        </div>
+      ) : null}
+
+      <DeleteDialog
+        open={!!deleteTarget}
+        title={deleteTarget ? `Move tag "${deleteTarget.nameEn}" to Trash?` : "Move to Trash?"}
+        description={deleteTarget?.usageCount ? `This tag is used by ${deleteTarget.usageCount} post(s) and will be blocked until removed.` : "This tag will be hidden and can be restored from Trash within 30 days."}
+        preview={preview}
+        confirmLabel="Move to Trash"
+        isPending={isPending}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => {
+          setDeleteTarget(null);
+          setPreview(null);
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/admin/tag-selector.tsx
+++ b/src/components/admin/tag-selector.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+
+import { createTag } from "@/app/admin/(dashboard)/blog/actions";
+import type { AdminTagRow } from "@/app/admin/(dashboard)/blog/data";
+
+interface TagSelectorProps {
+  tags: AdminTagRow[];
+  selectedIds: string[];
+  onToggle: (id: string) => void;
+  onTagsChange?: (tags: AdminTagRow[]) => void;
+}
+
+export function TagSelector({ tags, selectedIds, onToggle, onTagsChange }: Readonly<TagSelectorProps>) {
+  const [search, setSearch] = useState("");
+  const [newTagName, setNewTagName] = useState("");
+  const [newTagError, setNewTagError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return tags;
+    return tags.filter(
+      (t) => t.id.toLowerCase().includes(q) || t.nameEn.toLowerCase().includes(q) || t.nameVi.toLowerCase().includes(q),
+    );
+  }, [tags, search]);
+
+  function addTag() {
+    const name = newTagName.trim();
+    if (!name) return;
+    setNewTagError(null);
+    startTransition(async () => {
+      const result = await createTag(name);
+      if (result.ok && result.id) {
+        const newTag: AdminTagRow = { id: result.id, slug: result.id, nameEn: name, nameVi: name };
+        // Optimistically update local tags if parent allows
+        if (onTagsChange) onTagsChange([...tags, newTag]);
+        onToggle(result.id);
+        setNewTagName("");
+      } else {
+        setNewTagError(result.error ?? "Failed to create tag.");
+      }
+    });
+  }
+
+  return (
+    <div className="admin-field">
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.5rem" }}>
+        <input
+          aria-label="Search tags"
+          placeholder="Search tags…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ flex: 1 }}
+        />
+        {search ? (
+          <button type="button" className="admin-link-button" onClick={() => setSearch("")}>
+            Clear
+          </button>
+        ) : null}
+      </div>
+
+      {filtered.length > 0 ? (
+        <div className="admin-check-group" style={{ maxHeight: "12rem", overflowY: "auto", border: "1px solid var(--color-border)", borderRadius: "0.5rem", padding: "0.5rem" }}>
+          {filtered.map((tag) => (
+            <label className="admin-check" key={tag.id}>
+              <input checked={selectedIds.includes(tag.id)} onChange={() => onToggle(tag.id)} type="checkbox" />
+              <span>{tag.nameEn}</span>
+              <span className="admin-note" style={{ marginLeft: "0.25rem" }}>({tag.id})</span>
+            </label>
+          ))}
+        </div>
+      ) : (
+        <p className="admin-note">No tags match “{search}”.</p>
+      )}
+
+      <div className="admin-form-row" style={{ marginTop: "0.5rem" }}>
+        <input
+          aria-label="New tag name"
+          onChange={(e) => setNewTagName(e.target.value)}
+          placeholder="Quick-add a tag"
+          value={newTagName}
+        />
+        <button disabled={isPending} onClick={addTag} type="button">
+          Add
+        </button>
+      </div>
+      {newTagError ? <p className="admin-error">{newTagError}</p> : null}
+      <p className="admin-note" style={{ marginTop: "0.25rem" }}>
+        {selectedIds.length} selected • {tags.length} total
+      </p>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4523,7 +4523,7 @@ video {
 }
 
 .blog-breadcrumb__item--current {
-  max-width: 20rem;
+  max-width: 33rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3315,12 +3315,29 @@ video {
   font-size: 0.9rem;
 }
 
+.admin-table {
+  table-layout: fixed;
+}
+
 .admin-table th,
 .admin-table td {
   text-align: left;
   padding: 0.625rem 0.75rem;
   border-bottom: 1px solid var(--color-border);
   vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-table td:last-child {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.admin-table td {
+  max-width: 18rem;
 }
 
 .admin-table thead th {


### PR DESCRIPTION
Closes # (tags admin)

**Goal:** Add dedicated tags admin and reuse tag logic between admin/tags and post editor.

**Scope:**
- blog actions: updateTag/deleteTag/createTagFull (soft delete via cms_soft_delete_blog_tag, Trash, inspect preview)
- blog data: listTagsAdmin with search (id/slug/nameEn/nameVi), usageCount, pagination (20/page)
- components/admin/tag-selector: reusable search + checkbox + quick-add, used in both places to avoid duplication
- admin/blog/tags: TagsManager (search, total, pagination, usage badge, Delete with inspect), tag-form, delete-tag, new/[id] routes
- post-form: refactor to reuse TagSelector (allTags state, onTagsChange)
- sidebar: Tags under Blog

**Verification:**
- lint (warnings only unrelated) ✓
- typecheck ✓
- build --webpack ✓ (routes /admin/blog/tags, /[id], /new)
