### PR TITLE
fix: seo hidden configs + resume ILIKE + lint

### DIFF
--- a/src/app/admin/(dashboard)/media/media-library-grid.tsx
+++ b/src/app/admin/(dashboard)/media/media-library-grid.tsx
@@ -252,7 +252,7 @@ export function MediaLibraryGrid({
                 startTransition(async () => {
                   let deleted = 0;
                   for (const path of Array.from(selected)) {
-                    let res = await deleteMedia(bucket, path);
+                    const res = await deleteMedia(bucket, path);
                     if (res.ok) {
                       deleted++;
                       continue;

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,7 +1,16 @@
+import type { Metadata } from "next";
+
 import { ThemeProvider } from "@/features/theme/theme-provider";
 import { ThemeScript } from "@/features/theme/theme-script";
 
 import "@/styles/globals.css";
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 export default function AdminLayout({
   children,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -10,6 +10,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
+        disallow: ["/admin", "/api/"],
       },
     ],
     sitemap: `${siteUrl}/sitemap.xml`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -31,10 +31,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const homeLanguages = languagesFor("/");
   const blogLanguages = languagesFor("/blog");
 
+  // Derive lastModified for aggregated routes from the freshest published post,
+  // so Google sees a stable timestamp instead of `now()` on every request.
+  const latestPostDate = posts.reduce<Date | null>((latest, post) => {
+    const d = new Date(post.updatedAt || post.publishedAt);
+    return !latest || d > latest ? d : latest;
+  }, null);
+  const blogLastModified = latestPostDate ?? new Date();
+  const homeLastModified = latestPostDate ?? new Date();
+
   return [
     {
       url: getAbsoluteUrl(getLocalizedPathname("/", "en")),
-      lastModified: new Date(),
+      lastModified: homeLastModified,
       changeFrequency: "monthly",
       priority: 1,
       alternates: { languages: homeLanguages },
@@ -43,14 +52,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       .filter((locale) => locale !== "en")
       .map((locale) => ({
         url: getAbsoluteUrl(getLocalizedPathname("/", locale)),
-        lastModified: new Date(),
+        lastModified: homeLastModified,
         changeFrequency: "monthly" as const,
         priority: 1,
         alternates: { languages: homeLanguages },
       })),
     ...locales.map((locale) => ({
       url: getAbsoluteUrl(getLocalizedPathname("/blog", locale)),
-      lastModified: new Date(),
+      lastModified: blogLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.8,
       alternates: { languages: blogLanguages },
@@ -69,7 +78,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         url: getAbsoluteUrl(
           getLocalizedPathname(`/blog/category/${category.slug}`, locale),
         ),
-        lastModified: new Date(),
+        lastModified: category.updatedAt ? new Date(category.updatedAt) : blogLastModified,
         changeFrequency: "monthly" as const,
         priority: 0.6,
         alternates: { languages: languagesFor(`/blog/category/${category.slug}`) },
@@ -78,7 +87,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...tags.flatMap((tag) =>
       locales.map((locale) => ({
         url: getAbsoluteUrl(getLocalizedPathname(`/blog/tag/${tag.slug}`, locale)),
-        lastModified: new Date(),
+        lastModified: tag.updatedAt ? new Date(tag.updatedAt) : blogLastModified,
         changeFrequency: "monthly" as const,
         priority: 0.5,
         alternates: { languages: languagesFor(`/blog/tag/${tag.slug}`) },

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -450,50 +450,83 @@ export async function queryPublishedPostIndex(): Promise<
   }
 }
 
-/** Uncached core: category slugs that currently have published posts. */
-export async function queryCategoryIndex(): Promise<{ slug: string }[]> {
+/** Uncached core: category slugs that currently have published posts, with lastModified derived from the newest post in each category. */
+export async function queryCategoryIndex(): Promise<{ slug: string; updatedAt: string | null }[]> {
   const client = getServiceClient();
   if (!hasCmsConfig() || !client) return [];
 
   try {
-    const { data, error } = await client
-      .from("blog_categories")
-      .select("slug, blog_posts(id)")
-      .is("deleted_at", null)
-      .eq("blog_posts.status", "published");
-    if (error || !data) return [];
+    // Fetch categories and the latest published post's updated_at per category.
+    // Supabase does not expose MAX() directly, so we fetch (category_id, updated_at)
+    // for all published posts and reduce in JS — bounded by published post count
+    // (blog is small; sitemap is cached 1d and tagged `blog`).
+    const [catResult, postResult] = await Promise.all([
+      client.from("blog_categories").select("id, slug").is("deleted_at", null),
+      client
+        .from("blog_posts")
+        .select("category_id, updated_at")
+        .eq("status", "published")
+        .is("deleted_at", null),
+    ]);
 
-    return (data as unknown as { slug: string; blog_posts: unknown[] }[])
-      .filter((row) => row.blog_posts.length > 0)
-      .map((row) => ({ slug: row.slug }));
+    if (catResult.error || !catResult.data) return [];
+    if (postResult.error || !postResult.data) {
+      // Fallback: return slugs without dates
+      return (catResult.data as unknown as { slug: string }[]).map((r) => ({
+        slug: r.slug,
+        updatedAt: null,
+      }));
+    }
+
+    const maxByCategory = new Map<string, string>();
+    for (const row of postResult.data as unknown as { category_id: string; updated_at: string }[]) {
+      const prev = maxByCategory.get(row.category_id);
+      if (!prev || row.updated_at > prev) maxByCategory.set(row.category_id, row.updated_at);
+    }
+
+    return (catResult.data as unknown as { id: string; slug: string }[])
+      .filter((row) => maxByCategory.has(row.id))
+      .map((row) => ({ slug: row.slug, updatedAt: maxByCategory.get(row.id) ?? null }));
   } catch {
     return [];
   }
 }
 
-/** Uncached core: tag slugs that currently have published posts. */
-export async function queryTagIndex(): Promise<{ slug: string }[]> {
+/** Uncached core: tag slugs that currently have published posts, with lastModified derived from the newest post carrying each tag. */
+export async function queryTagIndex(): Promise<{ slug: string; updatedAt: string | null }[]> {
   const client = getServiceClient();
   if (!hasCmsConfig() || !client) return [];
 
   try {
-    const { data, error } = await client
-      .from("blog_tags")
-      .select("slug, blog_post_tags!inner(blog_posts!inner(status))")
-      .is("deleted_at", null)
-      .eq("blog_post_tags.blog_posts.status", "published");
-    if (error || !data) return [];
+    const [tagResult, postTagResult] = await Promise.all([
+      client.from("blog_tags").select("id, slug").is("deleted_at", null),
+      // Join through blog_post_tags → blog_posts to get updated_at per tag.
+      // We fetch (tag_id, blog_posts.updated_at) and reduce to max per tag.
+      client
+        .from("blog_post_tags")
+        .select("tag_id, blog_posts!inner(updated_at, status, deleted_at)")
+        .eq("blog_posts.status", "published")
+        .is("blog_posts.deleted_at", null),
+    ]);
 
-    // Deduplicate slugs (inner join may return duplicates if multiple posts per tag)
-    const seen = new Set<string>();
-    const result: { slug: string }[] = [];
-    for (const row of data as unknown as { slug: string }[]) {
-      if (!seen.has(row.slug)) {
-        seen.add(row.slug);
-        result.push({ slug: row.slug });
-      }
+    if (tagResult.error || !tagResult.data) return [];
+    if (postTagResult.error || !postTagResult.data) {
+      return (tagResult.data as unknown as { slug: string }[]).map((r) => ({
+        slug: r.slug,
+        updatedAt: null,
+      }));
     }
-    return result;
+
+    const maxByTag = new Map<string, string>();
+    for (const row of postTagResult.data as unknown as { tag_id: string; blog_posts: { updated_at: string } }[]) {
+      const updatedAt = row.blog_posts.updated_at;
+      const prev = maxByTag.get(row.tag_id);
+      if (!prev || updatedAt > prev) maxByTag.set(row.tag_id, updatedAt);
+    }
+
+    return (tagResult.data as unknown as { id: string; slug: string }[])
+      .filter((row) => maxByTag.has(row.id))
+      .map((row) => ({ slug: row.slug, updatedAt: maxByTag.get(row.id) ?? null }));
   } catch {
     return [];
   }

--- a/supabase/migrations/20260902000000_fix_resume_resolve_ilike.sql
+++ b/supabase/migrations/20260902000000_fix_resume_resolve_ilike.sql
@@ -1,0 +1,23 @@
+create or replace function public.cms_resolve_resume_media(p_path text)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare v_cnt int;
+begin
+  if not private.is_owner() then
+    return jsonb_build_object('status','failed','errorCode','DELETE_NOT_ALLOWED');
+  end if;
+  -- Use ILIKE for resume_media because thumbnail_src/full_src store as /api/resume-media/... with prefix and thumb suffix
+  -- while media_assets path is like "test.jpg" without prefix. Use %path% to match.
+  delete from public.resume_media
+  where (thumbnail_src ilike '%' || p_path || '%' or full_src ilike '%' || p_path || '%')
+    and resume_entry_id in (select id from public.resume_entries where deleted_at is null);
+  get diagnostics v_cnt = row_count;
+  return jsonb_build_object('status','deleted','deletedRows',v_cnt);
+end;
+$$;
+
+revoke all on function public.cms_resolve_resume_media(text) from public;
+grant execute on function public.cms_resolve_resume_media(text) to authenticated;


### PR DESCRIPTION
Closes: N/A (audit batch)

## Tổng hợp audit trước đó
- main đã là nhánh mới nhất (ahead dev 5 commits, dev is ancestor của main). 14 nhánh no-merged chỉ là branch cũ đã squash-merge.
- Còn 1 commit local chưa lên main: 49472ad ILIKE fix cho resume_media resolve.

## Thay đổi trong PR này (2 commits trên main)
1. 49472ad fix(db): resume media resolve use ILIKE for /api prefix (was exact, missed thumb)
2. 60df55a fix(seo): robots Disallow admin/api + admin noindex, sitemap stable lastModified, lint const
   - robots.ts: Disallow /admin, /api/
   - admin/layout.tsx: metadata robots index:false follow:false
   - sitemap.ts: blog/home lastModified từ latest post, category/tag từ MAX(updated_at) per entity (không new Date() mỗi request)
   - repository.ts: queryCategoryIndex/queryTagIndex thêm updatedAt (JS MAX reduce, cached 1d tag blog)
   - media-library-grid.tsx: let res -> const (fix eslint prefer-const)

## Verification
- lint: 0 error (2 warnings ở bin/ không liên quan)
- typecheck: pass
- build --webpack: pass (29/29 pages, sitemap 1d)
- npm test: 147 pass
- migration 20260902000000_fix_resume_resolve_ilike.sql cần apply local-first rồi --linked (chưa apply trong PR này, chỉ ship file)

## Known limitations
- sitemap category/tag lastModified fallback về blogLastModified nếu không có post (hiếm).
- .claude/bin/docs/superpowers untracked không commit theo .gitignore intention.
