### PR TITLE
feat(feed): add Atom + JSONFeed with pagination, enrich RSS

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -42,13 +42,15 @@ export default async function LocaleLayout({
     <html data-theme="light" lang={locale} suppressHydrationWarning>
       <head>
         <ThemeScript />
-        {/* RSS autodiscovery (spec §7): `/feed.xml` (en) / `/vi/feed.xml` (vi) */}
+        {/* Feed autodiscovery: RSS (per-locale) + Atom/JSONFeed (global, spec §7) */}
         <link
           href={getLocalizedPathname("/feed.xml", locale)}
           rel="alternate"
           title="RSS"
           type="application/rss+xml"
         />
+        <link href="/feeds.atom" rel="alternate" title="Atom" type="application/atom+xml" />
+        <link href="/feeds.json" rel="alternate" title="JSON Feed" type="application/feed+json" />
       </head>
       <body>
         <StructuredData locale={locale} />

--- a/src/app/feeds.atom/route.ts
+++ b/src/app/feeds.atom/route.ts
@@ -1,0 +1,42 @@
+import { getMessages } from "@/features/i18n/messages";
+import { getRssPostCount, getRssPostsPaginated } from "@/features/blog/repository";
+import { buildAtomFeed } from "@/features/blog/rss";
+
+export const dynamic = "force-dynamic";
+
+const FEED_PAGE_SIZE = 10;
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const pageParam = url.searchParams.get("page");
+  const page = pageParam ? Number(pageParam) : 1;
+
+  if (!Number.isInteger(page) || page < 1) {
+    return new Response("Invalid page", { status: 400 });
+  }
+
+  const messages = await getMessages("en");
+  const [total, posts] = await Promise.all([
+    getRssPostCount(),
+    getRssPostsPaginated("en", FEED_PAGE_SIZE, (page - 1) * FEED_PAGE_SIZE),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(total / FEED_PAGE_SIZE));
+
+  if (page > totalPages && total > 0) {
+    return new Response("Page not found", { status: 404 });
+  }
+
+  const xml = buildAtomFeed(posts, messages.metadata.title, {
+    page,
+    totalPages,
+    totalItems: total,
+  });
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/atom+xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/src/app/feeds.json/route.ts
+++ b/src/app/feeds.json/route.ts
@@ -1,0 +1,48 @@
+import { getMessages } from "@/features/i18n/messages";
+import { getRssPostCount, getRssPostsPaginated } from "@/features/blog/repository";
+import { buildJsonFeed } from "@/features/blog/rss";
+
+export const dynamic = "force-dynamic";
+
+const FEED_PAGE_SIZE = 10;
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const pageParam = url.searchParams.get("page");
+  const page = pageParam ? Number(pageParam) : 1;
+
+  if (!Number.isInteger(page) || page < 1) {
+    return new Response(JSON.stringify({ error: "Invalid page" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const messages = await getMessages("en");
+  const [total, posts] = await Promise.all([
+    getRssPostCount(),
+    getRssPostsPaginated("en", FEED_PAGE_SIZE, (page - 1) * FEED_PAGE_SIZE),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(total / FEED_PAGE_SIZE));
+
+  if (page > totalPages && total > 0) {
+    return new Response(JSON.stringify({ error: "Page not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const json = buildJsonFeed(posts, messages.metadata.title, messages.blog.intro, {
+    page,
+    totalPages,
+    totalItems: total,
+  });
+
+  return new Response(json, {
+    headers: {
+      "Content-Type": "application/feed+json; charset=utf-8",
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/src/components/navigation/feed-switcher.tsx
+++ b/src/components/navigation/feed-switcher.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { Locale } from "@/features/i18n/config";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+
+interface FeedSwitcherProps {
+  locale: Locale;
+}
+
+export function FeedSwitcher({ locale }: Readonly<FeedSwitcherProps>) {
+  const [open, setOpen] = useState(false);
+  const switcherRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus({ preventScroll: true });
+      }
+    }
+
+    function closeOutside(event: PointerEvent) {
+      if (event.target instanceof Node && !switcherRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", closeOnEscape, true);
+    document.addEventListener("pointerdown", closeOutside);
+
+    return () => {
+      document.removeEventListener("keydown", closeOnEscape, true);
+      document.removeEventListener("pointerdown", closeOutside);
+    };
+  }, [open]);
+
+  const rssHref = getLocalizedPathname("/feed.xml", locale);
+
+  return (
+    <div className="locale-switcher feed-switcher" ref={switcherRef}>
+      <button
+        aria-controls="feed-options"
+        aria-expanded={open}
+        aria-label="Feeds: RSS, Atom, JSONFeed"
+        className="locale-switcher__trigger feed-switcher__trigger"
+        onClick={() => setOpen((current) => !current)}
+        ref={triggerRef}
+        title="Feeds: RSS, Atom, JSONFeed"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="19"
+          viewBox="0 0 24 24"
+          width="19"
+        >
+          <path
+            d="M4 11a9 9 0 0 1 9 9"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+          <path
+            d="M4 15.5a4.5 4.5 0 0 1 4.5 4.5"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+          <circle cx="4.5" cy="19.5" r="1.5" fill="currentColor" />
+        </svg>
+      </button>
+
+      <nav
+        aria-label="Feed options"
+        className="locale-switcher__popover feed-switcher__popover"
+        data-open={open ? "true" : "false"}
+        id="feed-options"
+      >
+        <a href={rssHref} rel="alternate" type="application/rss+xml" onClick={() => setOpen(false)}>
+          <span>RSS</span>
+          <span className="feed-switcher__hint">.xml</span>
+        </a>
+        <a href="/feeds.atom" rel="alternate" type="application/atom+xml" onClick={() => setOpen(false)}>
+          <span>Atom</span>
+          <span className="feed-switcher__hint">.atom</span>
+        </a>
+        <a href="/feeds.json" rel="alternate" type="application/feed+json" onClick={() => setOpen(false)}>
+          <span>JSONFeed</span>
+          <span className="feed-switcher__hint">.json</span>
+        </a>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/navigation/site-header.tsx
+++ b/src/components/navigation/site-header.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/features/navigation/config";
 import { getLocalizedPathname } from "@/features/i18n/routing";
 import { ThemeToggle } from "@/features/theme/theme-toggle";
+import { FeedSwitcher } from "./feed-switcher";
 
 interface SiteHeaderProps {
   githubUrl: string;
@@ -413,6 +414,7 @@ export function SiteHeader({
                 messages={localeSwitcherMessages}
                 onNavigate={closeAfterLocaleNavigation}
               />
+              <FeedSwitcher locale={locale} />
               <ThemeToggle messages={themeToggleMessages} />
             </div>
           </div>

--- a/src/features/blog/repository.ts
+++ b/src/features/blog/repository.ts
@@ -572,12 +572,16 @@ export interface RssPostRow {
   slug: string;
   summary: string;
   publishedAt: string;
+  updatedAt: string;
+  category: { slug: string; name: string };
+  tags: { slug: string; name: string }[];
 }
 
-/** Uncached core: latest published posts for the RSS feed (spec §7). */
+/** Uncached core: latest published posts for the RSS/Atom/JSON feed (spec §7). */
 export async function queryRssPosts(
   locale: Locale,
   limit = 20,
+  offset = 0,
 ): Promise<RssPostRow[]> {
   const client = getServiceClient();
   if (!hasCmsConfig() || !client) return [];
@@ -585,29 +589,59 @@ export async function queryRssPosts(
   try {
     const { data, error } = await client
       .from("blog_posts")
-      .select(postSelect())
+      .select(
+        `${postSelect()}, blog_post_tags(tag_id, blog_tags(slug, blog_tag_translations(locale, name)))` as string,
+      )
       .eq("status", "published")
       .is("deleted_at", null)
       .order("published_at", { ascending: false })
       .order("id")
-      .limit(limit);
+      .range(offset, offset + limit - 1);
     if (error || !data) return [];
 
-    return (data as unknown as PostRow[])
+    return (data as unknown as (PostRow & { blog_post_tags: PostTagLinkRow[] })[])
       .map((row) => {
-        const item = mapPostListItem(row, locale);
-        return item
-          ? {
-              title: item.title,
-              slug: item.slug,
-              summary: item.summary,
-              publishedAt: item.publishedAt,
-            }
-          : null;
+        const item = mapPostListItem(row as unknown as PostRow, locale);
+        if (!item) return null;
+        const tags = (row.blog_post_tags ?? [])
+          .map((link) => {
+            const tagName = localeRow(link.blog_tags?.blog_tag_translations, locale);
+            return link.blog_tags && tagName
+              ? { slug: link.blog_tags.slug, name: tagName.name }
+              : null;
+          })
+          .filter((tag): tag is { slug: string; name: string } => tag !== null);
+
+        return {
+          title: item.title,
+          slug: item.slug,
+          summary: item.summary,
+          publishedAt: item.publishedAt,
+          updatedAt: item.updatedAt,
+          category: item.category,
+          tags,
+        };
       })
       .filter((row): row is RssPostRow => row !== null);
   } catch {
     return [];
+  }
+}
+
+/** Total count of published posts for feed pagination (used by Atom/JSON feeds). */
+export async function queryRssPostCount(): Promise<number> {
+  const client = getServiceClient();
+  if (!hasCmsConfig() || !client) return 0;
+  try {
+    const { count, error } = await client
+      .from("blog_posts")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "published")
+      .is("deleted_at", null);
+    if (error) return 0;
+    return count ?? 0;
+  } catch {
+    return 0;
   }
 }
 
@@ -668,7 +702,19 @@ export const getCategoryNav = unstable_cache(
 );
 
 export const getRssPosts = unstable_cache(
-  (locale: Locale) => queryRssPosts(locale, 20),
+  (locale: Locale) => queryRssPosts(locale, 20, 0),
   ["blog", "rss-posts"],
+  { tags: [BLOG_CACHE_TAG], revalidate: BLOG_SAFETY_NET_SECONDS },
+);
+
+export const getRssPostsPaginated = unstable_cache(
+  (locale: Locale, limit: number, offset: number) => queryRssPosts(locale, limit, offset),
+  ["blog", "rss-posts-paginated"],
+  { tags: [BLOG_CACHE_TAG], revalidate: BLOG_SAFETY_NET_SECONDS },
+);
+
+export const getRssPostCount = unstable_cache(
+  () => queryRssPostCount(),
+  ["blog", "rss-post-count"],
   { tags: [BLOG_CACHE_TAG], revalidate: BLOG_SAFETY_NET_SECONDS },
 );

--- a/src/features/blog/rss.test.ts
+++ b/src/features/blog/rss.test.ts
@@ -10,12 +10,18 @@ const posts: RssPostRow[] = [
     slug: "hello-welcome",
     summary: "A summary with <tags> & entities.",
     publishedAt: "2026-08-20T00:00:00Z",
+    updatedAt: "2026-08-20T00:00:00Z",
+    category: { slug: "tech", name: "Tech" },
+    tags: [{ slug: "nextjs", name: "Next.js" }],
   },
   {
     title: "Second post",
     slug: "second-post",
     summary: "Plain summary.",
     publishedAt: "2026-08-15T00:00:00Z",
+    updatedAt: "2026-08-15T00:00:00Z",
+    category: { slug: "life", name: "Life" },
+    tags: [],
   },
 ];
 
@@ -28,8 +34,10 @@ test("rss feed: en channel + item structure and URLs", () => {
   assert.ok(xml.includes('rel="self" type="application/rss+xml"'));
   assert.ok(xml.includes("https://khoawatt.com/feed.xml"));
   assert.ok(xml.includes("https://khoawatt.com/blog/hello-welcome"));
-  assert.ok(xml.includes("<guid>https://khoawatt.com/blog/hello-welcome</guid>"));
+  assert.ok(xml.includes("https://khoawatt.com/blog/hello-welcome</guid>"));
   assert.ok(xml.includes("<pubDate>Thu, 20 Aug 2026 00:00:00 GMT</pubDate>"));
+  assert.ok(xml.includes("<category>Tech</category>"));
+  assert.ok(xml.includes("<author>"));
 });
 
 test("rss feed: vi channel uses /vi feed and /vi/blog URLs", () => {

--- a/src/features/blog/rss.ts
+++ b/src/features/blog/rss.ts
@@ -1,14 +1,19 @@
 /**
- * RSS 2.0 feed generation (blog design spec §7).
+ * Feed generation (RSS 2.0, Atom 1.0, JSONFeed 1.1) — blog design spec §7.
  *
- * `/feed.xml` (en) and `/vi/feed.xml` (vi), latest 20 published posts. Feeds
- * read through the `blog`-tagged repository accessor, so `updateTag("blog")`
- * refreshes them together with every other blog read.
+ * - `/feed.xml` (en) and `/vi/feed.xml` (vi) → RSS 2.0, latest 20 posts.
+ * - `/feeds.atom` and `/feeds.json` → Atom / JSONFeed, paginated, mixed locales
+ *   (mirrors the reference site quan.hoabinh.vn/feeds.*).
+ * All reads go through the `blog`-tagged repository accessor so
+ * `updateTag("blog")` refreshes them together with every other blog read.
  */
 import type { Locale } from "@/features/i18n/config";
 import { getLocalizedPathname } from "@/features/i18n/routing";
-import { getAbsoluteUrl } from "@/features/seo/config";
+import { getAbsoluteUrl, getSiteUrl } from "@/features/seo/config";
 import type { RssPostRow } from "./repository";
+
+const FEED_AUTHOR_NAME = "Khoa Watt";
+const FEED_AUTHOR_EMAIL = "contact@khoawatt.com";
 
 function escapeXml(value: string): string {
   return value
@@ -17,6 +22,10 @@ function escapeXml(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+}
+
+function escapeHtmlForAtom(value: string): string {
+  return escapeXml(value);
 }
 
 export function buildRssFeed(
@@ -34,16 +43,24 @@ export function buildRssFeed(
         getLocalizedPathname(`/blog/${post.slug}`, locale),
       );
       const pubDate = new Date(post.publishedAt).toUTCString();
+      const categories = [
+        `<category>${escapeXml(post.category.name)}</category>`,
+        ...post.tags.map((t) => `<category>${escapeXml(t.name)}</category>`),
+      ].join("\n");
 
       return [
         "    <item>",
         `      <title>${escapeXml(post.title)}</title>`,
         `      <link>${postUrl}</link>`,
-        `      <guid>${postUrl}</guid>`,
+        `      <guid isPermaLink="true">${postUrl}</guid>`,
         `      <pubDate>${pubDate}</pubDate>`,
         `      <description>${escapeXml(post.summary)}</description>`,
+        `      <author>${escapeXml(FEED_AUTHOR_EMAIL)} (${escapeXml(FEED_AUTHOR_NAME)})</author>`,
+        categories ? `      ${categories.replaceAll("\n", "\n      ")}` : null,
         "    </item>",
-      ].join("\n");
+      ]
+        .filter(Boolean)
+        .join("\n");
     })
     .join("\n");
 
@@ -54,10 +71,138 @@ export function buildRssFeed(
     `    <title>${escapeXml(feedTitle)}</title>`,
     `    <link>${blogUrl}</link>`,
     `    <description>${escapeXml(feedDescription)}</description>`,
+    "    <language>" + (locale === "vi" ? "vi-vn" : "en-us") + "</language>",
     `    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml"/>`,
-    items,
+    items ? items : "",
     "  </channel>",
     "</rss>",
     "",
   ].join("\n");
+}
+
+export interface AtomFeedOptions {
+  page: number;
+  totalPages: number;
+  totalItems: number;
+}
+
+export function buildAtomFeed(
+  posts: RssPostRow[],
+  feedTitle: string,
+  opts: AtomFeedOptions,
+): string {
+  const siteUrl = getSiteUrl();
+  const feedUrl = `${siteUrl}/feeds.atom`;
+  const updated = posts[0]?.updatedAt
+    ? new Date(posts[0].updatedAt).toISOString()
+    : new Date().toISOString();
+  const feedId = `${siteUrl}/feeds.atom`;
+
+  const paginationLinks = [
+    `  <link href="${feedUrl}" rel="self"/>`,
+    `  <link href="${feedUrl}?page=1" rel="first"/>`,
+    `  <link href="${feedUrl}?page=${opts.totalPages}" rel="last"/>`,
+    opts.page < opts.totalPages ? `  <link href="${feedUrl}?page=${opts.page + 1}" rel="next"/>` : null,
+    opts.page > 1 ? `  <link href="${feedUrl}?page=${opts.page - 1}" rel="prev"/>` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const entries = posts
+    .map((post) => {
+      // Detect locale for this post by checking which translation exists; fallback to en.
+      // RssPostRow comes from a specific locale query, but Atom feed mixes locales,
+      // so we store the post's locale-agnostic URL as /blog/slug and let content negotiation handle it.
+      // For hreflang correctness we still emit the locale in <link> via xhtml? Atom uses category for language.
+      const postUrl = `${siteUrl}/blog/${post.slug}`;
+      const published = new Date(post.publishedAt).toISOString();
+      const updatedAt = new Date(post.updatedAt).toISOString();
+      const categories = [
+        `<category term="${escapeXml(post.category.slug)}" label="${escapeXml(post.category.name)}"/>`,
+        ...post.tags.map(
+          (t) => `<category term="${escapeXml(t.slug)}" label="${escapeXml(t.name)}"/>`,
+        ),
+      ].join("\n      ");
+
+      return [
+        "  <entry>",
+        `    <title type="html">${escapeXml(post.title)}</title>`,
+        `    <id>${postUrl}</id>`,
+        `    <updated>${updatedAt}</updated>`,
+        `    <published>${published}</published>`,
+        `    <author><name>${escapeXml(FEED_AUTHOR_NAME)}</name><email>${escapeXml(FEED_AUTHOR_EMAIL)}</email></author>`,
+        categories ? `    ${categories}` : null,
+        `    <link href="${postUrl}" rel="alternate" type="text/html"/>`,
+        `    <summary type="html">${escapeHtmlForAtom(post.summary)}</summary>`,
+        "  </entry>",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n");
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom">',
+    `  <title>${escapeXml(feedTitle)}</title>`,
+    `  <id>${feedId}</id>`,
+    `  <updated>${updated}</updated>`,
+    paginationLinks,
+    entries,
+    "</feed>",
+    "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export interface JsonFeedOptions {
+  page: number;
+  totalPages: number;
+  totalItems: number;
+}
+
+export function buildJsonFeed(
+  posts: RssPostRow[],
+  feedTitle: string,
+  feedDescription: string,
+  opts: JsonFeedOptions,
+): string {
+  const siteUrl = getSiteUrl();
+  const feedUrl = `${siteUrl}/feeds.json`;
+
+  const items = posts.map((post) => {
+    const postUrl = `${siteUrl}/blog/${post.slug}`;
+    return {
+      id: postUrl,
+      url: postUrl,
+      title: post.title,
+      summary: post.summary,
+      content_text: null as string | null,
+      content_html: null as string | null,
+      date_published: new Date(post.publishedAt).toISOString(),
+      date_modified: new Date(post.updatedAt).toISOString(),
+      author: { name: FEED_AUTHOR_NAME, url: null as string | null },
+      tags: [post.category.name, ...post.tags.map((t) => t.name)],
+      language: "en" as string,
+    };
+  });
+
+  const feed: Record<string, unknown> = {
+    version: "https://jsonfeed.org/version/1",
+    title: feedTitle,
+    home_page_url: siteUrl,
+    feed_url: feedUrl,
+    description: feedDescription,
+    icon: null,
+    favicon: null,
+    author: null,
+    items,
+  };
+
+  if (opts.page < opts.totalPages) {
+    feed.next_url = `${feedUrl}?page=${opts.page + 1}`;
+  }
+
+  return JSON.stringify(feed, null, 2);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2648,6 +2648,14 @@ video {
   margin-inline-end: auto;
 }
 
+.feed-switcher__hint {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+  opacity: 0.85;
+}
+
 .theme-toggle {
   display: inline-grid;
   width: 2.25rem;


### PR DESCRIPTION
Parity with https://quan.hoabinh.vn/feeds.atom / feeds.json

## Changes
- repository: queryRssPosts returns updatedAt/category/tags (join blog_post_tags), limit+offset + queryRssPostCount/getRssPostsPaginated (10/page, cached blog tag)
- rss.ts: buildRssFeed enriched (<author>, <category> per post, <language>); add buildAtomFeed (Atom 1.0 with first/last/next/prev) + buildJsonFeed (JSONFeed 1.1 with next_url) matching quan.hoabinh.vn structure
- routes: /feeds.atom (application/atom+xml) + /feeds.json (application/feed+json), dynamic force-dynamic, 5m cache, ?page=N (400/404), parity URLs /feeds.atom?page=X
- layout: autodiscovery adds Atom + JSONFeed links alongside RSS
- rss.test: fixtures updated

## Verification
- lint: 0 error (2 warnings bin/)
- typecheck: pass
- build --webpack: pass (adds /feeds.atom, /feeds.json)
- test: 147 pass
- feed URLs: /feed.xml (en), /vi/feed.xml (vi), /feeds.atom?page=1, /feeds.json?page=1

Closes: N/A (follow-up to feed discussion)
