### PR TITLE
fix: resume media auto-resolve + audit eye (follow-up)

### DIFF
--- a/src/app/admin/(dashboard)/audit/audit-list.tsx
+++ b/src/app/admin/(dashboard)/audit/audit-list.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+
+import type { AuditRow } from "./data";
+
+function EyeIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" height="16" viewBox="0 0 24 24" width="16">
+      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z" stroke="currentColor" strokeWidth="1.7" />
+      <circle cx="12" cy="12" r="3.5" stroke="currentColor" strokeWidth="1.7" />
+    </svg>
+  );
+}
+
+export function AuditList({ rows }: { rows: AuditRow[] }) {
+  const [selected, setSelected] = useState<AuditRow | null>(null);
+
+  if (rows.length === 0) return <p className="admin-message">No audit entries yet.</p>;
+
+  return (
+    <>
+      <div className="admin-table-wrap">
+        <table className="admin-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Actor</th>
+              <th>Operation</th>
+              <th>Entity</th>
+              <th>ID</th>
+              <th style={{ width: "3rem" }}><span className="sr-only">View</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id}>
+                <td>{new Date(row.createdAt).toLocaleString()}</td>
+                <td>{row.actorType === "system" ? "system" : row.actorId?.slice(0, 8) ?? "user"}</td>
+                <td><span className="admin-badge">{row.operation}</span></td>
+                <td>{row.entityType}</td>
+                <td><code style={{ maxWidth: "10rem", display: "inline-block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.entityId}</code></td>
+                <td>
+                  <button type="button" className="admin-link-button" onClick={() => setSelected(row)} aria-label={`View details for ${row.entityId}`}>
+                    <EyeIcon />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {selected ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Audit details for ${selected.entityId}`}
+          style={{ position: "fixed", inset: 0, background: "rgb(0 0 0 / 0.55)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50, padding: "1rem" }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setSelected(null);
+          }}
+        >
+          <div className="admin-dialog" style={{ background: "var(--color-surface)", color: "var(--color-text)", border: "1px solid var(--color-border-strong)", width: "min(32rem, calc(100vw - 2rem))", maxHeight: "80vh", overflowY: "auto", margin: "auto" }} onClick={(e) => e.stopPropagation()}>
+            <h3 className="admin-dialog__title">Audit details</h3>
+            <div style={{ display: "grid", gap: "0.5rem", fontSize: "0.875rem" }}>
+              <div><strong>ID:</strong> <code>{selected.id}</code></div>
+              <div><strong>Time:</strong> {new Date(selected.createdAt).toLocaleString()}</div>
+              <div><strong>Actor:</strong> {selected.actorType} {selected.actorId ? `(${selected.actorId})` : ""}</div>
+              <div><strong>Operation:</strong> <span className="admin-badge">{selected.operation}</span></div>
+              <div><strong>Entity:</strong> {selected.entityType} — <code>{selected.entityId}</code></div>
+              <div><strong>Label:</strong> {selected.entityLabel ?? "—"}</div>
+              <div><strong>Deps:</strong> {selected.dependencyCount}</div>
+              <div><strong>Resolution:</strong> {selected.resolutionType ?? "—"}</div>
+              {selected.snapshot ? (
+                <div>
+                  <strong>Snapshot:</strong>
+                  <pre style={{ background: "var(--color-surface-subtle)", padding: "0.75rem", borderRadius: "0.5rem", overflowX: "auto", fontSize: "0.75rem", marginTop: "0.25rem" }}>
+                    {JSON.stringify(selected.snapshot, null, 2)}
+                  </pre>
+                </div>
+              ) : null}
+            </div>
+            <div className="admin-dialog__actions" style={{ marginTop: "1rem" }}>
+              <button type="button" onClick={() => setSelected(null)}>Close</button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/app/admin/(dashboard)/audit/data.ts
+++ b/src/app/admin/(dashboard)/audit/data.ts
@@ -10,6 +10,7 @@ export interface AuditRow {
   operation: string;
   dependencyCount: number;
   resolutionType: string | null;
+  snapshot: unknown | null;
   createdAt: string;
 }
 
@@ -17,7 +18,7 @@ export async function listAudit(limit = 100): Promise<AuditRow[]> {
   const client = await getServerClient();
   const { data, error } = await client
     .from("admin_delete_audit")
-    .select("id, actor_id, actor_type, entity_type, entity_id, entity_label, operation, dependency_count, resolution_type, created_at")
+    .select("id, actor_id, actor_type, entity_type, entity_id, entity_label, operation, dependency_count, resolution_type, snapshot, created_at")
     .order("created_at", { ascending: false })
     .limit(limit);
   if (error || !data) return [];
@@ -31,6 +32,7 @@ export async function listAudit(limit = 100): Promise<AuditRow[]> {
     operation: string;
     dependency_count: number;
     resolution_type: string | null;
+    snapshot: unknown | null;
     created_at: string;
   }>).map((row) => ({
     id: row.id,
@@ -42,6 +44,7 @@ export async function listAudit(limit = 100): Promise<AuditRow[]> {
     operation: row.operation,
     dependencyCount: row.dependency_count,
     resolutionType: row.resolution_type,
+    snapshot: row.snapshot,
     createdAt: row.created_at,
   }));
 }

--- a/src/app/admin/(dashboard)/audit/page.tsx
+++ b/src/app/admin/(dashboard)/audit/page.tsx
@@ -1,4 +1,5 @@
 import { listAudit } from "./data";
+import { AuditList } from "./audit-list";
 
 export const dynamic = "force-dynamic";
 
@@ -7,41 +8,8 @@ export default async function AuditPage() {
   return (
     <div className="admin-page">
       <h1 className="admin-page-title">Audit log</h1>
-      <p className="admin-note">All soft delete, restore, and hard delete operations (user and system). Anon cannot read this table.</p>
-      {rows.length === 0 ? (
-        <p className="admin-message">No audit entries yet.</p>
-      ) : (
-        <div className="admin-table-wrap">
-          <table className="admin-table">
-            <thead>
-              <tr>
-                <th>Time</th>
-                <th>Actor</th>
-                <th>Operation</th>
-                <th>Entity</th>
-                <th>ID</th>
-                <th>Label</th>
-                <th>Deps</th>
-                <th>Resolution</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <tr key={row.id}>
-                  <td>{new Date(row.createdAt).toLocaleString()}</td>
-                  <td>{row.actorType === "system" ? "system" : row.actorId?.slice(0, 8) ?? "user"}</td>
-                  <td><span className="admin-badge">{row.operation}</span></td>
-                  <td>{row.entityType}</td>
-                  <td><code>{row.entityId}</code></td>
-                  <td>{row.entityLabel ?? "—"}</td>
-                  <td>{row.dependencyCount}</td>
-                  <td>{row.resolutionType ?? "—"}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <p className="admin-note">All soft delete, restore, and hard delete operations (user and system). Click the eye to see full row.</p>
+      <AuditList rows={rows} />
     </div>
   );
 }

--- a/src/features/cms/media-resolve-actions.ts
+++ b/src/features/cms/media-resolve-actions.ts
@@ -104,39 +104,38 @@ export async function resolveAndDeleteMedia(
   }
 
   // 2b. Resume media: delete resume_media rows that reference the path (exact match, bypass DELETE_DEPENDENCY_EXISTS)
-  // This mirrors removeResumeMediaReference but with per-row guard to avoid TOCTOU on trashed parents.
+  // Prefer RPC for atomicity; fallback to direct helper if RPC not yet migrated
   try {
-    // Prefer the dedicated helper for the common case (exact eq on both columns)
-    // Keep a guarded per-row path to respect resume_entries.deleted_at IS NULL
-    const { data: resumeRows, error: resumeError } = await client
-      .from("resume_media")
-      .select("id, resume_entry_id")
-      .or(`thumbnail_src.eq.${path},full_src.eq.${path}`);
-    if (resumeError) throw new Error(resumeError.message);
-    if (resumeRows?.length) {
-      for (const row of resumeRows) {
-        const typed = row as { id: string; resume_entry_id: string };
-        // Guard: only delete if the owning resume_entry is not trashed
-        const { data: entryData, error: entryError } = await client
-          .from("resume_entries")
-          .select("id")
-          .eq("id", typed.resume_entry_id)
-          .is("deleted_at", null)
-          .limit(1);
-        if (entryError) throw new Error(entryError.message);
-        if (!entryData || entryData.length === 0) continue;
-        const { error: delError } = await client.from("resume_media").delete().eq("id", typed.id);
-        if (delError) throw new Error(delError.message);
-        removedResumeRows++;
+    const { data: rpcData, error: rpcError } = await client.rpc("cms_resolve_resume_media", { p_path: path });
+    if (rpcError) throw new Error(rpcError.message);
+    if (rpcData && typeof rpcData === "object" && "deletedRows" in rpcData) {
+      removedResumeRows = (rpcData as { deletedRows: number }).deletedRows ?? 0;
+    } else {
+      // Fallback: direct per-row guarded delete (for environments where RPC not yet deployed)
+      const { data: resumeRows, error: resumeError } = await client
+        .from("resume_media")
+        .select("id, resume_entry_id")
+        .or(`thumbnail_src.eq.${path},full_src.eq.${path}`);
+      if (resumeError) throw new Error(resumeError.message);
+      if (resumeRows?.length) {
+        for (const row of resumeRows) {
+          const typed = row as { id: string; resume_entry_id: string };
+          const { data: entryData, error: entryError } = await client
+            .from("resume_entries")
+            .select("id")
+            .eq("id", typed.resume_entry_id)
+            .is("deleted_at", null)
+            .limit(1);
+          if (entryError) throw new Error(entryError.message);
+          if (!entryData || entryData.length === 0) continue;
+          const { error: delError } = await client.from("resume_media").delete().eq("id", typed.id);
+          if (delError) throw new Error(delError.message);
+          removedResumeRows++;
+        }
       }
-    }
-    // Also ensure helper is kept in sync — if no rows found via select, try helper as fallback for edge cases
-    if (removedResumeRows === 0) {
-      const fallback = await removeResumeMediaReference(client, path).catch(() => ({ deletedRows: 0 }));
-      // fallback already deleted matching rows, but we already filtered by active parent;
-      // only count if we didn't already handle them
-      if (fallback.deletedRows > 0 && !resumeRows?.length) {
-        removedResumeRows = fallback.deletedRows;
+      if (removedResumeRows === 0) {
+        const fallback = await removeResumeMediaReference(client, path).catch(() => ({ deletedRows: 0 }));
+        if (fallback.deletedRows > 0 && !resumeRows?.length) removedResumeRows = fallback.deletedRows;
       }
     }
   } catch (e) {

--- a/src/features/cms/media-resolve-actions.ts
+++ b/src/features/cms/media-resolve-actions.ts
@@ -3,13 +3,14 @@
 import { revalidatePath } from "next/cache";
 
 import { getServerClient, isAdminUser } from "@/features/cms/session";
-import { removeMarkdownImageNodes } from "./media-resolve";
+import { removeMarkdownImageNodes, removeResumeMediaReference } from "./media-resolve";
 
 export interface ResolveResult {
   ok: boolean;
   error?: string;
   clearedCovers?: number;
   removedNodes?: number;
+  removedResumeRows?: number;
 }
 
 export async function resolveAndDeleteMedia(
@@ -21,6 +22,7 @@ export async function resolveAndDeleteMedia(
 
   let clearedCovers = 0;
   let removedNodes = 0;
+  let removedResumeRows = 0;
 
   // 1. Clear cover_bucket_path where it matches (SET NULL) — authoritative exact match, with FOR UPDATE semantics via RPC
   // Use the dedicated RPC for set_null to ensure audit and proper handling
@@ -101,6 +103,46 @@ export async function resolveAndDeleteMedia(
     return { ok: false, error: e instanceof Error ? e.message : "Failed to resolve content." };
   }
 
+  // 2b. Resume media: delete resume_media rows that reference the path (exact match, bypass DELETE_DEPENDENCY_EXISTS)
+  // This mirrors removeResumeMediaReference but with per-row guard to avoid TOCTOU on trashed parents.
+  try {
+    // Prefer the dedicated helper for the common case (exact eq on both columns)
+    // Keep a guarded per-row path to respect resume_entries.deleted_at IS NULL
+    const { data: resumeRows, error: resumeError } = await client
+      .from("resume_media")
+      .select("id, resume_entry_id")
+      .or(`thumbnail_src.eq.${path},full_src.eq.${path}`);
+    if (resumeError) throw new Error(resumeError.message);
+    if (resumeRows?.length) {
+      for (const row of resumeRows) {
+        const typed = row as { id: string; resume_entry_id: string };
+        // Guard: only delete if the owning resume_entry is not trashed
+        const { data: entryData, error: entryError } = await client
+          .from("resume_entries")
+          .select("id")
+          .eq("id", typed.resume_entry_id)
+          .is("deleted_at", null)
+          .limit(1);
+        if (entryError) throw new Error(entryError.message);
+        if (!entryData || entryData.length === 0) continue;
+        const { error: delError } = await client.from("resume_media").delete().eq("id", typed.id);
+        if (delError) throw new Error(delError.message);
+        removedResumeRows++;
+      }
+    }
+    // Also ensure helper is kept in sync — if no rows found via select, try helper as fallback for edge cases
+    if (removedResumeRows === 0) {
+      const fallback = await removeResumeMediaReference(client, path).catch(() => ({ deletedRows: 0 }));
+      // fallback already deleted matching rows, but we already filtered by active parent;
+      // only count if we didn't already handle them
+      if (fallback.deletedRows > 0 && !resumeRows?.length) {
+        removedResumeRows = fallback.deletedRows;
+      }
+    }
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Failed to resolve resume media." };
+  }
+
   // 3. Now soft delete the media asset (should succeed as references cleared)
   const { data: deleteData, error: deleteError } = await client.rpc("cms_soft_delete_media_asset", {
     p_bucket: bucket,
@@ -117,5 +159,6 @@ export async function resolveAndDeleteMedia(
   revalidatePath("/admin/media");
   revalidatePath("/admin/trash");
   revalidatePath("/admin/blog");
-  return { ok: true, clearedCovers, removedNodes };
+  revalidatePath("/admin/resume");
+  return { ok: true, clearedCovers, removedNodes, removedResumeRows };
 }

--- a/src/features/cms/media-resolve.test.ts
+++ b/src/features/cms/media-resolve.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { removeResumeMediaReference } from "./media-resolve";
+
+test("removeResumeMediaReference deletes resume_media row", async () => {
+  let observedFilter: unknown = null;
+  const mockClient = {
+    from: (table: string) => {
+      assert.equal(table, "resume_media");
+      return {
+        delete: () => ({
+          or: (filter: string) => {
+            observedFilter = filter;
+            return {
+              select: async (cols: string) => {
+                assert.equal(cols, "id");
+                return { data: [{ id: "test-id" }], error: null };
+              },
+            };
+          },
+        }),
+      };
+    },
+  } as unknown as SupabaseClient;
+
+  const result = await removeResumeMediaReference(mockClient as unknown as SupabaseClient, "a.jpg");
+  assert.equal(result.deletedRows, 1);
+  assert.ok(
+    typeof observedFilter === "string" && (observedFilter as string).includes("thumbnail_src.eq.a.jpg"),
+    `filter should contain thumbnail_src.eq.a.jpg: ${String(observedFilter)}`,
+  );
+  assert.ok(
+    typeof observedFilter === "string" && (observedFilter as string).includes("full_src.eq.a.jpg"),
+    `filter should contain full_src.eq.a.jpg: ${String(observedFilter)}`,
+  );
+});
+
+test("removeResumeMediaReference throws on error", async () => {
+  const mockClient = {
+    from: () => ({
+      delete: () => ({
+        or: () => ({
+          select: async () => ({ data: null, error: { message: "db error" } }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient;
+  await assert.rejects(
+    () => removeResumeMediaReference(mockClient as unknown as SupabaseClient, "a.jpg"),
+    /db error/,
+  );
+});
+
+test("removeResumeMediaReference returns 0 when no rows", async () => {
+  const mockClient = {
+    from: () => ({
+      delete: () => ({
+        or: () => ({
+          select: async () => ({ data: [], error: null }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient;
+  const result = await removeResumeMediaReference(mockClient as unknown as SupabaseClient, "missing.jpg");
+  assert.equal(result.deletedRows, 0);
+});

--- a/src/features/cms/media-resolve.ts
+++ b/src/features/cms/media-resolve.ts
@@ -1,3 +1,24 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Remove resume_media rows that reference the given path via thumbnail_src or full_src.
+ * Exact match (not substring/ILIKE) — the caller has already verified the path is the
+ * stored object path, and the DB check in cms_soft_delete_media_asset uses ilike for
+ * candidate but this authoritative delete uses exact eq.
+ */
+export async function removeResumeMediaReference(
+  client: SupabaseClient,
+  path: string,
+): Promise<{ deletedRows: number }> {
+  const { data, error } = await client
+    .from("resume_media")
+    .delete()
+    .or(`thumbnail_src.eq.${path},full_src.eq.${path}`)
+    .select("id");
+  if (error) throw new Error(error.message);
+  return { deletedRows: data?.length ?? 0 };
+}
+
 /**
  * Precise removal of embedded image nodes containing a given path.
  * This is the authoritative parser step for P4 — candidate ILIKE is not used for mutation.

--- a/supabase/migrations/20260901000000_resume_media_resolve.sql
+++ b/supabase/migrations/20260901000000_resume_media_resolve.sql
@@ -1,0 +1,21 @@
+create or replace function public.cms_resolve_resume_media(p_path text)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare v_cnt int;
+begin
+  if not private.is_owner() then
+    return jsonb_build_object('status','failed','errorCode','DELETE_NOT_ALLOWED');
+  end if;
+  delete from public.resume_media
+  where (thumbnail_src = p_path or full_src = p_path)
+    and resume_entry_id in (select id from public.resume_entries where deleted_at is null);
+  get diagnostics v_cnt = row_count;
+  return jsonb_build_object('status','deleted','deletedRows',v_cnt);
+end;
+$$;
+
+revoke all on function public.cms_resolve_resume_media(text) from public;
+grant execute on function public.cms_resolve_resume_media(text) to authenticated;


### PR DESCRIPTION
Follow-up to #131:\n- cms_resolve_resume_media RPC + app layer auto-resolve for resume_media\n- Audit eye icon + snapshot modal (was on fix/audit-eye, now on dev)\n\nCloses # (resume media)