### PR TITLE
fix(home): proportional height for mosaic wide card on desktop

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4850,6 +4850,13 @@ video {
     grid-column: 2 / span 2;
     grid-row: 1;
     min-height: 0;
+    /*
+     * The cover is absolutely positioned, so without a proportional height
+     * this card collapses to text height and looks flat next to the square
+     * small cards. 16/10 over the 2-column span lands ~1.25x small height,
+     * matching the reference mosaic rhythm.
+     */
+    aspect-ratio: 16 / 10;
   }
 
   .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="small"] {


### PR DESCRIPTION
Closes #161.

## What changed
- CSS-only (`globals.css`, +7): mosaic `wide` card gets `aspect-ratio: 16/10` at the desktop breakpoint. The cover is absolutely positioned so the card previously collapsed to text height (~30% of the right column); over its 2-column span the ratio lands ~1.25x small-card height, matching the reference rhythm. Tablet/mobile untouched.

## Tests run
- Measured desktop 1600px: wide 716x448, small 350x350 (ratio 1.28), large 420x814 spanning both rows; grid sums flush.
- @vision PASS (no flat look, no overflow/overlap/distortion).
- Production build passes.

## Known limitations
- None.

## Docs affected
- None.