### PR TITLE
fix(home): blend blog preview section background with homepage rhythm

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4603,7 +4603,13 @@ video {
 
 .blog-preview-section {
   padding-block: var(--section-space);
-  background: var(--color-surface-subtle);
+  background:
+    radial-gradient(
+      circle at 10% 28%,
+      var(--color-accent-soft),
+      transparent 26rem
+    ),
+    var(--color-page);
 }
 
 .blog-preview-section__intro {


### PR DESCRIPTION
Closes #157.

## What changed
- One CSS rule: `.blog-preview-section` now uses the shared homepage pattern (`--color-page` base + subtle radial accent glow at 10% 28%, alternating with resume/contact) instead of a flat `--color-surface-subtle` band. No markup/layout/content changes.

## Tests run
- @vision PASS on light + dark screenshots (section scrolled into view with neighbors): background fully continuous, glow subtle, contrast and spacing intact.
- Production build passes (Turbopack CSS compile).

## Known limitations
- None.

## Docs affected
- None.