### PR TITLE
chore: ignore .worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 # Local system files and private keys
 .DS_Store
 *.pem
+.worktrees/


### PR DESCRIPTION
Allow parallel feature work via git worktrees without committing worktree contents. Needed for feat/newsletter-subscribe + feat/footer-tip parallel work.