### PR TITLE
feat(blog): cover image for ai-agents-2026-how-they-work

### DIFF
--- a/scripts/cover-ai-agents-2026-how-they-work.svg
+++ b/scripts/cover-ai-agents-2026-how-they-work.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <radialGradient id="glow" cx="78%" cy="42%" r="45%">
+      <stop offset="0%" stop-color="#E0B763" stop-opacity="0.20"/>
+      <stop offset="100%" stop-color="#E0B763" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="goldbar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#E0B763"/>
+      <stop offset="100%" stop-color="#C8963E"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="#161513"/>
+  <rect width="1600" height="900" fill="url(#glow)"/>
+  <rect x="0" y="0" width="12" height="900" fill="url(#goldbar)"/>
+
+  <!-- brand -->
+  <text x="80" y="110" font-family="DejaVu Sans, sans-serif" font-size="36" font-weight="bold" fill="#E0B763" letter-spacing="3">Khoa Watt</text>
+  <text x="330" y="110" font-family="DejaVu Sans, sans-serif" font-size="28" fill="#A39E93">· khoawatt.com</text>
+
+  <!-- category chip -->
+  <rect x="80" y="160" width="218" height="52" rx="26" fill="#E0B763" fill-opacity="0.16"/>
+  <text x="189" y="195" font-family="DejaVu Sans, sans-serif" font-size="24" font-weight="bold" fill="#E0B763" letter-spacing="2" text-anchor="middle">AI AGENTS</text>
+
+  <!-- title -->
+  <text x="80" y="340" font-family="DejaVu Sans, sans-serif" font-size="118" font-weight="bold" fill="#F5F1EA">AI Agents</text>
+  <text x="80" y="460" font-family="DejaVu Sans, sans-serif" font-size="118" font-weight="bold" fill="#F5F1EA">in 2026<tspan fill="#E0B763">.</tspan></text>
+  <text x="82" y="530" font-family="DejaVu Sans, sans-serif" font-size="30" fill="#C9C4B8">What they are · How they work · Why they matter</text>
+
+  <!-- flow strip -->
+  <g font-family="DejaVu Sans Mono, monospace" font-size="22" font-weight="bold">
+    <rect x="80" y="620" width="118" height="56" rx="12" fill="#242220" stroke="#C8963E" stroke-width="2"/>
+    <text x="139" y="656" fill="#E0B763" text-anchor="middle">Goal</text>
+    <text x="212" y="656" fill="#8A867E" font-size="26">→</text>
+    <rect x="244" y="620" width="118" height="56" rx="12" fill="#242220" stroke="#C8963E" stroke-width="2"/>
+    <text x="303" y="656" fill="#E0B763" text-anchor="middle">Plan</text>
+    <text x="376" y="656" fill="#8A867E" font-size="26">→</text>
+    <rect x="408" y="620" width="118" height="56" rx="12" fill="#242220" stroke="#C8963E" stroke-width="2"/>
+    <text x="467" y="656" fill="#E0B763" text-anchor="middle">Tool</text>
+    <text x="540" y="656" fill="#8A867E" font-size="26">→</text>
+    <rect x="572" y="620" width="156" height="56" rx="12" fill="#242220" stroke="#C8963E" stroke-width="2"/>
+    <text x="650" y="656" fill="#E0B763" text-anchor="middle">Observe</text>
+    <text x="742" y="656" fill="#8A867E" font-size="26">→</text>
+    <rect x="774" y="620" width="138" height="56" rx="12" fill="#242220" stroke="#C8963E" stroke-width="2"/>
+    <text x="843" y="656" fill="#E0B763" text-anchor="middle">Decide</text>
+    <text x="926" y="656" fill="#8A867E" font-size="26">→</text>
+    <rect x="958" y="620" width="158" height="56" rx="12" fill="#C8963E"/>
+    <text x="1037" y="656" fill="#161513" text-anchor="middle">Execute</text>
+  </g>
+
+  <!-- hub diagram right side -->
+  <g transform="translate(-50,0)">
+    <circle cx="1330" cy="430" r="150" fill="none" stroke="#C8963E" stroke-width="2" stroke-dasharray="6 8" opacity="0.7"/>
+    <circle cx="1330" cy="430" r="104" fill="#242220" stroke="#E0B763" stroke-width="3"/>
+    <text x="1330" y="422" font-family="DejaVu Sans, sans-serif" font-size="34" font-weight="bold" fill="#F5F1EA" text-anchor="middle">AGENT</text>
+    <text x="1330" y="458" font-family="DejaVu Sans Mono, monospace" font-size="16" fill="#A39E93" text-anchor="middle">plan · act · verify</text>
+
+    <g font-family="DejaVu Sans Mono, monospace" font-size="21" font-weight="bold" text-anchor="middle">
+      <line x1="1330" y1="326" x2="1330" y2="218" stroke="#C8963E" stroke-width="2"/>
+      <circle cx="1330" cy="188" r="44" fill="#242220" stroke="#E0B763" stroke-width="2"/>
+      <text x="1330" y="196" fill="#E0B763">Code</text>
+
+      <line x1="1420" y1="378" x2="1508" y2="326" stroke="#C8963E" stroke-width="2"/>
+      <circle cx="1536" cy="312" r="44" fill="#242220" stroke="#E0B763" stroke-width="2"/>
+      <text x="1536" y="320" fill="#E0B763">Web</text>
+
+      <line x1="1420" y1="482" x2="1508" y2="534" stroke="#C8963E" stroke-width="2"/>
+      <circle cx="1536" cy="548" r="44" fill="#242220" stroke="#E0B763" stroke-width="2"/>
+      <text x="1536" y="556" fill="#E0B763">API</text>
+
+      <line x1="1330" y1="534" x2="1330" y2="642" stroke="#C8963E" stroke-width="2"/>
+      <circle cx="1330" cy="672" r="44" fill="#242220" stroke="#E0B763" stroke-width="2"/>
+      <text x="1330" y="680" fill="#E0B763">DB</text>
+
+      <line x1="1240" y1="482" x2="1152" y2="534" stroke="#C8963E" stroke-width="2"/>
+      <circle cx="1124" cy="548" r="44" fill="#242220" stroke="#E0B763" stroke-width="2"/>
+      <text x="1124" y="556" fill="#E0B763">Files</text>
+
+      <line x1="1240" y1="378" x2="1152" y2="326" stroke="#C8963E" stroke-width="2"/>
+      <circle cx="1124" cy="312" r="44" fill="#242220" stroke="#E0B763" stroke-width="2"/>
+      <text x="1124" y="320" fill="#E0B763">Mem</text>
+    </g>
+  </g>
+
+  <text x="80" y="830" font-family="DejaVu Sans, sans-serif" font-size="24" fill="#A39E93">Autonomous AI agents · agentic AI · khoawatt.com/blog</text>
+</svg>

--- a/scripts/seed-blog-cover-ai-agents-2026.sql
+++ b/scripts/seed-blog-cover-ai-agents-2026.sql
@@ -1,0 +1,41 @@
+-- Cover for the first bilingual blog post (ai-agents-2026-how-they-work).
+--
+-- Uploads are NOT part of this file: place the rendered 1600x900 PNG at
+-- `blog-media/ai-agents-2026-how-they-work/cover.png` first, e.g.
+--   supabase storage cp <png> ss:///blog-media/ai-agents-2026-how-they-work/cover.png --local --experimental
+-- Source artwork: scripts/cover-ai-agents-2026-how-they-work.svg
+-- (regenerate with `node -e "require('sharp')('<svg>').png().toFile('<png>')"`).
+--
+-- Idempotent: safe to re-run (upserts by (bucket,path) / id).
+-- Local-first: apply with `supabase db query --local -f <this-file>`,
+-- verify, then promote with `--linked` only after human approval.
+--
+-- NOTE: wrapped in a single DO block because `supabase db query -f`
+-- executes the file as one prepared statement (multi-command files fail).
+
+DO $seed$
+BEGIN
+
+insert into media_assets (bucket, path, title, alt_en, alt_vi, width, height, size_bytes, mime) values
+  ('blog-media', 'ai-agents-2026-how-they-work/cover.png',
+   'AI Agents in 2026 — article cover',
+   'Editorial cover for the article AI Agents in 2026: dark background with gold accents, the six-stage agent loop Goal, Plan, Tool, Observe, Decide, Execute, and an agent hub connected to Code, Web, API, DB, Files and Memory tools.',
+   'Ảnh bìa bài viết AI Agent năm 2026: nền tối điểm vàng gold, vòng lặp sáu giai đoạn Goal, Plan, Tool, Observe, Decide, Execute và trung tâm agent nối tới các công cụ Code, Web, API, DB, Files và Memory.',
+   1600, 900, 158918, 'image/png')
+on conflict (bucket, path) do update set
+  title = excluded.title,
+  alt_en = excluded.alt_en,
+  alt_vi = excluded.alt_vi,
+  width = excluded.width,
+  height = excluded.height,
+  size_bytes = excluded.size_bytes,
+  mime = excluded.mime,
+  updated_at = now();
+
+update blog_posts
+set cover_bucket_path = 'ai-agents-2026-how-they-work/cover.png',
+    updated_at = now()
+where id = 'ai-agents-2026-how-they-work';
+
+END
+$seed$;


### PR DESCRIPTION
Closes #147 (follow-up of #145).

## What changed
- `scripts/cover-ai-agents-2026-how-they-work.svg` (new): 1600x900 source artwork, dark editorial + gold, Goal-to-Execute strip, agent hub diagram. Rendered to PNG via repo-local `sharp`.
- `scripts/seed-blog-cover-ai-agents-2026.sql` (new, idempotent): upserts `media_assets` row (1600x900, image/png, EN/VI alt) + sets `blog_posts.cover_bucket_path`.
- PNG bytes uploaded to `blog-media` local + linked at `ai-agents-2026-how-they-work/cover.png` (storage objects are not in git).

## Tests run
- Local: seed applied; uncached repository returns coverImage 800x450 with catalog EN alt; fresh dev render (after clearing stale Next persistent dev cache) shows cover via `/_next/image` srcset.
- Linked: storage object present; `media_assets` row 1600x900 image/png; post cover set + published.
- typecheck + build: see CI. Lint: no new issues (SVG/SQL not linted).
- Visual: @vision reviewed, 4 findings fixed (right margin, diagram gutter, small-text contrast, chip padding); radial-angle claim rebutted by measurement (29.8 deg).

## Cache note (important)
Direct SQL bypasses the admin `updateTag(blog)` path. The merge deploy carries a cold data cache, so the first post-deploy fetch reads the already-seeded cover state — no admin save needed. Verified live after merge.

## Docs affected
- None.