### PR TITLE
fix(a11y,seo): skip link, theme-color meta, centered resume counter

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -65,6 +65,9 @@ export default async function LocaleLayout({
         <link href="/feeds.json" rel="alternate" title="JSON Feed" type="application/feed+json" />
       </head>
       <body>
+        <a className="skip-link" href="#main-content">
+          {messages.header.skipToContent}
+        </a>
         <StructuredData locale={locale} />
         <GeolocationPermissionPrompt />
         <ThemeProvider>

--- a/src/components/layout/page-shell.tsx
+++ b/src/components/layout/page-shell.tsx
@@ -2,8 +2,12 @@ import type { ComponentPropsWithoutRef } from "react";
 
 type PageShellProps = ComponentPropsWithoutRef<"main">;
 
-export function PageShell({ className, ...props }: Readonly<PageShellProps>) {
+export function PageShell({ className, id = "main-content", ...props }: Readonly<PageShellProps>) {
   const classes = ["page-shell", className].filter(Boolean).join(" ");
 
-  return <main className={classes} {...props} />;
+  // tabIndex -1 keeps the landmark out of the Tab order while letting the
+  // skip link move keyboard focus here on activation.
+  return (
+    <main className={classes} id={id} tabIndex={-1} {...props} />
+  );
 }

--- a/src/features/i18n/messages/en.ts
+++ b/src/features/i18n/messages/en.ts
@@ -13,6 +13,7 @@ const messages = {
   },
   header: {
     primaryNavigation: "Portfolio sections",
+    skipToContent: "Skip to main content",
     homeAction: "Go to Home",
     openMenu: "Open navigation menu",
     closeMenu: "Close navigation menu",

--- a/src/features/i18n/messages/types.ts
+++ b/src/features/i18n/messages/types.ts
@@ -9,6 +9,7 @@ export interface LocaleSwitcherMessages {
 
 export interface HeaderMessages {
   primaryNavigation: string;
+  skipToContent: string;
   homeAction: string;
   openMenu: string;
   closeMenu: string;

--- a/src/features/i18n/messages/vi.ts
+++ b/src/features/i18n/messages/vi.ts
@@ -13,6 +13,7 @@ const messages = {
   },
   header: {
     primaryNavigation: "Các phần portfolio",
+    skipToContent: "Bỏ qua tới nội dung chính",
     homeAction: "Đi đến Trang chủ",
     openMenu: "Mở trình đơn điều hướng",
     closeMenu: "Đóng trình đơn điều hướng",

--- a/src/features/theme/theme-color.ts
+++ b/src/features/theme/theme-color.ts
@@ -1,0 +1,22 @@
+/**
+ * Keep the browser-chrome `theme-color` meta in sync with the active theme.
+ *
+ * The meta value is read live from the `--color-page` custom property, so it
+ * always matches the exact page background in both themes without hardcoded
+ * hex duplicates. `oklch()` is valid in `theme-color` on modern browsers;
+ * older ones ignore the meta (same as having none).
+ */
+export function syncThemeColorMeta(): void {
+  if (typeof document === "undefined") return;
+  const pageColor = getComputedStyle(document.documentElement)
+    .getPropertyValue("--color-page")
+    .trim();
+  if (!pageColor) return;
+  let meta = document.querySelector('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement("meta");
+    meta.setAttribute("name", "theme-color");
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute("content", pageColor);
+}

--- a/src/features/theme/theme-provider.tsx
+++ b/src/features/theme/theme-provider.tsx
@@ -16,6 +16,7 @@ import {
   type Theme,
   themeStorageKey,
 } from "@/features/theme/config";
+import { syncThemeColorMeta } from "@/features/theme/theme-color";
 
 interface ThemeContextValue {
   theme: Theme | null;
@@ -33,6 +34,7 @@ function getDocumentTheme(): Theme {
 
 function applyTheme(theme: Theme) {
   document.documentElement.dataset.theme = theme;
+  syncThemeColorMeta();
   window.dispatchEvent(new Event(themeChangeEvent));
 }
 
@@ -76,6 +78,8 @@ export function ThemeProvider({ children }: Readonly<ThemeProviderProps>) {
 
     if (getDocumentTheme() !== resolvedTheme) {
       applyTheme(resolvedTheme);
+    } else {
+      syncThemeColorMeta();
     }
   }, [pathname]);
 

--- a/src/features/theme/theme-script.tsx
+++ b/src/features/theme/theme-script.tsx
@@ -7,6 +7,16 @@ const themeInitializationScript = `
       ? storedTheme
       : (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
     document.documentElement.dataset.theme = resolvedTheme;
+    var pageColor = getComputedStyle(document.documentElement).getPropertyValue("--color-page").trim();
+    if (pageColor) {
+      var themeMeta = document.querySelector('meta[name="theme-color"]');
+      if (!themeMeta) {
+        themeMeta = document.createElement("meta");
+        themeMeta.setAttribute("name", "theme-color");
+        document.head.appendChild(themeMeta);
+      }
+      themeMeta.setAttribute("content", pageColor);
+    }
   } catch (error) {
     document.documentElement.dataset.theme = matchMedia("(prefers-color-scheme: dark)").matches
       ? "dark"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -238,6 +238,23 @@ video {
   outline-offset: 3px;
 }
 
+/* Skip link: offscreen until keyboard focus, above the sticky header. */
+.skip-link {
+  position: fixed;
+  inset-block-start: var(--space-2);
+  inset-inline-start: var(--space-2);
+  z-index: 100;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  transform: translateY(-300%);
+}
+
+.skip-link:focus-visible {
+  transform: none;
+}
+
 .page-shell {
   position: relative;
   isolation: isolate;
@@ -1459,7 +1476,9 @@ video {
 .resume-panel__toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  /* Mobile: the counter is the toolbar's only child — center it so it groups
+     with the centered entry controls above instead of hugging the edge. */
+  justify-content: center;
   gap: var(--space-4);
 }
 
@@ -2999,6 +3018,10 @@ video {
   .resume-category__item {
     width: 100%;
     white-space: normal;
+  }
+
+  .resume-panel__toolbar {
+    justify-content: space-between;
   }
 
   .home-hero__layout {


### PR DESCRIPTION
Closes #159.

## What changed
- Skip link to `#main-content` (first tab stop, EN/VI labels, focus-visible reveal; PageShell main is now a focusable skip target via `tabindex=-1`).
- `theme-color` meta synced live from `--color-page` (pre-paint inline script + provider updates on toggle; no hardcoded hex).
- Mobile resume counter centered under the entry controls (CSS-only; desktop `space-between` preserved).
- Redirect matrix: verified live, no code change needed (8/8 legacy groups 301 to matrix targets incl. `/vi` locale).

## Tests run
- Keyboard smoke (dev): first Tab lands visible on skip link; Enter moves focus into main; VI label correct.
- Meta present with computed page color; toggle-follow verified by code path (local dev JS suffers an environmental chunk-403 issue, so interactive toggle re-verified on prod where it works; post-merge live check will confirm).
- Mobile resume: counter measured centered (offBy 0) + screenshot; local resume content synced from prod (was missing translations/media rows) to enable the check, publicity restored to private afterwards.
- Full suite 161/161; ESLint changed files clean; typecheck + build pass.

## Known limitations
- Local dev client interactivity is flaky in this sandbox (chunk 403s); prod unaffected.
- Footnote/mermaid rendering notes from the MCP post are separate (mermaid done in #156).

## Docs affected
- None.