### PR TITLE
fix(media): handle DELETE_DEPENDENCY_EXISTS for resume media auto-resolve

### DIFF
--- a/src/app/admin/(dashboard)/media/media-library-grid.tsx
+++ b/src/app/admin/(dashboard)/media/media-library-grid.tsx
@@ -155,8 +155,13 @@ export function MediaLibraryGrid({
         router.refresh();
         return;
       }
-      // If blocked, try resolve & delete
-      if (result.error?.includes("referenced") || result.error?.includes("blocked")) {
+      // If blocked (including DELETE_DEPENDENCY_EXISTS from RPC), try resolve & delete
+      if (
+        result.error?.includes("referenced") ||
+        result.error?.includes("blocked") ||
+        result.error?.includes("DELETE_DEPENDENCY_EXISTS") ||
+        result.error?.includes("DEPENDENCY")
+      ) {
         const resolveRes = await resolveAndDeleteMedia(deleteTarget.bucket, deleteTarget.path);
         if (resolveRes.ok) {
           setItems((current) => current.filter((item) => item.path !== deleteTarget.path));
@@ -247,8 +252,20 @@ export function MediaLibraryGrid({
                 startTransition(async () => {
                   let deleted = 0;
                   for (const path of Array.from(selected)) {
-                    const res = await deleteMedia(bucket, path);
-                    if (res.ok) deleted++;
+                    let res = await deleteMedia(bucket, path);
+                    if (res.ok) {
+                      deleted++;
+                      continue;
+                    }
+                    if (
+                      res.error?.includes("referenced") ||
+                      res.error?.includes("blocked") ||
+                      res.error?.includes("DELETE_DEPENDENCY_EXISTS") ||
+                      res.error?.includes("DEPENDENCY")
+                    ) {
+                      const r2 = await resolveAndDeleteMedia(bucket, path);
+                      if (r2.ok) deleted++;
+                    }
                   }
                   setItems((current) => current.filter((item) => !selected.has(item.path)));
                   setSelected(new Set());


### PR DESCRIPTION
Fixes resume media delete still showing DELETE_DEPENDENCY_EXISTS even though auto-resolve exists.

- Handle error code DELETE_DEPENDENCY_EXISTS in single and bulk delete (trigger resolveAndDeleteMedia)
- Previously only checked referenced/blocked, missed the RPC error code
