### PR TITLE
feat(home): blog preview section on the landing page

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { Container } from "@/components/layout/container";
 import { PageShell } from "@/components/layout/page-shell";
+import { BlogPreviewSection } from "@/components/sections/blog/blog-preview-section";
 import { ContactSection } from "@/components/sections/contact/contact-section";
 import { HeroSection } from "@/components/sections/home/hero-section";
 import { ProjectsSection } from "@/components/sections/projects/projects-section";
@@ -25,6 +26,20 @@ import { navigationSectionIds } from "@/features/navigation/config";
 interface LocalePageProps {
   params: Promise<{ locale: string }>;
 }
+
+/**
+ * Sections rendered by dedicated components above. Any future section id
+ * without a component yet falls through to the generic placeholder below.
+ */
+const dedicatedSectionIds: ReadonlySet<string> = new Set([
+  "home",
+  "about",
+  "skills",
+  "projects",
+  "resume",
+  "blog",
+  "contact",
+]);
 
 export async function generateMetadata({
   params,
@@ -61,9 +76,12 @@ export default async function LocalePage({
       ) : (
         <ResumeSection content={await getCmsResume(locale)} />
       )}
+      <BlogPreviewSection locale={locale} messages={messages.blog} />
       <ContactSection content={contact} />
 
-      {navigationSectionIds.slice(6).map((sectionId) => (
+      {navigationSectionIds
+        .filter((sectionId) => !dedicatedSectionIds.has(sectionId))
+        .map((sectionId) => (
         <section
           aria-labelledby={`${sectionId}-anchor-title`}
           className="navigation-anchor navigation-anchor--placeholder"

--- a/src/components/navigation/site-header.tsx
+++ b/src/components/navigation/site-header.tsx
@@ -54,12 +54,15 @@ export function SiteHeader({
 
   useEffect(() => {
     function updateActiveSection() {
-      // Blog is a multi-route page link, not an anchor section: it is active on
-      // every blog route, independent of scroll position.
-      const blogPrefix = `${blogPath}/`;
-      if (window.location.pathname === blogPath || window.location.pathname.startsWith(blogPrefix)) {
-        setActiveSection("blog");
-        return;
+      // Home renders #blog as a real anchor section, so scroll-spy decides
+      // there. On blog routes no #blog element exists — keep Blog highlighted
+      // by route instead.
+      if (!document.getElementById("blog")) {
+        const blogPrefix = `${blogPath}/`;
+        if (window.location.pathname === blogPath || window.location.pathname.startsWith(blogPrefix)) {
+          setActiveSection("blog");
+          return;
+        }
       }
 
       const headerBottom = headerRef.current?.getBoundingClientRect().bottom ?? 0;
@@ -357,13 +360,8 @@ export function SiteHeader({
             <nav aria-label={messages.primaryNavigation}>
               <ul className="site-navigation__list">
                 {primaryNavigationIds.map((itemId) => {
-                  const isBlog = itemId === "blog";
                   const href =
-                    isBlog
-                      ? blogPath
-                      : itemId === "home"
-                        ? homePath
-                        : `#${itemId}`;
+                    itemId === "home" ? homePath : `#${itemId}`;
 
                   return (
                     <li key={itemId}>
@@ -373,13 +371,10 @@ export function SiteHeader({
                         }
                         className="site-navigation__link"
                         href={href}
-                        onClick={
-                          isBlog
-                            ? undefined
-                            : (event) =>
-                                itemId === "home"
-                                  ? navigateHome(event)
-                                  : navigateToSection(event, itemId)
+                        onClick={(event) =>
+                          itemId === "home"
+                            ? navigateHome(event)
+                            : navigateToSection(event, itemId)
                         }
                       >
                         {messages.sections[itemId]}

--- a/src/components/sections/blog/blog-preview-section.tsx
+++ b/src/components/sections/blog/blog-preview-section.tsx
@@ -1,0 +1,189 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { Container } from "@/components/layout/container";
+import { SectionHeading } from "@/components/ui/section-heading";
+import { getPublishedPosts } from "@/features/blog/repository";
+import type { PostListItem } from "@/features/blog/types";
+import type { Locale } from "@/features/i18n/config";
+import type { BlogMessages } from "@/features/i18n/messages/types";
+import { getLocalizedPathname } from "@/features/i18n/routing";
+
+interface BlogPreviewSectionProps {
+  locale: Locale;
+  messages: BlogMessages;
+}
+
+/** Newest posts shown on the home page; the listing page keeps paginating. */
+const PREVIEW_POST_COUNT = 4;
+
+/** Fixed pill tones (own design tokens, see globals.css `.blog-preview__pill`). */
+export const BLOG_PREVIEW_PILL_TONES = 6;
+
+/**
+ * Deterministic pill tone per category slug so a category keeps the same
+ * color across renders and locales.
+ */
+export function toneForCategorySlug(slug: string): number {
+  let hash = 0;
+
+  for (let index = 0; index < slug.length; index += 1) {
+    hash = (hash * 31 + slug.charCodeAt(index)) >>> 0;
+  }
+
+  return hash % BLOG_PREVIEW_PILL_TONES;
+}
+
+type PreviewCardSize = "large" | "wide" | "small" | "standard";
+
+interface PreviewCardProps {
+  locale: Locale;
+  messages: BlogMessages;
+  post: PostListItem;
+  size: PreviewCardSize;
+}
+
+function PreviewCard({ locale, messages, post, size }: Readonly<PreviewCardProps>) {
+  const href = getLocalizedPathname(`/blog/${post.slug}`, locale);
+  const localeTag = locale === "vi" ? "vi-VN" : "en-US";
+  const date = new Intl.DateTimeFormat(localeTag, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(post.publishedAt));
+  const readTime = messages.readMinutes.replace(
+    "{count}",
+    String(post.readingTimeMinutes),
+  );
+
+  return (
+    <article className="blog-preview__card" data-size={size}>
+      {post.coverImage ? (
+        <Image
+          alt={post.coverImage.alt}
+          className="blog-preview__cover"
+          height={post.coverImage.height}
+          sizes="(min-width: 64rem) 36rem, (min-width: 48rem) 45vw, 90vw"
+          src={post.coverImage.src}
+          width={post.coverImage.width}
+        />
+      ) : (
+        <div
+          aria-hidden="true"
+          className="blog-preview__cover blog-preview__cover--placeholder"
+        />
+      )}
+      <div aria-hidden="true" className="blog-preview__scrim" />
+      <div className="blog-preview__body">
+        <p
+          className="blog-preview__pill"
+          data-tone={toneForCategorySlug(post.category.slug)}
+        >
+          {post.category.name}
+        </p>
+        <h3 className="blog-preview__title">
+          <Link className="blog-preview__link" href={href}>
+            {post.title}
+          </Link>
+        </h3>
+        <p className="blog-preview__meta">
+          <time dateTime={post.publishedAt}>{date}</time>
+          <span aria-hidden="true" className="blog-preview__meta-separator">
+            ·
+          </span>
+          <span>{readTime}</span>
+        </p>
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Home-page blog preview (server component). Reads through the cached
+ * repository reader like the listing page; renders nothing when no post is
+ * published so the page still builds with zero posts.
+ */
+export async function BlogPreviewSection({
+  locale,
+  messages,
+}: Readonly<BlogPreviewSectionProps>) {
+  const posts = (await getPublishedPosts(locale, 1)).posts.slice(
+    0,
+    PREVIEW_POST_COUNT,
+  );
+
+  if (posts.length === 0) {
+    return null;
+  }
+
+  const isMosaic = posts.length >= PREVIEW_POST_COUNT;
+  const blogPath = getLocalizedPathname("/blog", locale);
+  const mosaicSizes: readonly PreviewCardSize[] = [
+    "large",
+    "wide",
+    "small",
+    "small",
+  ];
+
+  return (
+    <section
+      aria-labelledby="blog-title"
+      className="blog-preview-section navigation-anchor"
+      id="blog"
+    >
+      <Container>
+        <div className="blog-preview-section__intro">
+          <SectionHeading
+            description={messages.previewIntro}
+            eyebrow={messages.previewEyebrow}
+            title={messages.previewTitle}
+            titleId="blog-title"
+          />
+        </div>
+
+        <div
+          className="blog-preview__grid"
+          data-count={posts.length}
+          data-layout={isMosaic ? "mosaic" : "simple"}
+        >
+          {posts.map((post, index) => (
+            <PreviewCard
+              key={post.slug}
+              locale={locale}
+              messages={messages}
+              post={post}
+              size={
+                isMosaic
+                  ? (mosaicSizes[index] ?? "small")
+                  : index === 0
+                    ? "large"
+                    : "standard"
+              }
+            />
+          ))}
+        </div>
+
+        <div className="blog-preview-section__actions">
+          <Link className="blog-preview__see-more" href={blogPath}>
+            {messages.previewSeeMore}
+            <svg
+              aria-hidden="true"
+              className="blog-preview__see-more-arrow"
+              fill="none"
+              height="16"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </Link>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/components/sections/footer/footer-section.tsx
+++ b/src/components/sections/footer/footer-section.tsx
@@ -3,7 +3,6 @@ import type { FooterContentView } from "@/content/footer";
 import type { Locale } from "@/features/i18n/config";
 import type { HeaderMessages } from "@/features/i18n/messages/types";
 import {
-  blogNavigationPath,
   primaryNavigationIds,
 } from "@/features/navigation/config";
 import { getLocalizedPathname } from "@/features/i18n/routing";
@@ -93,12 +92,8 @@ export function FooterSection({
             </h3>
             <ul className="site-footer__links">
               {primaryNavigationIds.map((itemId) => {
-                const isBlog = itemId === "blog";
-                const href = isBlog
-                  ? getLocalizedPathname(blogNavigationPath, locale)
-                  : itemId === "home"
-                    ? rootPath
-                    : `${rootPath}#${itemId}`;
+                const href =
+                  itemId === "home" ? rootPath : `${rootPath}#${itemId}`;
 
                 return (
                   <li key={itemId}>

--- a/src/features/i18n/messages/en.ts
+++ b/src/features/i18n/messages/en.ts
@@ -61,6 +61,11 @@ const messages = {
     markdownViewLabel: "View .md",
     markdownCopiedLabel: "Copied markdown",
     markdownCopyErrorLabel: "Copy failed",
+    previewEyebrow: "Blog",
+    previewTitle: "Latest from the blog",
+    previewIntro:
+      "Recent writing on the web, engineering, and the tools shaping how I build.",
+    previewSeeMore: "See more",
   },
   themeToggle: {
     toggle: "Toggle color theme",

--- a/src/features/i18n/messages/types.ts
+++ b/src/features/i18n/messages/types.ts
@@ -55,6 +55,10 @@ export interface BlogMessages {
   markdownViewLabel: string;
   markdownCopiedLabel: string;
   markdownCopyErrorLabel: string;
+  previewEyebrow: string;
+  previewTitle: string;
+  previewIntro: string;
+  previewSeeMore: string;
 }
 
 export interface AdminFaviconMessages {

--- a/src/features/i18n/messages/vi.ts
+++ b/src/features/i18n/messages/vi.ts
@@ -61,6 +61,11 @@ const messages = {
     markdownViewLabel: "Xem .md",
     markdownCopiedLabel: "Đã sao chép",
     markdownCopyErrorLabel: "Sao chép thất bại",
+    previewEyebrow: "Bài viết",
+    previewTitle: "Bài viết mới nhất",
+    previewIntro:
+      "Các bài viết gần đây về web, kỹ thuật và những công cụ định hình cách tôi xây dựng.",
+    previewSeeMore: "Xem thêm",
   },
   themeToggle: {
     toggle: "Chuyển giao diện màu",

--- a/src/features/navigation/config.ts
+++ b/src/features/navigation/config.ts
@@ -4,12 +4,13 @@ export const navigationSectionIds = [
   "skills",
   "projects",
   "resume",
+  "blog",
   "contact",
 ] as const;
 
 export type NavigationSectionId = (typeof navigationSectionIds)[number];
 
-/** Blog is the first multi-route area; it is a page link, not an anchor. */
+/** Blog is both a home-page anchor section and a multi-route area (/blog). */
 export type NavigationItemId = NavigationSectionId | "blog";
 
 /** Header/footer order: Blog sits between Resume and Contact (spec §8.1). */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4599,6 +4599,249 @@ video {
   background: oklch(31% 0.08 82);
 }
 
+/* --- Home blog preview (mosaic: large + wide + 2 small overlay cards) --- */
+
+.blog-preview-section {
+  padding-block: var(--section-space);
+  background: var(--color-surface-subtle);
+}
+
+.blog-preview-section__intro {
+  display: grid;
+  gap: var(--space-8);
+}
+
+.blog-preview__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-4);
+  margin-block-start: var(--space-10);
+}
+
+.blog-preview__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: 16rem;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  isolation: isolate;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.blog-preview__card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+.blog-preview__card:has(.blog-preview__link:focus-visible) {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 3px;
+}
+
+.blog-preview__cover {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 240ms ease;
+}
+
+.blog-preview__card:hover .blog-preview__cover {
+  transform: scale(1.03);
+}
+
+.blog-preview__cover--placeholder {
+  background: linear-gradient(135deg, var(--color-accent-soft), var(--color-surface-subtle));
+}
+
+/* Dark scrim in both themes so overlay text keeps contrast on any cover. */
+.blog-preview__scrim {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: linear-gradient(
+    to top,
+    rgb(0 0 0 / 0.85) 0%,
+    rgb(0 0 0 / 0.5) 45%,
+    rgb(0 0 0 / 0.08) 75%
+  );
+}
+
+.blog-preview__body {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-5);
+  align-content: end;
+}
+
+.blog-preview__pill {
+  width: fit-content;
+  margin: 0;
+  padding: 0.125rem var(--space-3);
+  border-radius: var(--radius-pill);
+  color: #fff;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.blog-preview__pill[data-tone="0"] { background: #1e40af; }
+.blog-preview__pill[data-tone="1"] { background: #065f46; }
+.blog-preview__pill[data-tone="2"] { background: #92400e; }
+.blog-preview__pill[data-tone="3"] { background: #6b21a8; }
+.blog-preview__pill[data-tone="4"] { background: #9f1239; }
+.blog-preview__pill[data-tone="5"] { background: #155e75; }
+
+.blog-preview__title {
+  margin: 0;
+  color: #fff;
+  font-size: var(--font-size-lg);
+  line-height: 1.3;
+  text-wrap: balance;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.blog-preview__card[data-size="large"] .blog-preview__title {
+  font-size: var(--font-size-xl);
+  -webkit-line-clamp: 3;
+}
+
+.blog-preview__card[data-size="wide"] .blog-preview__title {
+  font-size: clamp(1.125rem, 1rem + 0.5vw, 1.375rem);
+}
+
+.blog-preview__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-preview__link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.blog-preview__link:focus {
+  outline: none;
+}
+
+.blog-preview__link:focus-visible {
+  outline: none;
+}
+
+.blog-preview__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  color: rgb(255 255 255 / 0.82);
+  font-size: var(--font-size-sm);
+}
+
+.blog-preview__meta-separator {
+  color: rgb(255 255 255 / 0.6);
+}
+
+.blog-preview-section__actions {
+  display: flex;
+  justify-content: center;
+  margin-block-start: var(--space-10);
+}
+
+.blog-preview__see-more {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 2.75rem;
+  padding: var(--space-3) var(--space-6);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transition:
+    border-color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.blog-preview__see-more:hover {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  transform: translateY(-1px);
+}
+
+.blog-preview__see-more:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.blog-preview__see-more-arrow {
+  transition: transform 160ms ease;
+}
+
+.blog-preview__see-more:hover .blog-preview__see-more-arrow {
+  transform: translateX(4px);
+}
+
+@media (min-width: 48rem) {
+  .blog-preview__grid[data-layout="mosaic"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="large"],
+  .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="wide"] {
+    grid-column: 1 / -1;
+  }
+
+  .blog-preview__grid[data-layout="simple"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .blog-preview__grid[data-layout="simple"] .blog-preview__card[data-size="large"] {
+    grid-column: 1 / -1;
+    min-height: 20rem;
+  }
+}
+
+@media (min-width: 64rem) {
+  .blog-preview__grid[data-layout="mosaic"] {
+    grid-template-columns: 1.2fr 1fr 1fr;
+  }
+
+  .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="large"] {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    min-height: 30rem;
+  }
+
+  .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="wide"] {
+    grid-column: 2 / span 2;
+    grid-row: 1;
+    min-height: 0;
+  }
+
+  .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="small"] {
+    aspect-ratio: 1 / 1;
+    min-height: 0;
+  }
+}
+
 /* --- Pagination --- */
 
 .blog-pagination {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4817,6 +4817,16 @@ video {
     grid-column: 1 / -1;
     min-height: 20rem;
   }
+
+  /*
+   * Two posts would leave an empty grid cell (large spans the first row,
+   * the single standard card fills half of the second). Render both cards
+   * as equal columns instead.
+   */
+  .blog-preview__grid[data-layout="simple"][data-count="2"] .blog-preview__card {
+    grid-column: auto;
+    min-height: 20rem;
+  }
 }
 
 @media (min-width: 64rem) {


### PR DESCRIPTION
Closes #152.

## What changed
- New server component `src/components/sections/blog/blog-preview-section.tsx`: mosaic of the 4 newest posts (cover/category/date/read-time, placeholder cover when coverless, null when zero posts), See-more link to /blog.
- Home page renders it as the `#blog` anchor (dedicated-section filter replaces the generic placeholder); Blog is now a home anchor and remains a multi-route area.
- Header scroll-spy + footer links treat Blog as anchor on home, route-highlighted on /blog/*.
- EN/VI messages; scoped `.blog-preview*` styles (light/dark).

## Tests run
- Dev render verified EN+VI on fresh cache: #blog section, 2 cards with covers, see-more link, correct locale post links, aria-labelledby. (Note: a stale Next persistent dev cache initially hid the section; wiped .next and re-verified. Unrelated to this diff.)
- Full suite 160/160; ESLint changed files 0 errors; typecheck + build pass.
- Review of inherited in-flight work: no secrets; server-component + typed messages + placeholder discipline match repo patterns.

## Known limitations
- Mosaic layout needs 4+ posts for full effect (2 live now -> simple layout path).
- No screenshots attached (visual check via dev DOM); happy to add on request.

## Docs affected
- None.