### PR TITLE
fix(home): even mosaic halves on desktop

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4859,18 +4859,20 @@ video {
 }
 
 @media (min-width: 64rem) {
+  /* Two even halves: large spans columns 1-2, wide spans 3-4, smalls
+     auto-place into 3/4 of row 2. */
   .blog-preview__grid[data-layout="mosaic"] {
-    grid-template-columns: 1.2fr 1fr 1fr;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="large"] {
-    grid-column: 1;
+    grid-column: 1 / span 2;
     grid-row: 1 / span 2;
     min-height: 30rem;
   }
 
   .blog-preview__grid[data-layout="mosaic"] .blog-preview__card[data-size="wide"] {
-    grid-column: 2 / span 2;
+    grid-column: 3 / span 2;
     grid-row: 1;
     min-height: 0;
     /*


### PR DESCRIPTION
Follow-up of #161/#162 (same mosaic rhythm, refined per owner feedback).

## What changed
- CSS-only (`globals.css`, +11/-3): desktop mosaic grid `1.2fr 1fr 1fr` -> 4 even columns; large spans 1-2 (rows 1-2), wide spans 3-4 (row 1, keeps 16/10 aspect from #162), smalls auto-place 3/4 row 2. Left and right halves exactly even. Tablet/mobile untouched.

## Tests run
- Measured desktop 1600px: halves 568px == 568px; wide 568x355, smalls 276x276 (ratio 1.29); grid rows flush.
- @vision PASS (even halves, wide no longer flat, no regressions).
- Production build passes.

## Known limitations
- None.

## Docs affected
- None.