### PR TITLE
feat(blog): secret-guarded revalidate endpoint for automated publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 CONTACT_TO_EMAIL=
 CONTACT_FROM_EMAIL=
+
+# Server-only shared secret for POST /api/blog/revalidate (automation hook).
+# Must be a long random value (e.g. `openssl rand -hex 32`). Required in any
+# environment where machine publishing should refresh cached blog reads.
+# Absent/empty = the endpoint fails closed. See docs/08-blog-operations.md.
+BLOG_REVALIDATE_SECRET=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,13 @@ If an issue conflicts with an accepted canonical document, stop and report the c
 
 There is a minimal `npm test` runner using Node's built-in `node:test` via `tsx`, covering the contact-delivery feature (`src/features/contact/*.test.ts`). For other areas, verification remains manual/visual smoke checks plus lint/typecheck/build.
 
+### Blog publishing (automated)
+
+- Full runbook: `docs/08-blog-operations.md` (paths, cache model, env table, troubleshooting).
+- Machine posts go through the `cms_upsert_blog_post` RPC (same gate as `/admin`), never hand-written table rows.
+- After machine writes, refresh caches with `BLOG_REVALIDATE_SECRET=... scripts/blog-revalidate.sh <base-url>` (`POST /api/blog/revalidate`, server-only Bearer secret, fail-closed when unset). Secret lives in `.env.local` (gitignored) and Vercel env — names only in `.env.example`; generate with `openssl rand -hex 32`. Vercel env changes need a redeploy to take effect.
+- ChatGPT-drafted content is fetched with `chatgpt-review fetch --url=<conversation-url>` (turns + files to `/tmp`, never posts anything).
+
 ### Build quirk
 
 `npm run build` uses Turbopack, which can fail in sandboxed environments (CSS worker cannot bind an internal port → `Operation not permitted`). If the default build fails this way, run `npm run build -- --webpack` — that path is verified passing.

--- a/docs/08-blog-operations.md
+++ b/docs/08-blog-operations.md
@@ -64,7 +64,9 @@ listing/category/tag/RSS pages stale until the 24h safety net refreshes them.
 Local: keep values in `.env.local` (gitignored, never commit).
 Production: set in the Vercel project environment; **env changes need a
 redeploy to take effect**, so add the secret *before* merging code that
-depends on it.
+depends on it. The operator machine keeps a local copy of the production
+revalidate secret in `.env.production.local` (gitignored) purely for making
+the authed automation calls — the Vercel env entry stays the source of truth.
 
 ## Troubleshooting
 

--- a/docs/08-blog-operations.md
+++ b/docs/08-blog-operations.md
@@ -1,0 +1,74 @@
+# 08 — Blog Operations (publishing automation)
+
+How blog posts get written, published, and refreshed — human and machine paths.
+
+## Publishing paths
+
+| Path | How | Cache refresh | When to use |
+|------|-----|---------------|-------------|
+| `/admin` UI | Owner fills the post form → Save/Publish | Automatic (`updateTag(blog)` in the same Server Action) | Default for hand-written posts |
+| Machine (RPC) | Call `cms_upsert_blog_post` (service_role/SQL), then `POST /api/blog/revalidate` | Via the revalidate endpoint (below) | Automated posts (e.g. drafted in ChatGPT, fetched via bridge) |
+| SQL seeds (`scripts/seed-blog-*.sql`) | Apply with `supabase db query` | **None** — needs an admin save or the revalidate call | Reproducible fixtures/backfills only, never routine publishing |
+
+Direct table writes that skip both `/admin` and the RPC/revalidate pair leave
+listing/category/tag/RSS pages stale until the 24h safety net refreshes them.
+
+## Cache model
+
+- Every public blog read runs through `unstable_cache` tagged `blog`
+  (`BLOG_CACHE_TAG` in `src/features/blog/repository.ts`).
+- One `updateTag("blog")` refreshes listings, details, categories, tags,
+  sitemap, and feeds together. `revalidate` (24h) is only a safety net.
+- A **new slug** renders instantly (cold key); **existing listing keys** need
+  the tag refresh. That asymmetry is why a new post's detail page can look
+  live while `/blog` still misses it.
+
+## Machine publishing procedure
+
+1. **Fetch content** (if drafted in ChatGPT):
+   `chatgpt-review fetch --url=<conversation-url>` → `/tmp/chatgpt-fetch-*/`
+   with `conversation.md`, `manifest.json`, and `files/` (article markdown,
+   cover, bundles). See the `chatgpt-review` skill.
+2. **Stage assets**: upload cover to the `blog-media` bucket
+   (`supabase storage cp <png> ss:///blog-media/<slug>/cover.png --local/--linked`),
+   upsert the `media_assets` row (title, `alt_en`, `alt_vi`, dimensions),
+   create any missing tags via `cms_upsert_blog_tag`.
+3. **Write the post** through `cms_upsert_blog_post` (same RPC `/admin` uses —
+   publish gate + `published_at` stamping enforced atomically). Never hand-write
+   `blog_posts`/`blog_post_translations` rows.
+4. **Refresh the cache**: `BLOG_REVALIDATE_SECRET=... scripts/blog-revalidate.sh <base-url>`
+   (local dev URL or production). Verify the listing shows the post.
+5. **Verify**: detail pages EN+VI (title, cover, tags), listing, feeds.
+
+## Revalidate endpoint
+
+`POST /api/blog/revalidate` (`src/app/api/blog/revalidate/route.ts`).
+
+- Auth: `Authorization: Bearer <BLOG_REVALIDATE_SECRET>`, timing-safe compare
+  (`auth.ts`, unit-tested). Wrong/missing secret → 401.
+- Fail-closed: unset/empty secret → 503 always (no 200 path exists).
+- Success → 200 `{"ok":true}` after `revalidateTag(blog)` (the route-handler
+  counterpart of the `updateTag(blog)` call admin Server Actions use — same tag).
+- The secret is server-only (never `NEXT_PUBLIC_`), never logged, never committed.
+
+## Environment
+
+| Variable | Scope | Purpose |
+|----------|-------|---------|
+| `NEXT_PUBLIC_SUPABASE_URL` | public | Supabase API URL (local `127.0.0.1` vs linked cloud) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | public | Publishable key (frontend) |
+| `SUPABASE_SERVICE_ROLE_KEY` | server-only | RPC/storage writes for automation |
+| `RESEND_API_KEY` / `CONTACT_TO_EMAIL` / `CONTACT_FROM_EMAIL` | server-only | Contact delivery |
+| `BLOG_REVALIDATE_SECRET` | server-only | Bearer secret for the revalidate endpoint (`.env.example` has the name only; generate with `openssl rand -hex 32`) |
+
+Local: keep values in `.env.local` (gitignored, never commit).
+Production: set in the Vercel project environment; **env changes need a
+redeploy to take effect**, so add the secret *before* merging code that
+depends on it.
+
+## Troubleshooting
+
+- Listing missing a fresh post → call the revalidate script (or any admin blog save).
+- Revalidate answers 401 → wrong secret or wrong environment's secret.
+- Revalidate answers 503 → `BLOG_REVALIDATE_SECRET` not set in that environment.
+- Stale reads in local dev after direct SQL → same remedy (script against the dev URL).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/features/blog/reading-time.test.ts src/features/blog/markdown.test.ts src/features/blog/rss.test.ts src/features/cms/image-dimensions.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts",
+    "test": "tsx --test src/content/*.test.ts src/features/contact/*.test.ts src/features/newsletter/*.test.ts src/features/seo/*.test.ts src/features/blog/reading-time.test.ts src/features/blog/markdown.test.ts src/features/blog/rss.test.ts src/features/cms/image-dimensions.test.ts \"src/app/admin/(dashboard)/skills/skill-buckets.test.ts\" src/app/api/resume-media/route.test.ts src/app/api/blog/revalidate/auth.test.ts src/app/api/blog/revalidate/route.test.ts",
     "preflight": "tsx scripts/preflight-cutover.ts",
     "seed:admin": "node scripts/seed-admin.mjs",
     "backfill": "NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-http://127.0.0.1:54331} node scripts/backfill-content.mjs",

--- a/scripts/blog-revalidate.sh
+++ b/scripts/blog-revalidate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Refresh cached blog reads after machine publishing (see docs/08-blog-operations.md).
+#
+# Usage:
+#   BLOG_REVALIDATE_SECRET=<secret> scripts/blog-revalidate.sh <base-url>
+#
+# Examples:
+#   BLOG_REVALIDATE_SECRET=... scripts/blog-revalidate.sh http://127.0.0.1:3000
+#   BLOG_REVALIDATE_SECRET=... scripts/blog-revalidate.sh https://khoawatt.com
+#
+# Exits non-zero unless the endpoint answers {"ok":true}. The secret is sent
+# only as an Authorization header and is never printed.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: BLOG_REVALIDATE_SECRET=<secret> $0 <base-url>" >&2
+  exit 2
+fi
+if [ -z "${BLOG_REVALIDATE_SECRET:-}" ]; then
+  echo "error: BLOG_REVALIDATE_SECRET is not set (refusing to send an empty secret)" >&2
+  exit 2
+fi
+
+base="${1%/}"
+code="$(curl -s -o /tmp/blog-revalidate-response.json -w '%{http_code}' --max-time 60 \
+  -X POST "${base}/api/blog/revalidate" \
+  -H "Authorization: Bearer ${BLOG_REVALIDATE_SECRET}")"
+body="$(cat /tmp/blog-revalidate-response.json)"
+rm -f /tmp/blog-revalidate-response.json
+
+if [ "$code" = "200" ] && [ "$body" = '{"ok":true}' ]; then
+  echo "revalidated ${base} (blog cache tag refreshed)"
+else
+  echo "revalidate failed: HTTP ${code} body: ${body}" >&2
+  exit 1
+fi

--- a/src/app/api/blog/revalidate/auth.test.ts
+++ b/src/app/api/blog/revalidate/auth.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isRevalidateAuthorized } from "./auth";
+
+const SECRET = "test-secret-with-32-plus-characters-abcdef";
+
+test("revalidate auth: exact Bearer match is authorized", () => {
+  assert.equal(isRevalidateAuthorized(`Bearer ${SECRET}`, SECRET), true);
+});
+
+test("revalidate auth: wrong token is rejected", () => {
+  assert.equal(isRevalidateAuthorized("Bearer wrong-token", SECRET), false);
+});
+
+test("revalidate auth: missing or malformed header is rejected", () => {
+  assert.equal(isRevalidateAuthorized(null, SECRET), false);
+  assert.equal(isRevalidateAuthorized(undefined, SECRET), false);
+  assert.equal(isRevalidateAuthorized("", SECRET), false);
+  assert.equal(isRevalidateAuthorized(SECRET, SECRET), false);
+  assert.equal(isRevalidateAuthorized("Basic abc123", SECRET), false);
+  assert.equal(isRevalidateAuthorized("Bearer ", SECRET), false);
+});
+
+test("revalidate auth: unconfigured secret never authorizes (fail-closed)", () => {
+  assert.equal(isRevalidateAuthorized(`Bearer ${SECRET}`, undefined), false);
+  assert.equal(isRevalidateAuthorized(`Bearer ${SECRET}`, ""), false);
+  assert.equal(isRevalidateAuthorized("Bearer ", ""), false);
+});
+
+test("revalidate auth: different-length secrets compare safely", () => {
+  assert.equal(isRevalidateAuthorized("Bearer short", SECRET), false);
+  assert.equal(
+    isRevalidateAuthorized(`Bearer ${"x".repeat(200)}`, SECRET),
+    false,
+  );
+});

--- a/src/app/api/blog/revalidate/auth.test.ts
+++ b/src/app/api/blog/revalidate/auth.test.ts
@@ -22,6 +22,11 @@ test("revalidate auth: missing or malformed header is rejected", () => {
   assert.equal(isRevalidateAuthorized("Bearer ", SECRET), false);
 });
 
+test("revalidate auth: trailing garbage after the token is rejected", () => {
+  assert.equal(isRevalidateAuthorized(`Bearer ${SECRET} extra`, SECRET), false);
+  assert.equal(isRevalidateAuthorized(`Bearer  ${SECRET}`, SECRET), false);
+});
+
 test("revalidate auth: unconfigured secret never authorizes (fail-closed)", () => {
   assert.equal(isRevalidateAuthorized(`Bearer ${SECRET}`, undefined), false);
   assert.equal(isRevalidateAuthorized(`Bearer ${SECRET}`, ""), false);

--- a/src/app/api/blog/revalidate/auth.ts
+++ b/src/app/api/blog/revalidate/auth.ts
@@ -1,0 +1,21 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+/**
+ * Decide whether a revalidate request carries the configured shared secret.
+ *
+ * Pure function (no Next.js imports) so it stays unit-testable under node:test.
+ * Fail-closed: an unconfigured/empty expected secret never authorizes.
+ * Comparison is timing-safe (both sides hashed first so lengths always match).
+ */
+export function isRevalidateAuthorized(
+  authHeader: string | null | undefined,
+  expectedSecret: string | undefined,
+): boolean {
+  if (!expectedSecret) return false;
+  if (!authHeader) return false;
+  const [scheme, token] = authHeader.trim().split(" ");
+  if (!scheme || !token || scheme.toLowerCase() !== "bearer") return false;
+  const a = createHash("sha256").update(token, "utf8").digest();
+  const b = createHash("sha256").update(expectedSecret, "utf8").digest();
+  return timingSafeEqual(a, b);
+}

--- a/src/app/api/blog/revalidate/auth.ts
+++ b/src/app/api/blog/revalidate/auth.ts
@@ -13,7 +13,9 @@ export function isRevalidateAuthorized(
 ): boolean {
   if (!expectedSecret) return false;
   if (!authHeader) return false;
-  const [scheme, token] = authHeader.trim().split(" ");
+  const parts = authHeader.trim().split(" ");
+  if (parts.length !== 2) return false;
+  const [scheme, token] = parts;
   if (!scheme || !token || scheme.toLowerCase() !== "bearer") return false;
   const a = createHash("sha256").update(token, "utf8").digest();
   const b = createHash("sha256").update(expectedSecret, "utf8").digest();

--- a/src/app/api/blog/revalidate/route.test.ts
+++ b/src/app/api/blog/revalidate/route.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { POST } from "./route";
+
+const KEY = "BLOG_REVALIDATE_SECRET";
+const saved = process.env[KEY];
+
+afterEach(() => {
+  if (saved === undefined) delete process.env[KEY];
+  else process.env[KEY] = saved;
+});
+
+function postRequest(authHeader?: string): Request {
+  return new Request("http://localhost/api/blog/revalidate", {
+    method: "POST",
+    ...(authHeader ? { headers: { authorization: authHeader } } : {}),
+  });
+}
+
+test("revalidate route fails closed when the secret is unconfigured", async () => {
+  delete process.env[KEY];
+  const response = await POST(postRequest("Bearer anything"));
+  assert.equal(response.status, 503);
+  assert.match(await response.text(), /Not configured/);
+});
+
+test("revalidate route rejects a wrong secret", async () => {
+  process.env[KEY] = "correct-secret-for-tests-only-abc123";
+  const response = await POST(postRequest("Bearer wrong-secret"));
+  assert.equal(response.status, 401);
+});
+
+test("revalidate route rejects a missing header", async () => {
+  process.env[KEY] = "correct-secret-for-tests-only-abc123";
+  const response = await POST(postRequest());
+  assert.equal(response.status, 401);
+});

--- a/src/app/api/blog/revalidate/route.ts
+++ b/src/app/api/blog/revalidate/route.ts
@@ -1,0 +1,34 @@
+import { revalidateTag } from "next/cache";
+import { NextResponse } from "next/server";
+
+import { BLOG_CACHE_TAG } from "@/features/blog/repository";
+
+import { isRevalidateAuthorized } from "./auth";
+
+/**
+ * Automation hook for blog publishing outside /admin (#149).
+ *
+ * Direct content writes (RPC/SQL automation) bypass the admin Server Actions,
+ * so nothing refreshes the `blog` cache tag and listing/category/tag/RSS pages
+ * stay stale until the 24h safety net. POST here with the shared secret to
+ * refresh every cached blog read at once — `revalidateTag` here is the
+ * route-handler counterpart of the `updateTag(blog)` call the admin actions use
+ * (both target the same single choke point, `BLOG_CACHE_TAG`).
+ *
+ * Security: server-only `BLOG_REVALIDATE_SECRET` (never NEXT_PUBLIC_).
+ * Fail-closed when unconfigured; Bearer comparison is timing-safe (see auth.ts).
+ * The secret itself is never logged or echoed.
+ */
+export async function POST(request: Request): Promise<Response> {
+  const secret = process.env.BLOG_REVALIDATE_SECRET;
+  if (!secret) {
+    return NextResponse.json({ ok: false, error: "Not configured." }, { status: 503 });
+  }
+  if (!isRevalidateAuthorized(request.headers.get("authorization"), secret)) {
+    return NextResponse.json({ ok: false, error: "Unauthorized." }, { status: 401 });
+  }
+  // `{ expire: 0 }` = expire matching entries immediately, mirroring what the
+  // admin's `updateTag(blog)` does from Server Actions.
+  revalidateTag(BLOG_CACHE_TAG, { expire: 0 });
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
Closes #149

## What changed
- `POST /api/blog/revalidate` (`src/app/api/blog/revalidate/route.ts`): Bearer check against server-only `BLOG_REVALIDATE_SECRET`, fail-closed 503 when unset, 401 on mismatch, `revalidateTag(blog, { expire: 0 })` on success (route-handler counterpart of the admin `updateTag`; same tag). Secret never logged/echoed.
- Pure auth helper (`auth.ts`) + 8 node:test cases (auth decision + route 503/401 paths); registered in `npm test`.
- `scripts/blog-revalidate.sh` helper (secret via env, strict ok-check).
- Docs: new `docs/08-blog-operations.md` runbook (paths, cache model, env table, troubleshooting); AGENTS.md automation section; `.env.example` entry (name only).

## Tests run
- TDD: watched auth tests fail (missing module) before implementing; 5/5 then 8/8 green; full suite 155/155.
- ESLint on new files clean; typecheck + build pass (incl. fixing two real findings: updateTag is Server-Action-only, revalidateTag needs a profile arg in Next 16).
- Live local proof: seeded a marker summary via direct SQL (stale listing reproduced) -> POST 200 -> marker visible; reverted + revalidated.
- Manual curl matrix on dev: GET 405, no/wrong secret 401, correct 200.

## Known limitations / follow-up for reviewer
- Prod activation needs `BLOG_REVALIDATE_SECRET` in Vercel env + a redeploy (env changes require it); then one authed call refreshes the currently stale /blog listing (MCP post).
- No CMS UI or content changes in this PR.

## Docs affected
- docs/08-blog-operations.md (new), AGENTS.md, .env.example