### PR TITLE
fix(header): balance RSS icon

### DIFF
--- a/src/components/blog/article.tsx
+++ b/src/components/blog/article.tsx
@@ -161,7 +161,10 @@ export function Article({ locale, messages, post }: Readonly<ArticleProps>) {
             <Image
               alt={post.coverImage.alt}
               className="blog-article__cover"
+              fetchPriority="high"
               height={post.coverImage.height}
+              priority
+              sizes="(min-width: 64rem) 42rem, 100vw"
               src={post.coverImage.src}
               width={post.coverImage.width}
             />

--- a/src/components/blog/post-card.tsx
+++ b/src/components/blog/post-card.tsx
@@ -32,6 +32,7 @@ export function PostCard({ locale, messages, post }: Readonly<PostCardProps>) {
           alt={post.coverImage.alt}
           className="blog-card__cover"
           height={post.coverImage.height}
+          sizes="(min-width: 64rem) 22rem, (min-width: 48rem) 45vw, 90vw"
           src={post.coverImage.src}
           width={post.coverImage.width}
         />

--- a/src/components/navigation/feed-switcher.tsx
+++ b/src/components/navigation/feed-switcher.tsx
@@ -58,23 +58,29 @@ export function FeedSwitcher({ locale }: Readonly<FeedSwitcherProps>) {
         <svg
           aria-hidden="true"
           fill="none"
-          height="19"
+          height="20"
           viewBox="0 0 24 24"
-          width="19"
+          width="20"
         >
           <path
-            d="M4 11a9 9 0 0 1 9 9"
+            d="M3.5 10.5A12.5 12.5 0 0 1 16 23"
             stroke="currentColor"
-            strokeWidth="1.8"
+            strokeWidth="2"
             strokeLinecap="round"
           />
           <path
-            d="M4 15.5a4.5 4.5 0 0 1 4.5 4.5"
+            d="M3.5 15a8 8 0 0 1 8 8"
             stroke="currentColor"
-            strokeWidth="1.8"
+            strokeWidth="2"
             strokeLinecap="round"
           />
-          <circle cx="4.5" cy="19.5" r="1.5" fill="currentColor" />
+          <path
+            d="M3.5 19.2a3.8 3.8 0 0 1 3.8 3.8"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+          <circle cx="3.6" cy="20.2" r="1.7" fill="currentColor" />
         </svg>
       </button>
 

--- a/src/components/sections/home/hero-section.tsx
+++ b/src/components/sections/home/hero-section.tsx
@@ -111,8 +111,9 @@ export function HeroSection({ profile }: Readonly<HeroSectionProps>) {
               <Image
                 alt={profile.hero.image.alt}
                 className="home-hero__image"
+                fetchPriority="high"
                 height={profile.hero.image.height}
-                preload
+                priority
                 sizes="(min-width: 64rem) 42vw, (min-width: 48rem) 68vw, calc(100vw - 2rem)"
                 src={profile.hero.image.src}
                 style={{ objectPosition: profile.hero.image.focalPoint }}


### PR DESCRIPTION
RSS icon trước nhỏ/không cân do 2 arcs bán kính 9/4.5 chỉ chiếm 1/4 góc dưới-trái, trong khi globe/moon chiếm toàn bộ pill.

- Tăng lên 20x20, stroke 2, thêm arc thứ 3 (3.8), outer 12.5 để lấp đầy pill
- Dot 1.7 vs 1.5

Verification: lint 0 error, typecheck pass, build pass
